### PR TITLE
[Sec 01/17] Stop evaluating customer/AI code in the host process

### DIFF
--- a/src/lib/quickstart/storage-capture.ts
+++ b/src/lib/quickstart/storage-capture.ts
@@ -1,15 +1,23 @@
 /**
- * Run a freshly-rendered auth-setup test in a transient Chromium context, then
- * capture the resulting `context.storageState()` and persist it via
- * createStorageState so the QuickStart walkthrough test can re-use it via
- * setupOverrides.extraSteps.
+ * Run a freshly-rendered auth-setup test, then capture the resulting
+ * `context.storageState()` and persist it via createStorageState so the
+ * QuickStart walkthrough test can re-use it via setupOverrides.extraSteps.
  *
- * Lives outside the EB pod path on purpose — this is a one-shot session that
- * needs to return the auth blob to the caller, not a Lastest test run.
+ * SECURITY: the auth-setup code is AI/user-derived arbitrary Playwright code.
+ * On a provisioned (Kubernetes) deployment it is executed in a disposable
+ * runner/EB pod via executeSetupViaRunner — never `eval`'d in the host process
+ * (which holds DATABASE_URL / STRIPE_* / SYSTEM_EB_TOKEN). Only a self-hosted
+ * single-tenant install with no runner pool falls back to in-process execution.
  */
 
 import { chromium } from "playwright";
 import * as queries from "@/lib/db/queries";
+import { executeSetupViaRunner } from "@/lib/execution/executor";
+import {
+  claimOrProvisionPoolEB,
+  releasePoolEB,
+} from "@/server/actions/embedded-sessions";
+import { isKubernetesMode } from "@/lib/eb/provisioner";
 
 export interface CaptureStorageStateInput {
   repositoryId: string;
@@ -113,6 +121,50 @@ async function attemptCapture(
   }
 }
 
+/**
+ * Run the auth-setup code in a disposable runner/EB pod and return its captured
+ * storage state. Returns null when no pooled browser could be claimed (so the
+ * caller can decide whether a host fallback is permitted).
+ */
+async function tryCaptureViaRunner(
+  input: CaptureStorageStateInput,
+): Promise<
+  { ok: true; storageStateJson: string } | { ok: false; reason: string } | null
+> {
+  let runnerId: string | null = null;
+  try {
+    const poolEB = await claimOrProvisionPoolEB({ purpose: "interactive" });
+    runnerId = poolEB?.runnerId ?? null;
+  } catch {
+    runnerId = null;
+  }
+  if (!runnerId) return null;
+
+  try {
+    const result = await executeSetupViaRunner(
+      input.testCode,
+      `quickstart-auth-${input.repositoryId}`,
+      runnerId,
+      input.baseUrl,
+      undefined,
+      input.timeoutMs ?? 90_000,
+      null,
+    );
+    const json = result.storageStateJson;
+    if (!json) {
+      return { ok: false, reason: "runner returned no storage state" };
+    }
+    return { ok: true, storageStateJson: json };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    await releasePoolEB(runnerId).catch(() => {});
+  }
+}
+
 export async function captureStorageState(
   input: CaptureStorageStateInput,
 ): Promise<CaptureStorageStateResult> {
@@ -126,13 +178,30 @@ export async function captureStorageState(
     };
   }
 
