### PR TITLE
Improve first-run UX from tester feedback (a, b, d, e)

### DIFF
--- a/src/app/(onboarding)/onboarding/onboarding-client.tsx
+++ b/src/app/(onboarding)/onboarding/onboarding-client.tsx
@@ -230,6 +230,29 @@ export function OnboardingClient({
                 next();
               });
             }}
+            onQuickStart={() =>
+              startTransition(async () => {
+                try {
+                  const created = await createLocalRepo(
+                    "My First Project",
+                    "https://demo.playwright.dev/todomvc/",
+                    "todomvc",
+                  );
+                  track(Events.repo_linked, { source: "sandbox" });
+                  await finish(
+                    created.seededTestId
+                      ? `/tests?test=${encodeURIComponent(created.seededTestId)}`
+                      : "/",
+                  );
+                } catch (err) {
+                  toast.error(
+                    err instanceof Error
+                      ? err.message
+                      : "Could not start the sample test",
+                  );
+                }
+              })
+            }
           />
         )}
 
@@ -396,12 +419,14 @@ function Step1Fork({
   selected,
   onSelect,
   onNext,
+  onQuickStart,
   pending,
 }: {
   userName: string;
   selected: OnboardingPath | null;
   onSelect: (p: OnboardingPath) => void;
   onNext: () => void;
+  onQuickStart: () => void;
   pending: boolean;
 }) {
   return (
@@ -414,6 +439,33 @@ function Step1Fork({
           You can always switch later. This just tailors the setup.
         </p>
       </div>
+
+      {/* Fastest path: skip every setup step and land on a ready-to-run test. */}
+      <Card className="border-primary/40 bg-primary/5">
+        <CardContent className="flex flex-wrap items-center justify-between gap-3 py-3">
+          <div className="flex items-center gap-2">
+            <Rocket className="h-4 w-4 text-primary" />
+            <div>
+              <div className="text-sm font-medium">
+                Just want to see it run?
+              </div>
+              <div className="text-xs text-muted-foreground">
+                We&apos;ll create a sample project and drop you on a test you
+                can run right now. Set up your own app later.
+              </div>
+            </div>
+          </div>
+          <Button
+            variant="default"
+            size="sm"
+            onClick={onQuickStart}
+            disabled={pending}
+          >
+            {pending ? <Loader2 className="mr-2 h-3 w-3 animate-spin" /> : null}
+            Run a sample test
+          </Button>
+        </CardContent>
+      </Card>
 
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
         {PATHS.map((p) => {
@@ -504,7 +556,7 @@ const SANDBOX_TEMPLATES: SandboxTemplate[] = [
     name: "The Internet",
     url: "https://the-internet.herokuapp.com/",
     description:
-      "A QA testing playground with logins, drag-drop, frames, and more.",
+      "A QA playground (logins, drag-drop, frames). Third-party host — can be slow or briefly unavailable.",
   },
   {
     id: "playwright-docs",

--- a/src/lib/demo/sandbox-seeds.ts
+++ b/src/lib/demo/sandbox-seeds.ts
@@ -127,6 +127,35 @@ export async function test(page: Page, baseUrl: string, screenshotPath: string, 
 }
 `;
 
+/**
+ * Generic, URL-agnostic smoke test. Unlike the template seeds, this navigates
+ * to whatever `baseUrl` the test runs against and captures a baseline — so it
+ * works for a user's *own* app, not a hardcoded third-party playground. Used
+ * when a sandbox is created with a custom URL, and when a user later sets a
+ * custom base URL (we re-point an untouched sample at their site).
+ */
+const SMOKE_TEST_CODE = `import { Page } from 'playwright';
+
+export async function test(page: Page, baseUrl: string, screenshotPath: string, stepLogger: any) {
+  let screenshotStep = 0;
+  function getScreenshotPath() {
+    screenshotStep++;
+    const ext = screenshotPath.lastIndexOf('.');
+    if (ext > 0) {
+      return screenshotPath.slice(0, ext) + '-step' + screenshotStep + screenshotPath.slice(ext);
+    }
+    return screenshotPath + '-step' + screenshotStep;
+  }
+
+  stepLogger.log('Open the page');
+  await page.goto(baseUrl, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('load').catch(() => {});
+
+  stepLogger.log('Capture a baseline screenshot');
+  await page.screenshot({ path: getScreenshotPath(), fullPage: true });
+}
+`;
+
 export const SANDBOX_SEEDS: Record<SandboxSeedId, SeedDefinition> = {
   todomvc: {
     area: {
@@ -224,4 +253,140 @@ export async function seedSandboxTemplate(
   });
 
   return testId;
+}
+
+/** Codes we seed automatically. Used to recognise an *untouched* sample so we
+ *  can safely re-point or replace it without clobbering user edits. */
+const SEED_CODES = new Set<string>([
+  TODOMVC_CODE,
+  HEROKUAPP_CODE,
+  PLAYWRIGHT_DOCS_CODE,
+  SMOKE_TEST_CODE,
+]);
+
+/**
+ * Seed a generic smoke test against an arbitrary base URL. Idempotent: a no-op
+ * when the repo already has any test. This is the "bring your own URL" seed —
+ * a fresh repo with a custom URL gets a real, runnable first test of *their*
+ * app instead of a third-party demo.
+ */
+export async function seedGenericSmokeTest(
+  repositoryId: string,
+  targetUrl: string,
+): Promise<string | null> {
+  const existing = await db
+    .select({ id: tests.id })
+    .from(tests)
+    .where(eq(tests.repositoryId, repositoryId))
+    .limit(1);
+  if (existing.length > 0) return existing[0].id;
+
+  const now = new Date();
+  const faId = uuid();
+  await db.insert(functionalAreas).values({
+    id: faId,
+    repositoryId,
+    name: "Smoke test",
+    parentId: null,
+    agentPlan: "A starter test that loads your app and captures a baseline.",
+    planGeneratedAt: now,
+  });
+
+  const testId = uuid();
+  await db.insert(tests).values({
+    id: testId,
+    repositoryId,
+    functionalAreaId: faId,
+    name: "Homepage loads",
+    code: SMOKE_TEST_CODE,
+    targetUrl,
+    executionMode: "procedural",
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  await db.insert(testVersions).values({
+    id: uuid(),
+    testId,
+    version: 1,
+    code: SMOKE_TEST_CODE,
+    name: "Homepage loads",
+    targetUrl,
+    changeReason: "manual_edit",
+    createdAt: now,
+  });
+
+  return testId;
+}
+
+/**
+ * When a user sets a custom base URL during onboarding, re-point an *untouched*
+ * seeded sample at their site. Fixes the case where a demo template (e.g. the
+ * herokuapp "form auth" test) was seeded but the user actually wants to test
+ * their own URL — without this the first test still targets the demo site and
+ * fails. No-op when the repo has multiple tests or the sample was edited.
+ */
+export async function repointSeededSampleToSmoke(
+  repositoryId: string,
+  newBaseUrl: string,
+): Promise<boolean> {
+  const repoTests = await db
+    .select({
+      id: tests.id,
+      code: tests.code,
+      targetUrl: tests.targetUrl,
+      functionalAreaId: tests.functionalAreaId,
+    })
+    .from(tests)
+    .where(eq(tests.repositoryId, repositoryId));
+
+  // Only act when the repo holds exactly one, unedited, auto-seeded sample.
+  if (repoTests.length !== 1) return false;
+  const t = repoTests[0];
+  if (!t.code || !SEED_CODES.has(t.code)) return false;
+  // Already a smoke test pointing at the right URL — nothing to do.
+  if (t.code === SMOKE_TEST_CODE && t.targetUrl === newBaseUrl) return false;
+
+  const now = new Date();
+  await db
+    .update(tests)
+    .set({
+      code: SMOKE_TEST_CODE,
+      name: "Homepage loads",
+      targetUrl: newBaseUrl,
+      executionMode: "procedural",
+      updatedAt: now,
+    })
+    .where(eq(tests.id, t.id));
+
+  if (t.functionalAreaId) {
+    await db
+      .update(functionalAreas)
+      .set({
+        name: "Smoke test",
+        agentPlan:
+          "A starter test that loads your app and captures a baseline.",
+      })
+      .where(eq(functionalAreas.id, t.functionalAreaId));
+  }
+
+  const versionRows = await db
+    .select({ version: testVersions.version })
+    .from(testVersions)
+    .where(eq(testVersions.testId, t.id));
+  const nextVersion =
+    versionRows.reduce((max, r) => Math.max(max, r.version ?? 0), 0) + 1;
+
+  await db.insert(testVersions).values({
+    id: uuid(),
+    testId: t.id,
+    version: nextVersion,
+    code: SMOKE_TEST_CODE,
+    name: "Homepage loads",
+    targetUrl: newBaseUrl,
+    changeReason: "manual_edit",
+    createdAt: now,
+  });
+
+  return true;
 }

--- a/src/lib/execution/error-classify.test.ts
+++ b/src/lib/execution/error-classify.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyRunError,
+  formatClassifiedError,
+} from "@/lib/execution/error-classify";
+import type { NetworkRequest } from "@/lib/db/schema";
+
+function net(partial: Partial<NetworkRequest>): NetworkRequest {
+  return {
+    url: "https://example.com/",
+    method: "GET",
+    status: 200,
+    duration: 1,
+    resourceType: "document",
+    ...partial,
+  };
+}
+
+describe("classifyRunError", () => {
+  it("returns null for ordinary assertion failures", () => {
+    expect(
+      classifyRunError({
+        errorMessage:
+          "locator.click: Error: strict mode violation, element not found",
+      }),
+    ).toBeNull();
+  });
+
+  it("classifies a bare runner timeout", () => {
+    const c = classifyRunError({ runnerStatus: "timeout" });
+    expect(c?.category).toBe("runner_timeout");
+    // keeps the substring downstream heuristics look for
+    expect(c?.title.toLowerCase()).toContain("timed out");
+  });
+
+  it("classifies a runner disconnect", () => {
+    const c = classifyRunError({ runnerStatus: "disconnected" });
+    expect(c?.category).toBe("runner_disconnected");
+    expect(c?.title.toLowerCase()).toContain("disconnected");
+  });
+
+  it("classifies DNS failures", () => {
+    const c = classifyRunError({
+      errorMessage:
+        "page.goto: net::ERR_NAME_NOT_RESOLVED at https://nope.test",
+    });
+    expect(c?.category).toBe("dns");
+    expect(c?.suggestion).toBeTruthy();
+  });
+
+  it("classifies connection refused", () => {
+    const c = classifyRunError({
+      errorMessage: "page.goto: net::ERR_CONNECTION_REFUSED",
+    });
+    expect(c?.category).toBe("connection_refused");
+  });
+
+  it("classifies TLS errors", () => {
+    const c = classifyRunError({
+      errorMessage: "net::ERR_CERT_AUTHORITY_INVALID",
+    });
+    expect(c?.category).toBe("tls");
+  });
+
+  it("classifies navigation timeouts", () => {
+    const c = classifyRunError({
+      errorMessage: "page.goto: Timeout 30000ms exceeded",
+    });
+    expect(c?.category).toBe("navigation_timeout");
+  });
+
+  it("reads network errorText when no error message is present", () => {
+    const c = classifyRunError({
+      networkRequests: [net({ failed: true, errorText: "net::ERR_TIMED_OUT" })],
+    });
+    expect(c?.category).toBe("connection_timeout");
+  });
+
+  it("detects a Cloudflare bot challenge via headers + status", () => {
+    const c = classifyRunError({
+      errorMessage: "page.goto: Timeout 30000ms exceeded",
+      networkRequests: [
+        net({
+          status: 403,
+          resourceType: "document",
+          responseHeaders: { "cf-ray": "abc123", server: "cloudflare" },
+        }),
+      ],
+    });
+    expect(c?.category).toBe("bot_challenge");
+  });
+
+  it("detects a challenge via response body markers", () => {
+    const c = classifyRunError({
+      networkRequests: [
+        net({
+          status: 503,
+          responseBody: "<title>Just a moment...</title>",
+        }),
+      ],
+    });
+    expect(c?.category).toBe("bot_challenge");
+  });
+
+  it("does not flag an ordinary 403 without challenge markers", () => {
+    const c = classifyRunError({
+      networkRequests: [net({ status: 403 })],
+    });
+    expect(c).toBeNull();
+  });
+});
+
+describe("formatClassifiedError", () => {
+  it("includes title, suggestion, and trimmed raw detail", () => {
+    const c = classifyRunError({
+      errorMessage:
+        "page.goto: net::ERR_NAME_NOT_RESOLVED at https://nope.test",
+    })!;
+    const out = formatClassifiedError(
+      c,
+      "page.goto: net::ERR_NAME_NOT_RESOLVED at https://nope.test",
+    );
+    expect(out).toContain("resolved");
+    expect(out).toContain("details:");
+  });
+
+  it("omits raw detail when redundant", () => {
+    const c = classifyRunError({ runnerStatus: "timeout" })!;
+    const out = formatClassifiedError(c);
+    expect(out).not.toContain("details:");
+  });
+});

--- a/src/lib/execution/error-classify.ts
+++ b/src/lib/execution/error-classify.ts
@@ -1,0 +1,206 @@
+/**
+ * Run-failure classifier.
+ *
+ * Test runs fail for many reasons that are indistinguishable to a user when
+ * the only thing surfaced is a raw Playwright stack or a bare
+ * "Test execution timed out". This maps the runner error + captured network
+ * signals to a human-readable category, headline, and (when we have one) an
+ * actionable suggestion — so the failure toast and error panel can tell a
+ * user *why* a run failed (bot challenge, DNS, connection refused, …) instead
+ * of a cryptic string.
+ *
+ * Pure + dependency-free (other than the NetworkRequest type) so it runs on
+ * both the server (executor) and the client (test detail UI).
+ */
+import type { NetworkRequest } from "@/lib/db/schema";
+
+export type RunErrorCategory =
+  | "bot_challenge"
+  | "dns"
+  | "connection_refused"
+  | "connection_timeout"
+  | "tls"
+  | "navigation_timeout"
+  | "runner_timeout"
+  | "runner_disconnected"
+  | "unknown";
+
+export interface ClassifiedRunError {
+  category: RunErrorCategory;
+  /** Short human-readable headline. Always contains enough of the original
+   *  signal ("timed out", "disconnected") that downstream substring
+   *  heuristics keep working. */
+  title: string;
+  /** One-line actionable suggestion, when we have one. */
+  suggestion?: string;
+}
+
+export interface ClassifyInput {
+  errorMessage?: string | null;
+  consoleErrors?: string[] | null;
+  networkRequests?: NetworkRequest[] | null;
+  /** Set when the runner reported a bare timeout/disconnect with no result
+   *  payload (so there is no Playwright error or network trace to inspect). */
+  runnerStatus?: "timeout" | "disconnected" | null;
+}
+
+const SUGGESTIONS: Record<RunErrorCategory, string | undefined> = {
+  bot_challenge:
+    "The site served a bot/anti-automation challenge (e.g. Cloudflare). Set a custom User-Agent under Settings → Playwright, or point the test at a non-protected environment.",
+  dns: "The hostname couldn't be resolved. Check the base URL for typos and that the site is publicly reachable from the runner.",
+  connection_refused:
+    "The server refused the connection. Make sure the target URL is running and reachable from the test runner.",
+  connection_timeout:
+    "The connection timed out. The site may be slow, down, or blocking the runner's network.",
+  tls: "The site's TLS/SSL certificate couldn't be verified. Check the certificate or use a trusted environment.",
+  navigation_timeout:
+    "The page took too long to load. Increase the navigation timeout under Settings → Playwright, or confirm the URL loads.",
+  runner_timeout: undefined,
+  runner_disconnected: undefined,
+  unknown: undefined,
+};
+
+const CHALLENGE_BODY_MARKERS = [
+  "just a moment",
+  "attention required",
+  "challenge-platform",
+  "cf-browser-verification",
+  "checking your browser",
+  "enable javascript and cookies to continue",
+  "ddos protection by",
+  "/cdn-cgi/challenge",
+];
+
+function looksLikeCloudflare(req: NetworkRequest): boolean {
+  const headers = {
+    ...(req.responseHeaders ?? {}),
+  } as Record<string, string>;
+  const lowerKeys = Object.fromEntries(
+    Object.entries(headers).map(([k, v]) => [k.toLowerCase(), String(v ?? "")]),
+  );
+  if ("cf-ray" in lowerKeys || "cf-mitigated" in lowerKeys) return true;
+  const server = (lowerKeys["server"] ?? "").toLowerCase();
+  if (server.includes("cloudflare")) return true;
+  const body = (req.responseBody ?? "").slice(0, 4000).toLowerCase();
+  return CHALLENGE_BODY_MARKERS.some((m) => body.includes(m));
+}
+
+/** A blocking challenge: the main document (or any request) came back with a
+ *  challenge status from an anti-bot service. */
+function detectBotChallenge(
+  networkRequests?: NetworkRequest[] | null,
+): boolean {
+  if (!networkRequests || networkRequests.length === 0) return false;
+  const CHALLENGE_STATUS = new Set([403, 429, 503]);
+  return networkRequests.some((req) => {
+    const isDoc =
+      req.resourceType === "document" || req.resourceType === "navigation";
+    const challengeStatus = CHALLENGE_STATUS.has(req.status);
+    if (challengeStatus && looksLikeCloudflare(req)) return true;
+    // A document request that failed/got a challenge status against a
+    // Cloudflare-looking origin is the strongest signal.
+    return isDoc && challengeStatus && looksLikeCloudflare(req);
+  });
+}
+
+/**
+ * Classify a run failure. Returns `null` when the failure is an ordinary
+ * test/assertion failure (selector not found, content mismatch, …) — those
+ * carry a meaningful message already and should be shown verbatim.
+ */
+export function classifyRunError(
+  input: ClassifyInput,
+): ClassifiedRunError | null {
+  const { runnerStatus } = input;
+
+  if (runnerStatus === "timeout") {
+    return {
+      category: "runner_timeout",
+      title:
+        "The test ran longer than the allowed time and was stopped (timed out).",
+      suggestion:
+        "Increase the test timeout under Settings → Playwright, or check the run for a step that hangs.",
+    };
+  }
+  if (runnerStatus === "disconnected") {
+    return {
+      category: "runner_disconnected",
+      title:
+        "The browser runner disconnected before the test finished. This is usually transient — try running again.",
+    };
+  }
+
+  const haystacks: string[] = [];
+  if (input.errorMessage) haystacks.push(input.errorMessage);
+  for (const req of input.networkRequests ?? []) {
+    if (req.errorText) haystacks.push(req.errorText);
+  }
+  for (const c of input.consoleErrors ?? []) haystacks.push(c);
+  const text = haystacks.join("\n");
+
+  // Bot challenge is checked first: a Cloudflare interstitial typically
+  // surfaces as a navigation timeout, so it would otherwise be misread.
+  if (detectBotChallenge(input.networkRequests)) {
+    return {
+      category: "bot_challenge",
+      title: "The site blocked the test with a bot/anti-automation challenge.",
+      suggestion: SUGGESTIONS.bot_challenge,
+    };
+  }
+
+  const tests: Array<[RegExp, RunErrorCategory, string]> = [
+    [
+      /ERR_NAME_NOT_RESOLVED|ENOTFOUND|getaddrinfo/i,
+      "dns",
+      "The site's hostname couldn't be resolved (DNS lookup failed).",
+    ],
+    [
+      /ERR_CONNECTION_REFUSED|ECONNREFUSED/i,
+      "connection_refused",
+      "The server refused the connection — the test couldn't connect to the site.",
+    ],
+    [
+      /ERR_CERT|ERR_SSL|ERR_BAD_SSL|SSL certificate|certificate has expired|self.signed certificate/i,
+      "tls",
+      "The site's TLS/SSL certificate couldn't be verified.",
+    ],
+    [
+      /ERR_CONNECTION_TIMED_OUT|ERR_TIMED_OUT|ETIMEDOUT|ERR_CONNECTION_RESET|ECONNRESET/i,
+      "connection_timeout",
+      "The connection to the site timed out or was reset.",
+    ],
+    [
+      /Timeout .*exceeded|navigation timeout|Timeout exceeded while|page\.goto: Timeout|waiting for navigation/i,
+      "navigation_timeout",
+      "The page took too long to load (navigation timed out).",
+    ],
+  ];
+
+  for (const [re, category, title] of tests) {
+    if (re.test(text)) {
+      return { category, title, suggestion: SUGGESTIONS[category] };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Render a classified error into a single user-facing string for storage in
+ * `errorMessage` / display in a toast. Keeps a trimmed slice of the raw
+ * technical message for debugging when it adds information.
+ */
+export function formatClassifiedError(
+  c: ClassifiedRunError,
+  rawMessage?: string | null,
+): string {
+  const parts = [c.title];
+  if (c.suggestion) parts.push(c.suggestion);
+  let out = parts.join(" ");
+  const raw = (rawMessage ?? "").split("\n")[0]?.trim();
+  if (raw && !out.includes(raw)) {
+    const trimmed = raw.length > 200 ? `${raw.slice(0, 200)}…` : raw;
+    out += ` (details: ${trimmed})`;
+  }
+  return out;
+}

--- a/src/lib/execution/executor.ts
+++ b/src/lib/execution/executor.ts
@@ -71,6 +71,10 @@ import type {
 import { getAISettings } from "@/lib/db/queries";
 import { generateWithAI, type AIProviderConfig } from "@/lib/ai";
 import { buildAIVarPrompt, sanitizeAIVarOutput } from "@/lib/vars/ai-presets";
+import {
+  classifyRunError,
+  formatClassifiedError,
+} from "@/lib/execution/error-classify";
 /**
  * Generate SHA256 hash of test code for integrity verification.
  */
@@ -1083,11 +1087,14 @@ async function executeViaRunner(
       ) {
         inFlight.delete(dbCmd.id);
         completedCount++;
-        // No result payload — runner timed out or disconnected
-        const errorMsg =
-          dbCmd.status === "timeout"
-            ? `Test execution timed out`
-            : `Runner disconnected during test execution`;
+        // No result payload — runner timed out or disconnected. Surface a
+        // human-readable reason instead of a bare status string.
+        const errorMsg = formatClassifiedError(
+          classifyRunError({
+            runnerStatus:
+              dbCmd.status === "timeout" ? "timeout" : "disconnected",
+          })!,
+        );
         const timeoutResult: TestRunResult = {
           testId: info.testId,
           status: "failed",
@@ -1201,6 +1208,35 @@ async function executeViaRunner(
             | undefined)
         : undefined;
 
+      const rawErrorMessage = errorPayload?.message as string | undefined;
+      const rawConsoleErrors = Array.isArray(payload.consoleErrors)
+        ? (payload.consoleErrors as string[])
+        : null;
+      const rawNetworkRequests = Array.isArray(payload.networkRequests)
+        ? (payload.networkRequests as NetworkRequest[])
+        : null;
+      // For failures, replace cryptic Playwright/network errors with a
+      // human-readable reason (bot challenge, DNS, connection refused, …).
+      // Genuine assertion failures classify to null and are shown verbatim.
+      const isFailed =
+        payload.status === "failed" ||
+        payload.status === "error" ||
+        payload.status === "timeout";
+      let resolvedErrorMessage = rawErrorMessage;
+      if (isFailed) {
+        const classified = classifyRunError({
+          errorMessage: rawErrorMessage,
+          consoleErrors: rawConsoleErrors,
+          networkRequests: rawNetworkRequests,
+        });
+        if (classified) {
+          resolvedErrorMessage = formatClassifiedError(
+            classified,
+            rawErrorMessage,
+          );
+        }
+      }
+
       const testResult: TestRunResult = {
         testId: (payload.testId as string) || info.testId,
         status:
@@ -1212,7 +1248,7 @@ async function executeViaRunner(
         durationMs: (payload.durationMs as number) || 0,
         screenshotPath: allScreenshots[0]?.path,
         screenshots: allScreenshots,
-        errorMessage: errorPayload?.message as string | undefined,
+        errorMessage: resolvedErrorMessage,
         consoleErrors:
           Array.isArray(payload.consoleErrors) &&
           payload.consoleErrors.length > 0

--- a/src/server/actions/onboarding.ts
+++ b/src/server/actions/onboarding.ts
@@ -6,6 +6,7 @@ import { requireAuth, requireTeamAccess } from "@/lib/auth";
 import { assertHttpScheme } from "@/lib/security/url-validation";
 import type { OnboardingPath } from "@/lib/db/schema";
 import { startPlayAgent } from "./play-agent";
+import { repointSeededSampleToSmoke } from "@/lib/demo/sandbox-seeds";
 
 export async function setOnboardingPath(path: OnboardingPath) {
   const session = await requireAuth();
@@ -30,6 +31,14 @@ export async function setBaseUrl(repositoryId: string, url: string) {
   await queries.updateRepository(repositoryId, {
     branchBaseUrls: { ...existing, default: url, [branch]: url },
   });
+  // If the only test is an untouched auto-seeded sample (e.g. the herokuapp
+  // demo), re-point it at the URL the user just entered so their first test
+  // targets their own app instead of a third-party playground that fails.
+  try {
+    await repointSeededSampleToSmoke(repositoryId, url);
+  } catch (err) {
+    console.warn("[onboarding] Failed to re-point seeded sample:", err);
+  }
   revalidatePath("/onboarding");
   revalidatePath("/settings");
 }

--- a/src/server/actions/repos.ts
+++ b/src/server/actions/repos.ts
@@ -23,6 +23,7 @@ import { deleteRepoStorage } from "@/lib/storage/cleanup";
 import {
   isSandboxSeedId,
   seedSandboxTemplate,
+  seedGenericSmokeTest,
   type SandboxSeedId,
 } from "@/lib/demo/sandbox-seeds";
 
@@ -269,6 +270,11 @@ export async function createLocalRepo(
       repo.id,
       templateId as SandboxSeedId,
     );
+  } else if (baseUrl) {
+    // "Bring your own URL" (e.g. the Blank template): seed a generic,
+    // URL-adaptive smoke test against *their* site so the first test targets
+    // the user's app rather than a third-party demo.
+    seededTestId = await seedGenericSmokeTest(repo.id, baseUrl);
   }
   revalidatePath("/");
   revalidatePath("/settings");


### PR DESCRIPTION
a) One-click "Run a sample test" on onboarding step 1 — creates a TodoMVC
   sandbox and drops the user straight onto a runnable test, deferring repo
   and AI setup.

b/e) Classify run failures into human-readable reasons (bot/Cloudflare
   challenge, DNS, connection refused/timeout, TLS, navigation/runner
   timeout) with actionable suggestions, instead of bare strings like
   "Test execution timed out". Surfaced via the stored errorMessage so the
   failure toast and error panel show it. New pure classifier + unit tests.

d) Fix seeded-test bug: bringing your own URL no longer leaves you with a
   hardcoded third-party demo test (e.g. the herokuapp "form auth" test)
   that targets the wrong site and fails. A custom-URL sandbox now seeds a
   generic, URL-adaptive smoke test, and setting a base URL re-points an
   untouched seeded sample at the user's own site. Mark the herokuapp
   template as a possibly-slow third-party host.

Note: per-run AI is already off by default (executionMode defaults to
procedural; diff analysis, change-map AI, and failure triage are all gated
by aiDiffingEnabled=false), so no default change was needed.