### PR TITLE
Add bidirectional plan/spec sync and bulk generation for tests

### DIFF
--- a/src/app/(app)/tests/definition-page-client.tsx
+++ b/src/app/(app)/tests/definition-page-client.tsx
@@ -33,7 +33,7 @@ import { ImportFromSpecDialog } from '@/components/ai/import-from-spec-dialog';
 import { CodeDiffScanDialog } from '@/components/ai/code-diff-scan-dialog';
 import { createArea, deleteArea, deleteAreaWithContents, moveTestToArea, moveArea, exportAllPlans, updateAreaPlan, updateArea } from '@/server/actions/areas';
 import { deleteTests, restoreTests, permanentlyDeleteTests, getTest, getTestDetailData } from '@/server/actions/tests';
-import { createPlaceholderTestCase } from '@/server/actions/specs';
+import { createPlaceholderTestCase, bulkGenerateForTests } from '@/server/actions/specs';
 import { TestDetailClient } from '@/app/(app)/tests/[id]/test-detail-client';
 import { runTests } from '@/server/actions/runs';
 import { createAndRunBuild } from '@/server/actions/builds';
@@ -53,6 +53,7 @@ import {
   FlaskConical,
   Plus,
   Wrench,
+  FileText,
   CheckCircle2,
   XCircle,
   Clock,
@@ -192,6 +193,7 @@ export function DefinitionPageClient({
   const [isRunningAreaBuild, setIsRunningAreaBuild] = useState(false);
   const [isBulkDeleting, setIsBulkDeleting] = useState(false);
   const [isBulkFixing, setIsBulkFixing] = useState(false);
+  const [isBulkGenSpecs, setIsBulkGenSpecs] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isFixingAll, setIsFixingAll] = useState(false);
   const [fixResult, setFixResult] = useState<{ fixed: number; failed: number } | null>(null);
@@ -671,6 +673,26 @@ export function DefinitionPageClient({
       setFixResult({ fixed: result.fixed, failed: result.failed });
     } finally {
       setIsBulkFixing(false);
+    }
+  };
+
+  const handleBulkGenerateSpecs = async () => {
+    if (selectedTestIds.size === 0) return;
+    setIsBulkGenSpecs(true);
+    try {
+      const result = await bulkGenerateForTests(repositoryId, Array.from(selectedTestIds));
+      if (result.specsCreated > 0 || result.areasUpdated > 0) {
+        toast.success(
+          `Created ${result.specsCreated} spec${result.specsCreated === 1 ? '' : 's'} and refreshed ${result.areasUpdated} plan${result.areasUpdated === 1 ? '' : 's'}`,
+        );
+        router.refresh();
+      } else {
+        toast.info('All selected tests already have specs');
+      }
+    } catch {
+      toast.error('Failed to generate specs/plan from selection');
+    } finally {
+      setIsBulkGenSpecs(false);
     }
   };
 
@@ -1198,6 +1220,18 @@ export function DefinitionPageClient({
                             {isBulkFixing ? 'Fixing...' : `Fix (${selectedFailedTests.length})`}
                           </Button>
                         )}
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={handleBulkGenerateSpecs}
+                          disabled={isBulkGenSpecs}
+                          title="Back-fill missing specs and refresh the plan for the selected tests' areas"
+                        >
+                          {isBulkGenSpecs
+                            ? <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+                            : <FileText className="h-3.5 w-3.5 mr-1.5" />}
+                          {isBulkGenSpecs ? 'Generating...' : 'Generate Plan & Specs'}
+                        </Button>
                         <Button variant="ghost" size="sm" onClick={() => setSelectedTestIds(new Set())}>
                           <X className="h-3.5 w-3.5 mr-1.5" />
                           Clear

--- a/src/components/areas/area-specs-panel.tsx
+++ b/src/components/areas/area-specs-panel.tsx
@@ -6,9 +6,15 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { CheckCircle, Circle, Plus, Loader2, ExternalLink } from 'lucide-react';
 import { toast } from 'sonner';
-import { convertPlanToPlaceholders, createPlaceholderTestCase } from '@/server/actions/specs';
+import {
+  convertPlanToPlaceholders,
+  createPlaceholderTestCase,
+  generatePlanFromSpecs,
+  generateSpecsFromTests,
+  generatePlanFromTests,
+} from '@/server/actions/specs';
 import { useRouter } from 'next/navigation';
-import { Wand2 } from 'lucide-react';
+import { Wand2, FileText, FileCode2 } from 'lucide-react';
 
 interface AreaTestCase {
   id: string;
@@ -22,16 +28,19 @@ interface AreaTestCasesPanelProps {
   repositoryId: string;
   tests: AreaTestCase[];
   hasAgentPlan: boolean;
+  hasSpecs?: boolean;
   onOpenTest?: (testId: string) => void;
 }
 
-export function AreaTestCasesPanel({ areaId, repositoryId, tests, hasAgentPlan, onOpenTest }: AreaTestCasesPanelProps) {
+export function AreaTestCasesPanel({ areaId, repositoryId, tests, hasAgentPlan, hasSpecs = false, onOpenTest }: AreaTestCasesPanelProps) {
   const router = useRouter();
   const [showAdd, setShowAdd] = useState(false);
   const [newName, setNewName] = useState('');
   const [newDescription, setNewDescription] = useState('');
   const [saving, setSaving] = useState(false);
   const [convertingPlan, setConvertingPlan] = useState(false);
+  const [specsToPlan, setSpecsToPlan] = useState(false);
+  const [fromTests, setFromTests] = useState(false);
 
   const handleAddTestCase = async () => {
     if (!newName.trim()) return;
@@ -72,15 +81,68 @@ export function AreaTestCasesPanel({ areaId, repositoryId, tests, hasAgentPlan, 
     }
   };
 
+  const handleSpecsToPlan = async () => {
+    setSpecsToPlan(true);
+    try {
+      const result = await generatePlanFromSpecs(areaId, repositoryId);
+      if (result.success) {
+        toast.success('Plan generated from specs');
+        router.refresh();
+      } else {
+        toast.error(result.error || 'Failed to generate plan');
+      }
+    } catch {
+      toast.error('Failed to generate plan');
+    } finally {
+      setSpecsToPlan(false);
+    }
+  };
+
+  const handleGenerateFromTests = async () => {
+    setFromTests(true);
+    try {
+      const specsResult = await generateSpecsFromTests(areaId, repositoryId);
+      const planResult = hasAgentPlan
+        ? { success: true }
+        : await generatePlanFromTests(areaId, repositoryId);
+
+      const bits: string[] = [];
+      if (specsResult.created > 0) bits.push(`${specsResult.created} spec${specsResult.created === 1 ? '' : 's'}`);
+      if (!hasAgentPlan && planResult.success) bits.push('plan');
+      if (bits.length > 0) {
+        toast.success(`Generated ${bits.join(' + ')} from existing tests`);
+        router.refresh();
+      } else {
+        toast.info('All tests already have specs and a plan');
+      }
+    } catch {
+      toast.error('Failed to generate from tests');
+    } finally {
+      setFromTests(false);
+    }
+  };
+
   return (
     <div className="mt-4 space-y-2">
       <div className="flex items-center justify-between">
         <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Test Cases ({tests.length})</h4>
-        <div className="flex items-center gap-1.5">
+        <div className="flex items-center gap-1.5 flex-wrap justify-end">
           {hasAgentPlan && (
-            <Button variant="ghost" size="sm" onClick={handleConvertPlan} disabled={convertingPlan} className="h-7 text-xs">
+            <Button variant="ghost" size="sm" onClick={handleConvertPlan} disabled={convertingPlan} className="h-7 text-xs" title="Create placeholder tests + specs from the plan">
               {convertingPlan ? <Loader2 className="h-3 w-3 mr-1 animate-spin" /> : <Wand2 className="h-3 w-3 mr-1" />}
               From Plan
+            </Button>
+          )}
+          {!hasAgentPlan && (hasSpecs || tests.length > 0) && (
+            <Button variant="ghost" size="sm" onClick={handleSpecsToPlan} disabled={specsToPlan} className="h-7 text-xs" title="Compose an agent plan from the existing specs">
+              {specsToPlan ? <Loader2 className="h-3 w-3 mr-1 animate-spin" /> : <FileText className="h-3 w-3 mr-1" />}
+              From Specs
+            </Button>
+          )}
+          {tests.length > 0 && (
+            <Button variant="ghost" size="sm" onClick={handleGenerateFromTests} disabled={fromTests} className="h-7 text-xs" title="Back-fill missing specs (and plan) from these tests">
+              {fromTests ? <Loader2 className="h-3 w-3 mr-1 animate-spin" /> : <FileCode2 className="h-3 w-3 mr-1" />}
+              From Tests
             </Button>
           )}
           <Button variant="ghost" size="sm" onClick={() => setShowAdd(true)} className="h-7 text-xs">

--- a/src/lib/playwright/planner-agent.ts
+++ b/src/lib/playwright/planner-agent.ts
@@ -171,7 +171,9 @@ export async function agentDiscoverAreas(
       })),
     }));
 
-    // Save agent plans to functional areas
+    // Save agent plans to functional areas + auto-populate specs side so both
+    // halves are generated together by the planner path.
+    const { syncAreaPlanAndSpecs } = await import('@/server/actions/specs');
     for (const area of areas) {
       if (area.testPlan) {
         const dbArea = await queries.getOrCreateFunctionalAreaByRepo(
@@ -183,6 +185,11 @@ export async function agentDiscoverAreas(
           agentPlan: area.testPlan,
           planGeneratedAt: new Date(),
         });
+        try {
+          await syncAreaPlanAndSpecs(dbArea.id, repositoryId);
+        } catch {
+          // Non-critical: spec sync failure shouldn't fail discovery.
+        }
       }
     }
 

--- a/src/server/actions/play-agent.ts
+++ b/src/server/actions/play-agent.ts
@@ -1344,17 +1344,37 @@ async function runGenerate(sessionId: string, repositoryId: string, teamId: stri
             emitActivity(teamId, repositoryId, sessionId, 'artifact:created',
               `Generator ${existingPlaceholder ? 'upgraded placeholder' : 'created'} test "${group.name}" in ${area.name}`,
               { stepId: 'generate', agentType: 'generator', artifactType: 'test', artifactId: test.id, artifactLabel: group.name });
-            // Link to matching spec if one exists
+            // Link to matching spec if one exists; otherwise create a new one so
+            // every generated test has a populated spec side.
             try {
               const areaSpecs = await queries.getSpecsForArea(area.id);
               const matchingSpec = areaSpecs.find(s =>
                 !s.testId && s.title.toLowerCase() === group.name.toLowerCase()
               );
+              const codeHash = createHash('sha256').update(genResult.code).digest('hex');
               if (matchingSpec) {
-                const { createHash } = await import('crypto');
-                const codeHash = createHash('sha256').update(genResult.code).digest('hex');
                 await queries.linkSpecToTest(matchingSpec.id, test.id);
                 await queries.updateTestSpec(matchingSpec.id, { codeHash });
+              } else {
+                const existingForTest = await queries.getTestSpec(test.id);
+                if (!existingForTest) {
+                  const specBody = [
+                    `**Area:** ${area.name}`,
+                    area.description ? `**Description:** ${area.description}` : '',
+                    group.description || group.name,
+                  ].filter(Boolean).join('\n\n');
+                  const specId = await queries.createTestSpec({
+                    repositoryId,
+                    testId: test.id,
+                    functionalAreaId: area.id,
+                    title: group.name,
+                    spec: specBody,
+                    source: 'planner',
+                    status: 'has_test',
+                    codeHash,
+                  });
+                  await queries.linkSpecToTest(specId, test.id);
+                }
               }
             } catch {
               // Non-critical

--- a/src/server/actions/spec-import.ts
+++ b/src/server/actions/spec-import.ts
@@ -846,7 +846,7 @@ export async function generateTestsFromStories(
           const code = extractCodeFromResponse(response);
 
           if (code) {
-            await queries.createTest({
+            const test = await queries.createTest({
               repositoryId,
               functionalAreaId: task.areaId,
               name: testName,
@@ -854,6 +854,28 @@ export async function generateTestsFromStories(
               description: acDescription,
               targetUrl: options?.targetUrl || null,
             });
+
+            // Create a linked spec so the spec side is populated alongside the test.
+            const specBody = [
+              `**Area:** ${task.story.title}`,
+              task.story.description ? `**Story:** ${task.story.description}` : '',
+              '',
+              task.group.map(ac => `- ${ac.description}`).join('\n'),
+            ].filter(Boolean).join('\n');
+            const { createHash } = await import('crypto');
+            const codeHash = createHash('sha256').update(code).digest('hex');
+            const specId = await queries.createTestSpec({
+              repositoryId,
+              testId: test.id,
+              functionalAreaId: task.areaId,
+              title: testName,
+              spec: specBody,
+              source: 'planner',
+              status: 'has_test',
+              codeHash,
+            });
+            await queries.linkSpecToTest(specId, test.id);
+
             return { created: true, testName };
           }
           return { created: false, testName };
@@ -870,6 +892,17 @@ export async function generateTestsFromStories(
         testsCreated++;
       } else if (!result.success) {
         errors.push(`${result.error || 'Unknown error'}`);
+      }
+    }
+
+    // Materialize `agentPlan` for each touched area so the plan side isn't empty.
+    const { syncAreaPlanAndSpecs } = await import('./specs');
+    const touchedAreaIds = Array.from(new Set(allTasks.map(t => t.areaId)));
+    for (const areaId of touchedAreaIds) {
+      try {
+        await syncAreaPlanAndSpecs(areaId, repositoryId);
+      } catch {
+        // Non-critical.
       }
     }
 
@@ -1002,6 +1035,25 @@ export async function createPlaceholdersFromStories(
           const msg = err instanceof Error ? err.message : 'Unknown error';
           errors.push(`${testName}: ${msg}`);
         }
+      }
+    }
+
+    // Materialize `agentPlan` for each touched area so plan/spec stay in sync.
+    const { syncAreaPlanAndSpecs } = await import('./specs');
+    const touchedAreaIds = new Set<string>();
+    for (const story of stories) {
+      const area = await queries.getOrCreateFunctionalAreaByRepo(
+        repositoryId,
+        story.title,
+        story.description,
+      );
+      touchedAreaIds.add(area.id);
+    }
+    for (const areaId of touchedAreaIds) {
+      try {
+        await syncAreaPlanAndSpecs(areaId, repositoryId);
+      } catch {
+        // Non-critical.
       }
     }
 

--- a/src/server/actions/specs.ts
+++ b/src/server/actions/specs.ts
@@ -373,6 +373,201 @@ export async function convertPlanToPlaceholders(
   return { created };
 }
 
+/** Reverse of convertPlanToSpecs: compose an area's `agentPlan` from its existing specs. */
+export async function generatePlanFromSpecs(
+  functionalAreaId: string,
+  repositoryId: string,
+): Promise<{ success: boolean; planLength?: number; error?: string }> {
+  await requireRepoAccess(repositoryId);
+
+  const area = await queries.getFunctionalArea(functionalAreaId);
+  if (!area) return { success: false, error: 'Area not found' };
+
+  const specs = await queries.getSpecsForArea(functionalAreaId);
+  if (specs.length === 0) return { success: false, error: 'No specs to compose plan from' };
+
+  const header = `## ${area.name}${area.description ? `\n\n${area.description}` : ''}`;
+  const scenarios = specs.map((s, idx) => {
+    const body = s.spec?.trim() ? s.spec.trim() : s.title;
+    return `### Scenario ${idx + 1}: ${s.title}\n${body}`;
+  });
+  const plan = `${header}\n\n${scenarios.join('\n\n')}`;
+
+  await queries.updateFunctionalArea(functionalAreaId, {
+    agentPlan: plan,
+    planGeneratedAt: new Date(),
+  });
+
+  revalidatePath('/areas');
+  revalidatePath('/tests');
+  return { success: true, planLength: plan.length };
+}
+
+/** Given tests (optionally placeholder) in an area, create a linked spec for each one that lacks one. */
+export async function generateSpecsFromTests(
+  functionalAreaId: string,
+  repositoryId: string,
+  options?: { testIds?: string[] },
+): Promise<{ created: number }> {
+  await requireRepoAccess(repositoryId);
+
+  const area = await queries.getFunctionalArea(functionalAreaId);
+  if (!area) return { created: 0 };
+
+  const allTests = await queries.getTestsByFunctionalArea(functionalAreaId);
+  const targetTests = options?.testIds
+    ? allTests.filter(t => options.testIds!.includes(t.id))
+    : allTests;
+
+  let created = 0;
+  for (const test of targetTests) {
+    const existing = await queries.getTestSpec(test.id);
+    if (existing) continue;
+
+    const specBody = [
+      area.name ? `**Area:** ${area.name}` : '',
+      area.description ? `**Description:** ${area.description}` : '',
+      test.description || '',
+    ].filter(Boolean).join('\n\n') || test.name;
+
+    const specId = await queries.createTestSpec({
+      repositoryId,
+      testId: test.id,
+      functionalAreaId,
+      title: test.name,
+      spec: specBody,
+      source: 'manual',
+      status: 'has_test',
+      codeHash: hashCode(test.code),
+    });
+    await queries.linkSpecToTest(specId, test.id);
+    created++;
+  }
+
+  if (created > 0) {
+    revalidatePath('/areas');
+    revalidatePath('/tests');
+  }
+  return { created };
+}
+
+/** Compose an area's `agentPlan` from its existing tests (name + description). */
+export async function generatePlanFromTests(
+  functionalAreaId: string,
+  repositoryId: string,
+  options?: { testIds?: string[] },
+): Promise<{ success: boolean; planLength?: number; error?: string }> {
+  await requireRepoAccess(repositoryId);
+
+  const area = await queries.getFunctionalArea(functionalAreaId);
+  if (!area) return { success: false, error: 'Area not found' };
+
+  const allTests = await queries.getTestsByFunctionalArea(functionalAreaId);
+  const targetTests = options?.testIds
+    ? allTests.filter(t => options.testIds!.includes(t.id))
+    : allTests;
+
+  if (targetTests.length === 0) return { success: false, error: 'No tests to compose plan from' };
+
+  const header = `## ${area.name}${area.description ? `\n\n${area.description}` : ''}`;
+  const scenarios = targetTests.map((t, idx) => {
+    const body = t.description?.trim() ? t.description.trim() : t.name;
+    return `### Scenario ${idx + 1}: ${t.name}\n${body}`;
+  });
+  const plan = `${header}\n\n${scenarios.join('\n\n')}`;
+
+  await queries.updateFunctionalArea(functionalAreaId, {
+    agentPlan: plan,
+    planGeneratedAt: new Date(),
+  });
+
+  revalidatePath('/areas');
+  revalidatePath('/tests');
+  return { success: true, planLength: plan.length };
+}
+
+/**
+ * Fill the missing half (plan or specs) of an area, using tests as a fallback.
+ * Idempotent: safe to call after each of the generation paths (planner, generator, import).
+ */
+export async function syncAreaPlanAndSpecs(
+  functionalAreaId: string,
+  repositoryId: string,
+): Promise<{ specsCreated: number; planCreated: boolean }> {
+  await requireRepoAccess(repositoryId);
+
+  const area = await queries.getFunctionalArea(functionalAreaId);
+  if (!area) return { specsCreated: 0, planCreated: false };
+
+  const specs = await queries.getSpecsForArea(functionalAreaId);
+  const tests = await queries.getTestsByFunctionalArea(functionalAreaId);
+  const hasPlan = !!area.agentPlan?.trim();
+
+  let specsCreated = 0;
+  let planCreated = false;
+
+  // Fill specs side
+  if (specs.length === 0) {
+    if (hasPlan) {
+      const result = await convertPlanToSpecs(functionalAreaId, repositoryId);
+      specsCreated += result.created;
+    } else if (tests.length > 0) {
+      const result = await generateSpecsFromTests(functionalAreaId, repositoryId);
+      specsCreated += result.created;
+    }
+  } else {
+    // Back-fill specs for any tests missing one
+    const result = await generateSpecsFromTests(functionalAreaId, repositoryId);
+    specsCreated += result.created;
+  }
+
+  // Fill plan side
+  if (!hasPlan) {
+    const currentSpecs = specs.length > 0 ? specs : await queries.getSpecsForArea(functionalAreaId);
+    if (currentSpecs.length > 0) {
+      const result = await generatePlanFromSpecs(functionalAreaId, repositoryId);
+      planCreated = result.success;
+    } else if (tests.length > 0) {
+      const result = await generatePlanFromTests(functionalAreaId, repositoryId);
+      planCreated = result.success;
+    }
+  }
+
+  return { specsCreated, planCreated };
+}
+
+/** Bulk: for a set of tests (possibly across areas), create missing specs and refresh plan per area. */
+export async function bulkGenerateForTests(
+  repositoryId: string,
+  testIds: string[],
+): Promise<{ specsCreated: number; areasUpdated: number }> {
+  await requireRepoAccess(repositoryId);
+
+  if (testIds.length === 0) return { specsCreated: 0, areasUpdated: 0 };
+
+  // Group tests by area
+  const testsById = await Promise.all(testIds.map(id => queries.getTest(id)));
+  const areaGroups = new Map<string, string[]>();
+  for (const t of testsById) {
+    if (!t?.functionalAreaId) continue;
+    const list = areaGroups.get(t.functionalAreaId) ?? [];
+    list.push(t.id);
+    areaGroups.set(t.functionalAreaId, list);
+  }
+
+  let specsCreated = 0;
+  for (const [areaId, ids] of areaGroups) {
+    const { created } = await generateSpecsFromTests(areaId, repositoryId, { testIds: ids });
+    specsCreated += created;
+    // Refresh the plan side so both halves stay in sync.
+    await generatePlanFromTests(areaId, repositoryId);
+  }
+
+  revalidatePath('/areas');
+  revalidatePath('/tests');
+  return { specsCreated, areasUpdated: areaGroups.size };
+}
+
 /** Check if a test's code has drifted from its spec */
 export async function detectSpecDrift(testId: string): Promise<{ isDrifted: boolean; specId?: string }> {
   await requireTeamAccess();


### PR DESCRIPTION
## Summary
This PR adds comprehensive bidirectional synchronization between agent plans and specs, along with new bulk generation capabilities. It enables users to generate missing specs from tests, compose plans from specs, and keep both halves of an area in sync across different workflows (planner, generator, import).

## Key Changes

- **New sync functions in `specs.ts`:**
  - `generatePlanFromSpecs()` - Compose an area's plan from existing specs
  - `generateSpecsFromTests()` - Create specs for tests that lack them
  - `generatePlanFromTests()` - Compose a plan directly from test names/descriptions
  - `syncAreaPlanAndSpecs()` - Idempotent sync that fills missing plan or specs using available data (specs → plan, or tests → specs → plan)
  - `bulkGenerateForTests()` - Bulk operation to generate specs and refresh plans for multiple tests across areas

- **UI enhancements in `area-specs-panel.tsx`:**
  - Added "From Specs" button to generate plan from existing specs
  - Added "From Tests" button to back-fill missing specs and plan from tests
  - Updated button layout to handle multiple generation options
  - Added descriptive tooltips for each action

- **Auto-population of specs during generation:**
  - `generateTestsFromStories()` now creates linked specs alongside generated tests
  - `createPlaceholdersFromStories()` calls `syncAreaPlanAndSpecs()` to materialize plans
  - `runGenerate()` in play-agent creates specs for generated tests if no matching spec exists
  - `agentDiscoverAreas()` in planner-agent calls `syncAreaPlanAndSpecs()` after saving plans

- **Bulk test operations in `definition-page-client.tsx`:**
  - Added "Generate Plan & Specs" button for selected tests
  - Calls `bulkGenerateForTests()` to back-fill missing specs and refresh area plans

## Implementation Details

- All generation functions are idempotent and safe to call multiple times
- `syncAreaPlanAndSpecs()` intelligently chooses the generation path based on what data exists (prioritizes specs over tests for plan generation)
- Specs created during generation include area context and test descriptions in their body
- All generation operations trigger path revalidation to keep UI in sync
- Non-critical spec sync failures in background operations don't block the main workflow

https://claude.ai/code/session_01UdVdUYQv7yc4FHSfHMZjNN