-  // First attempt; one retry on transient network/browser errors.
-  let attempt = await attemptCapture(input, body);
-  if (!attempt.ok && TRANSIENT_ERROR_RE.test(attempt.reason)) {
-    console.warn(
-      `[QuickStart auth-setup] transient error, retrying once: ${attempt.reason}`,
-    );
+  // Preferred path: execute off-host in a disposable runner/EB pod.
+  let attempt = await tryCaptureViaRunner(input);
+
+  if (!attempt) {
+    // No pooled browser available. On a provisioned deployment we must NOT fall
+    // back to in-process eval of arbitrary auth code.
+    if (isKubernetesMode()) {
+      return {
+        captured: false,
+        failureReason: "All browsers are busy. Please try again later.",
+        durationMs: Date.now() - start,
+      };
+    }
+
+    // Self-hosted / local-dev fallback: no runner pool configured. Such
+    // deployments are single-tenant, so in-process execution is acceptable.
+    // First attempt; one retry on transient network/browser errors.
     attempt = await attemptCapture(input, body);
+    if (!attempt.ok && TRANSIENT_ERROR_RE.test(attempt.reason)) {
+      console.warn(
+        `[QuickStart auth-setup] transient error, retrying once: ${attempt.reason}`,
+      );
+      attempt = await attemptCapture(input, body);
+    }
   }
 
   if (!attempt.ok) {

--- a/src/server/actions/play-agent.ts
+++ b/src/server/actions/play-agent.ts
@@ -24,8 +24,7 @@ import { createHash } from "crypto";
 import { generateWithAI, extractCodeFromResponse } from "@/lib/ai";
 import type { AIProviderConfig } from "@/lib/ai/types";
 import { chromium } from "playwright";
-import type { SetupContext, SetupScript } from "@/lib/setup/types";
-import { runPlaywrightSetup } from "@/lib/setup/script-runner";
+import { executeSetupViaRunner } from "@/lib/execution/executor";
 import { classifyTemplate } from "@/lib/templates/classifier";
 import { gatherCodebaseIntelligence } from "@/lib/ai/codebase-intelligence";
 import { claimEmbeddedBrowserForAgent } from "@/server/actions/ai";
@@ -626,47 +625,28 @@ async function testLoginScript(
   code: string,
   baseUrl: string,
   repositoryId: string,
-  cdpUrl: string,
+  runnerId: string,
 ): Promise<{ success: boolean; error?: string; duration: number }> {
-  let browser = null;
-  let context = null;
+  const start = Date.now();
   try {
-    browser = await chromium.connectOverCDP(cdpUrl);
-    context = await browser.newContext({
-      viewport: { width: 1280, height: 720 },
-    });
-    const page = await context.newPage();
-
-    const script: SetupScript = {
-      id: "temp-login-test",
-      repositoryId,
-      name: "Login Test",
-      type: "playwright",
+    // SECURITY: the login script is AI-generated arbitrary Playwright code.
+    // Execute it inside the EB pod via the runner (run_setup) rather than
+    // eval'ing it in the host process — connecting over CDP would still run the
+    // script's JavaScript in-host, where DATABASE_URL / STRIPE_* live.
+    await executeSetupViaRunner(
       code,
-      createdAt: null,
-      updatedAt: null,
-    };
-
-    const setupContext: SetupContext = {
+      `play-agent-login-${repositoryId}`,
+      runnerId,
       baseUrl,
-      page,
-      variables: {},
-      repositoryId,
-    };
-
-    const result = await runPlaywrightSetup(page, script, setupContext);
-    return {
-      success: result.success,
-      error: result.error,
-      duration: result.duration,
-    };
+      { width: 1280, height: 720 },
+      undefined,
+      null,
+    );
+    return { success: true, duration: Date.now() - start };
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Script execution failed";
-    return { success: false, error: message, duration: 0 };
-  } finally {
-    if (context) await context.close().catch(() => {});
-    if (browser) await browser.close().catch(() => {});
+    return { success: false, error: message, duration: Date.now() - start };
   }
 }
 
@@ -963,7 +943,7 @@ async function runEnvSetup(
       scriptResult.code,
       baseUrl,
       repositoryId,
-      eb.cdpUrl,
+      eb.runnerId,
     );
 
     if (!testResult.success) {

--- a/src/server/actions/setup-scripts.ts
+++ b/src/server/actions/setup-scripts.ts
@@ -12,6 +12,12 @@ import { validateApiScript } from "@/lib/setup/api-seeder";
 import { chromium } from "playwright";
 import { runPlaywrightSetup } from "@/lib/setup/script-runner";
 import type { SetupScript, SetupContext } from "@/lib/setup/types";
+import { executeSetupViaRunner } from "@/lib/execution/executor";
+import {
+  claimOrProvisionPoolEB,
+  releasePoolEB,
+} from "@/server/actions/embedded-sessions";
+import { isKubernetesMode } from "@/lib/eb/provisioner";
 
 export interface CreateSetupScriptInput {
   repositoryId: string;
@@ -148,14 +154,78 @@ export async function testSetupScript(
     };
   }
 
+  const code = script.code;
+  if (!code) {
+    return { success: false, duration: 0, error: "No setup code" };
+  }
+
+  const settings = await queries.getPlaywrightSettings(script.repositoryId);
+  const viewport =
+    settings?.viewportWidth && settings?.viewportHeight
+      ? { width: settings.viewportWidth, height: settings.viewportHeight }
+      : { width: 1280, height: 720 };
+
+  // SECURITY: setup scripts are arbitrary customer-authored Playwright code.
+  // Prefer running them in a disposable runner/EB pod so they never `eval` in
+  // the host process (which holds DATABASE_URL / STRIPE_* / SYSTEM_EB_TOKEN).
+  // On a provisioned (Kubernetes) deployment this path is mandatory; only a
+  // self-hosted single-tenant install with no pool falls back to host execution.
+  let runnerId: string | null = null;
+  try {
+    const poolEB = await claimOrProvisionPoolEB({ purpose: "interactive" });
+    runnerId = poolEB?.runnerId ?? null;
+  } catch {
+    runnerId = null;
+  }
+
+  if (runnerId) {
+    const start = Date.now();
+    try {
+      const result = await executeSetupViaRunner(
+        code,
+        script.id,
+        runnerId,
+        targetUrl,
+        viewport,
+        settings?.navigationTimeout ?? undefined,
+        settings,
+      );
+      return {
+        success: true,
+        duration: Date.now() - start,
+        variables: result.variables,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        duration: Date.now() - start,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    } finally {
+      await releasePoolEB(runnerId).catch(() => {});
+    }
+  }
+
+  // No pooled browser was available. In a provisioned deployment we must NOT
+  // fall back to in-process eval — return a transient busy error instead.
+  if (isKubernetesMode()) {
+    return {
+      success: false,
+      duration: 0,
+      error: "All browsers are busy. Please try again later.",
+    };
+  }
+
+  // Self-hosted / local-dev fallback: no runner pool is configured, so there is
+  // no disposable sandbox to use. Execute in-process. This is acceptable only
+  // because such deployments are single-tenant (every team member is already
+  // trusted with the host); a multi-tenant deployment always runs a pool above.
   let browser = null;
   let page = null;
 
   try {
     browser = await chromium.launch({ headless: true });
-    const context = await browser.newContext({
-      viewport: { width: 1280, height: 720 },
-    });
+    const context = await browser.newContext({ viewport });
     page = await context.newPage();
 
     const setupContext: SetupContext = {


### PR DESCRIPTION
**Severity: CRITICAL** — finding #1 of the application security review (see `SECURITY-REVIEW.md` in the final PR of this stack).

`testSetupScript`, QuickStart `captureStorageState`, and play-agent `testLoginScript` eval'd customer/AI-authored code **in the host Next.js process**, where `DATABASE_URL`, `STRIPE_*`, and `SYSTEM_EB_TOKEN` live — cross-tenant RCE for any authenticated user.

All three paths now execute the code in a disposable runner/EB pod via the existing `executeSetupViaRunner` path. Installs with no pool keep an in-process fallback (acceptable for single-tenant self-hosted).

---
**Stack 1/17 — base: `main`.** This is a stacked PR queue; merge top-down. Next: #Sec-02.

https://claude.ai/code/session_01QsD28d52asLNJX3YAsmjyV

---
_Generated by [Claude Code](https://claude.ai/code/session_01QsD28d52asLNJX3YAsmjyV)_