### PR TITLE
Fix recording/debug session lifecycle and stream reliability issues

### DIFF
--- a/packages/embedded-browser/src/debug-executor.ts
+++ b/packages/embedded-browser/src/debug-executor.ts
@@ -96,6 +96,14 @@ class PauseController {
   private pendingResolve: (() => void) | null = null;
   private pendingReject: ((err: Error) => void) | null = null;
   private onPause: () => void;
+  // A resume that arrived while no checkpoint was waiting (the previous step
+  // was still executing). Without buffering, that user action (step_forward /
+  // run_to_end clicked mid-step) was silently dropped and the session looked
+  // unresponsive — the user had to click again.
+  private queuedResume: {
+    mode: "paused" | "running" | "run_to_step";
+    target?: number;
+  } | null = null;
 
   constructor(
     mode: "paused" | "running" | "run_to_step",
@@ -112,6 +120,18 @@ class PauseController {
     if (this.mode === "running") return;
     if (this.mode === "run_to_step" && stepIdx < this.target) return;
 
+    // Consume a resume that was issued while the previous step was running.
+    if (this.queuedResume) {
+      const q = this.queuedResume;
+      this.queuedResume = null;
+      this.mode = q.mode;
+      if (q.target !== undefined) this.target = q.target;
+      if (this.mode === "running") return;
+      if (this.mode === "run_to_step" && stepIdx < this.target) return;
+      // mode === "paused" means single-step: execute this step, pause at next.
+      if (this.mode === "paused") return;
+    }
+
     if (this.mode === "run_to_step") this.mode = "paused";
     this.onPause();
 
@@ -122,6 +142,12 @@ class PauseController {
   }
 
   resume(newMode: "paused" | "running" | "run_to_step", target?: number): void {
+    if (!this.pendingResolve) {
+      // Nothing is waiting (a step is mid-execution) — buffer for the next
+      // checkpoint instead of dropping the action.
+      this.queuedResume = { mode: newMode, target };
+      return;
+    }
     this.mode = newMode;
     if (target !== undefined) this.target = target;
     const resolve = this.pendingResolve;

--- a/packages/embedded-browser/src/debug-executor.ts
+++ b/packages/embedded-browser/src/debug-executor.ts
@@ -189,6 +189,11 @@ export class EmbeddedDebugExecutor {
   private setupVariables?: Record<string, unknown>;
   private stabilization?: StabilizationPayload;
   private generation = 0;
+  // Set when update_code changes the step list while an execution built from
+  // the OLD instrumented body is still alive. Resuming that body would run
+  // stale code (the inserted/edited steps would silently not exist), so any
+  // resume while stale triggers a replay with the new code instead.
+  private staleCode = false;
 
   constructor(browser: Browser) {
     this.browser = browser;
@@ -209,6 +214,7 @@ export class EmbeddedDebugExecutor {
     this.status = "initializing";
     this.error = undefined;
     this.codeVersion = 0;
+    this.staleCode = false;
     this.targetUrl = payload.targetUrl;
     this.viewport = payload.viewport || { width: 1280, height: 720 };
     this.storageState = payload.storageState;
@@ -266,6 +272,7 @@ export class EmbeddedDebugExecutor {
     this.currentStepIndex = 0;
     this.status = "running";
     this.error = undefined;
+    this.staleCode = false;
     this.generation++;
     const gen = this.generation;
     this.runExecution(gen, targetStep).catch((err) => {
@@ -282,6 +289,13 @@ export class EmbeddedDebugExecutor {
   ): Promise<void> {
     switch (action) {
       case "step_forward":
+        if (this.staleCode) {
+          // The running body predates the latest code edit — re-run with the
+          // new code and land paused right after the current step (so an
+          // inserted step right after it is the next thing to execute).
+          await this.replayToStep(Math.max(0, this.currentStepIndex + 1));
+          break;
+        }
         if (this.pauseController) {
           this.status = "stepping";
           this.pauseController.resume("paused");
@@ -295,6 +309,10 @@ export class EmbeddedDebugExecutor {
       }
 
       case "run_to_end":
+        if (this.staleCode) {
+          await this.replayToStep(this.steps.length);
+          break;
+        }
         if (this.pauseController) {
           this.status = "running";
           this.pauseController.resume("running");
@@ -305,11 +323,12 @@ export class EmbeddedDebugExecutor {
         if (payload?.stepIndex === undefined) break;
         const targetIdx = payload.stepIndex;
         if (targetIdx < 0 || targetIdx >= this.steps.length) break;
-        if (targetIdx === this.currentStepIndex) break;
+        if (targetIdx === this.currentStepIndex && !this.staleCode) break;
 
         if (
           targetIdx > this.currentStepIndex &&
           this.pauseController &&
+          !this.staleCode &&
           this.status !== "completed" &&
           this.status !== "error"
         ) {
@@ -317,7 +336,7 @@ export class EmbeddedDebugExecutor {
           this.status = "running";
           this.pauseController.resume("run_to_step", targetIdx);
         } else {
-          // BACKWARD or forward from completed/error: full replay
+          // BACKWARD, forward from completed/error, or stale code: full replay
           await this.replayToStep(targetIdx);
         }
         break;
@@ -329,6 +348,10 @@ export class EmbeddedDebugExecutor {
           this.cleanBody = payload.cleanBody;
           if (payload.code) this.code = payload.code;
           this.codeVersion++;
+          // The live execution (if any) was instrumented from the OLD body —
+          // resuming it would silently run stale code. Any subsequent control
+          // action replays with the new code instead (see staleCode checks).
+          this.staleCode = true;
 
           // Check if changes affect already-executed steps
           const executedCount = this.stepResults.filter(
@@ -353,9 +376,13 @@ export class EmbeddedDebugExecutor {
             );
             this.stepResults = newResults;
 
-            // If current step is past the changed area, warn
+            // Steps already ran with the old code — surface that the next
+            // control action re-executes from the start with the new code.
+            // Keep the legacy "Step back to apply" marker: the debug UI keys
+            // its soft-warning banner off that substring.
             if (this.currentStepIndex < payload.steps.length) {
-              this.error = "Step back to apply code changes";
+              this.error =
+                "Code changed — Step back to apply, or any step action will re-run from the start with the new code";
               this.status = "error";
             }
           } else {

--- a/packages/embedded-browser/src/index.ts
+++ b/packages/embedded-browser/src/index.ts
@@ -862,8 +862,14 @@ async function startup(): Promise<void> {
 
         runnerClient.setStatus("busy", payload.sessionId);
 
-        // Notify stream viewers before stopping screencast so they suppress stall detection
-        streamServer?.broadcastStatus("busy");
+        // Distinct "setup" stream status: viewers show a blocking "running
+        // setup, please wait" overlay for the WHOLE setup phase (the setup
+        // pages stream live but input is detached, so interaction would be
+        // silently ignored). Cleared by the "recording" broadcast once the
+        // recorder is live. Suppresses viewer stall detection like "busy".
+        streamServer?.broadcastStatus(
+          payload.setupSteps?.length ? "setup" : "busy",
+        );
 
         // Stop screencast/input on idle page
         await screencast?.stop();
@@ -1554,7 +1560,9 @@ async function startup(): Promise<void> {
         activeTasks++;
         if (activeTasks === 1) {
           capturedClient.setStatus("busy", `setup:${payload.setupId}`);
-          streamServer?.broadcastStatus("busy", payload.targetUrl);
+          // "setup" (vs generic "busy") drives the viewer's blocking
+          // "running setup, please wait" overlay for the whole setup phase.
+          streamServer?.broadcastStatus("setup", payload.targetUrl);
           if (!setupHeaded) {
             // Pause screencast to free Chromium CPU for setup execution.
             // In headed (debug) mode we keep it alive and re-route it to the

--- a/packages/embedded-browser/src/index.ts
+++ b/packages/embedded-browser/src/index.ts
@@ -893,14 +893,40 @@ async function startup(): Promise<void> {
             for (let i = 0; i < payload.setupSteps.length; i++) {
               const step = payload.setupSteps[i]!;
               const stepSetupId = `rec-${payload.sessionId.slice(0, 8)}-${i}`;
-              const result = await testExecutor.runSetup(browser, {
-                setupId: stepSetupId,
-                code: step.code,
-                codeHash: step.codeHash,
-                targetUrl: payload.targetUrl,
-                timeout: 120_000,
-                viewport: payload.viewport,
-              });
+              const result = await testExecutor.runSetup(
+                browser,
+                {
+                  setupId: stepSetupId,
+                  code: step.code,
+                  codeHash: step.codeHash,
+                  targetUrl: payload.targetUrl,
+                  timeout: 120_000,
+                  viewport: payload.viewport,
+                },
+                {
+                  // Stream the setup page live (same as debug-session setup) —
+                  // the screencast was stopped above, so without this the
+                  // viewer sat on a blank canvas with no sign of progress
+                  // until the recording page finally attached.
+                  onPageCreated: async (setupPage: Page) => {
+                    try {
+                      await screencast?.start(setupPage, (frame) => {
+                        streamServer!.broadcastFrame(
+                          frame.data,
+                          frame.width,
+                          frame.height,
+                          frame.timestamp,
+                        );
+                      });
+                    } catch (err) {
+                      console.error(
+                        "[Command] Failed to attach screencast to recording-setup page:",
+                        err,
+                      );
+                    }
+                  },
+                },
+              );
               if (result.status !== "passed") {
                 throw new Error(
                   `Setup step ${i + 1}/${payload.setupSteps.length} failed: ${result.error ?? "unknown"}`,
@@ -1401,13 +1427,20 @@ async function startup(): Promise<void> {
           steps?: import("./debug-executor.js").DebugStep[];
         };
 
+        // Replays replace the BrowserContext + page (step_back, run_to_step
+        // going backward, or any action re-running stale code after an edit).
+        // Compare page identity around the action and re-attach the screencast
+        // + input whenever it changed — keying off step_back alone left the
+        // stream bound to a closed page after run_to_step replays ("insert
+        // click → click a step → stream dead").
+        const pageBefore = debugExecutor.getPage();
+
         await debugExecutor.handleAction(payload.action, payload);
 
-        // After step_back, screencast needs restart on new page (old context closed)
-        if (payload.action === "step_back") {
+        const newPage = debugExecutor.getPage();
+        if (newPage !== pageBefore) {
           await screencast?.stop();
           await inputHandler?.detach();
-          const newPage = debugExecutor.getPage();
           if (newPage && screencast) {
             // Force the new debug page to render at the EB's native resolution
             const cdp = await newPage.context().newCDPSession(newPage);

--- a/packages/embedded-browser/src/index.ts
+++ b/packages/embedded-browser/src/index.ts
@@ -68,11 +68,33 @@ let isRecording = false;
 let isDebugging = false;
 let recordingWatchdog: ReturnType<typeof setInterval> | null = null;
 let lastRecordingEventTime = 0;
-const RECORDING_INACTIVITY_TIMEOUT = 60_000; // 1 minute
+// Reaps abandoned recording sessions. Live stream input also counts as
+// activity (wired via streamServer.onInputActivity below) — previously only
+// *recorded* events reset this clock, so a user who paused for 60s to read
+// the page had their recording silently auto-stopped ("recording froze").
+const RECORDING_INACTIVITY_TIMEOUT = 300_000; // 5 minutes
+// Active session IDs — used to drop redispatched start commands for a session
+// that is already running (the server redelivers commands whose ack was lost).
+let currentRecordingSessionId: string | null = null;
+let currentDebugSessionId: string | null = null;
 
 // Concurrent test execution tracking (each test gets its own BrowserContext)
 let activeTasks = 0;
 const activeTestIds = new Set<string>();
+
+// Command-id dedup (mirrors packages/runner client.ts). The server redelivers
+// a command when its ack is lost or its row is reaped back to pending; without
+// this guard a redispatched start_recording / start_debug / debug_action /
+// run_setup executes twice (run_test alone had testId-based dedup).
+let seenCommandIds = new Set<string>();
+function isDuplicateCommand(id: string): boolean {
+  if (seenCommandIds.has(id)) return true;
+  seenCommandIds.add(id);
+  if (seenCommandIds.size > 1000) {
+    seenCommandIds = new Set([...seenCommandIds].slice(-500));
+  }
+  return false;
+}
 
 async function startup(): Promise<void> {
   console.log("=== Embedded Browser Service ===");
@@ -371,6 +393,12 @@ async function startup(): Promise<void> {
   await inputHandler.attach(page);
   streamServer.setInputHandler(inputHandler);
 
+  // Live viewer input keeps the recording session alive — the inactivity
+  // watchdog must only reap sessions nobody is interacting with.
+  streamServer.onInputActivity = () => {
+    if (isRecording) lastRecordingEventTime = Date.now();
+  };
+
   // 4b. Notify clients when a file chooser dialog opens
   page.on("filechooser", () => {
     streamServer?.broadcastStatus("connected", page?.url(), undefined, true);
@@ -417,6 +445,13 @@ async function startup(): Promise<void> {
       .catch(() => {
         /* swallow — redispatch covers loss */
       });
+
+    // Drop redeliveries AFTER acking (the ack is idempotent server-side and
+    // re-confirms receipt so the row doesn't bounce back to pending again).
+    if (isDuplicateCommand(command.id)) {
+      console.log(`[Command] Skipping duplicate command ${command.id}`);
+      return;
+    }
 
     switch (command.type) {
       case "command:run_test": {
@@ -795,6 +830,18 @@ async function startup(): Promise<void> {
 
       case "command:start_recording": {
         if (!browser || !runnerClient || !recorder) break;
+        const startRecPayload = command.payload as { sessionId: string };
+        // Redispatch guard: the same session arriving again (lost ack /
+        // reaped command row) must not tear down and restart a live recording.
+        if (
+          isRecording &&
+          currentRecordingSessionId === startRecPayload.sessionId
+        ) {
+          console.log(
+            `[Command] Ignoring duplicate start_recording for active session ${startRecPayload.sessionId}`,
+          );
+          break;
+        }
         // Reset inspect mode (may have been left on by a debug session)
         if (streamServer) {
           streamServer.inspectMode = false;
@@ -910,8 +957,11 @@ async function startup(): Promise<void> {
           });
           await inputHandler?.attach(recordingPage);
           isRecording = true;
+          currentRecordingSessionId = payload.sessionId;
 
-          // Start inactivity watchdog
+          // Start inactivity watchdog. Cleared before re-arming — a leftover
+          // interval from a previous session would double-fire stop commands.
+          if (recordingWatchdog) clearInterval(recordingWatchdog);
           lastRecordingEventTime = Date.now();
           recordingWatchdog = setInterval(() => {
             if (
@@ -919,9 +969,11 @@ async function startup(): Promise<void> {
               Date.now() - lastRecordingEventTime > RECORDING_INACTIVITY_TIMEOUT
             ) {
               console.warn(
-                "[Watchdog] Recording inactive for 60s — auto-stopping",
+                `[Watchdog] Recording inactive for ${RECORDING_INACTIVITY_TIMEOUT / 1000}s — auto-stopping`,
               );
-              runnerClient?.onCommand?.({
+              // Route through the command chain so it can't interleave with a
+              // server-sent command that's mid-flight.
+              runnerClient?.enqueueCommand({
                 id: crypto.randomUUID(),
                 type: "command:stop_recording",
                 timestamp: Date.now(),
@@ -937,6 +989,7 @@ async function startup(): Promise<void> {
         } catch (err) {
           console.error(`[Command] Failed to start recording:`, err);
           isRecording = false;
+          currentRecordingSessionId = null;
           if (recordingWatchdog) {
             clearInterval(recordingWatchdog);
             recordingWatchdog = null;
@@ -1037,6 +1090,7 @@ async function startup(): Promise<void> {
             await recorder.forceCleanup();
           }
           isRecording = false;
+          currentRecordingSessionId = null;
 
           // Re-attach screencast + input to idle page
           try {
@@ -1178,6 +1232,39 @@ async function startup(): Promise<void> {
 
       case "command:start_debug": {
         if (!browser || !runnerClient) break;
+        const startDbgPayload = command.payload as { sessionId: string };
+        // Redispatch guard: don't rebuild a live debug session from scratch
+        // when the server redelivers the same start command.
+        if (
+          isDebugging &&
+          currentDebugSessionId === startDbgPayload.sessionId
+        ) {
+          console.log(
+            `[Command] Ignoring duplicate start_debug for active session ${startDbgPayload.sessionId}`,
+          );
+          break;
+        }
+        // A different session is replacing the current one — tear the old one
+        // down first. Previously the old executor (context + page + paused
+        // execution loop) and its state-reporter interval were simply
+        // overwritten and leaked: two intervals kept POSTing debug_state and
+        // the orphaned context held Chromium resources.
+        if (debugStateReporter) {
+          clearInterval(debugStateReporter);
+          debugStateReporter = null;
+        }
+        if (debugExecutor) {
+          try {
+            await debugExecutor.stop();
+          } catch (err) {
+            console.error(
+              "[Command] Error stopping previous debug session:",
+              err,
+            );
+          }
+          debugExecutor = null;
+          isDebugging = false;
+        }
         // Remember & reset inspect mode from any previous session
         const wasInspecting = streamServer?.inspectMode ?? false;
         if (streamServer) {
@@ -1234,6 +1321,7 @@ async function startup(): Promise<void> {
           }
 
           isDebugging = true;
+          currentDebugSessionId = payload.sessionId;
 
           // Re-inject inspect overlay on the new debug page if it was active
           if (wasInspecting && streamServer) {
@@ -1263,6 +1351,7 @@ async function startup(): Promise<void> {
         } catch (err) {
           console.error(`[Command] Failed to start debug session:`, err);
           isDebugging = false;
+          currentDebugSessionId = null;
           if (debugStateReporter) {
             clearInterval(debugStateReporter);
             debugStateReporter = null;
@@ -1367,6 +1456,7 @@ async function startup(): Promise<void> {
           }
           debugExecutor = null;
           isDebugging = false;
+          currentDebugSessionId = null;
 
           // Re-attach screencast + input to idle page
           try {

--- a/packages/embedded-browser/src/input-handler.ts
+++ b/packages/embedded-browser/src/input-handler.ts
@@ -339,12 +339,12 @@ export class InputHandler {
   private async handleTouch(event: TouchEvent): Promise<void> {
     if (!this.cdpSession) return;
 
-    const CDP_TOUCH_TYPE: Record<string, string> = {
+    const CDP_TOUCH_TYPE = {
       start: "touchStart",
       move: "touchMove",
       end: "touchEnd",
       cancel: "touchCancel",
-    };
+    } as const;
 
     const cdpType = CDP_TOUCH_TYPE[event.action];
     if (!cdpType) return;

--- a/packages/embedded-browser/src/input-handler.ts
+++ b/packages/embedded-browser/src/input-handler.ts
@@ -19,6 +19,17 @@ export interface MouseEvent {
   clickCount?: number;
   deltaX?: number;
   deltaY?: number;
+  // Live modifier state sampled from the viewer's browser event. Preferred
+  // over the keyboard-tracked state below, which can stick when a modifier
+  // keyup is never forwarded (canvas lost focus while the key was held) —
+  // stuck Ctrl/Alt turned every later click into a ctrl/alt+click that links
+  // interpret as open-in-new-tab, so the page visibly ignored the click.
+  modifiers?: {
+    ctrl?: boolean;
+    shift?: boolean;
+    alt?: boolean;
+    meta?: boolean;
+  };
 }
 
 export interface KeyboardEvent {
@@ -175,6 +186,14 @@ export class InputHandler {
     if (!this.cdpSession) return;
 
     const button = BUTTON_MAP[event.button ?? "left"] ?? "left";
+    // Prefer the event's own modifier snapshot; resync the tracked state from
+    // it so stale keyboard-derived modifiers can't stick around.
+    if (event.modifiers) {
+      this.modifiers.ctrl = event.modifiers.ctrl ?? false;
+      this.modifiers.shift = event.modifiers.shift ?? false;
+      this.modifiers.alt = event.modifiers.alt ?? false;
+      this.modifiers.meta = event.modifiers.meta ?? false;
+    }
     // CDP modifiers bitmask: 1=Alt, 2=Ctrl, 4=Meta, 8=Shift
     const modifiers =
       (this.modifiers.alt ? 1 : 0) |

--- a/packages/embedded-browser/src/runner-client.ts
+++ b/packages/embedded-browser/src/runner-client.ts
@@ -90,9 +90,25 @@ export class EmbeddedRunnerClient {
   // the pod exits. Without this the k8s DELETE can race a result/network_bodies
   // POST and the test's artefacts never land.
   private pendingSends: Set<Promise<boolean>> = new Set();
+  // Serializes onCommand invocations so commands run in queue order (e.g. a
+  // start_debug and stop_debug delivered in the same heartbeat batch can't
+  // interleave their screencast/input teardown). run_test / run_setup handlers
+  // spawn their work internally, so chaining doesn't serialize test execution.
+  // The chain is intentionally NOT awaited by the heartbeat loop.
+  private commandChain: Promise<void> = Promise.resolve();
 
   /** Called when the main app sends a command (test/recording) */
   onCommand?: (command: BaseMessage) => Promise<void>;
+
+  /** Public so locally-synthesized commands (e.g. the recording inactivity
+   *  watchdog's stop_recording) go through the same ordering chain. */
+  enqueueCommand(cmd: BaseMessage): void {
+    this.commandChain = this.commandChain
+      .then(() => this.onCommand?.(cmd))
+      .catch((err) => {
+        console.error(`[EmbeddedRunner] Command ${cmd.type} failed:`, err);
+      });
+  }
 
   constructor(options: EmbeddedRunnerOptions) {
     this.serverUrl = options.serverUrl.replace(/\/$/, "");
@@ -185,7 +201,7 @@ export class EmbeddedRunnerClient {
       // Process any pending commands
       if (data.commands && data.commands.length > 0) {
         for (const cmd of data.commands) {
-          this.onCommand?.(cmd);
+          this.enqueueCommand(cmd);
         }
       }
 
@@ -372,7 +388,7 @@ export class EmbeddedRunnerClient {
         const data = (await response.json()) as HeartbeatResponse;
         if (data.commands && data.commands.length > 0) {
           for (const cmd of data.commands) {
-            this.onCommand?.(cmd);
+            this.enqueueCommand(cmd);
           }
         }
       }

--- a/packages/embedded-browser/src/screencast.ts
+++ b/packages/embedded-browser/src/screencast.ts
@@ -45,6 +45,8 @@ export class ScreencastManager {
   private height: number;
   private ackFailCount = 0;
   private recovering = false;
+  private lastFrameAt = 0;
+  private frameWatchdog: ReturnType<typeof setInterval> | null = null;
 
   constructor(private options: ScreencastOptions = {}) {
     this.width = options.maxWidth ?? 1280;
@@ -68,6 +70,8 @@ export class ScreencastManager {
     session.on("Page.screencastFrame", (frame: ScreencastFrame) => {
       // Ignore frames from a superseded session (start() was called again).
       if (!this.running || this.cdpSession !== session) return;
+
+      this.lastFrameAt = Date.now();
 
       // Relay frame to callback
       this.frameCallback?.({
@@ -107,6 +111,37 @@ export class ScreencastManager {
       everyNthFrame: this.options.everyNthFrame ?? 1,
     });
 
+    // Frame watchdog: an idle page legitimately produces no frames, but a
+    // wedged screencast (lost ack, renderer hiccup) looks identical — the
+    // viewer shows a stale picture while clicks demonstrably reach the page.
+    // Re-kicking start/stop on the live session is cheap, forces Chrome to
+    // emit a fresh frame immediately, and recovers a broken ack chain. If the
+    // session itself is dead, the sends throw and we fall through to a full
+    // detach/re-attach recovery.
+    this.lastFrameAt = Date.now();
+    this.frameWatchdog = setInterval(() => {
+      if (!this.running || this.cdpSession !== session) return;
+      if (Date.now() - this.lastFrameAt < 30_000) return;
+      this.lastFrameAt = Date.now(); // avoid re-kicking every tick while idle
+      session
+        .send("Page.stopScreencast")
+        .then(() =>
+          session.send("Page.startScreencast", {
+            format: this.options.format ?? "jpeg",
+            quality: this.options.quality ?? 80,
+            maxWidth: this.width,
+            maxHeight: this.height,
+            everyNthFrame: this.options.everyNthFrame ?? 1,
+          }),
+        )
+        .catch(() => {
+          console.error(
+            "[Screencast] Watchdog re-kick failed — CDP session dead, re-attaching",
+          );
+          void this.recover(session);
+        });
+    }, 10_000);
+
     console.log(
       `[Screencast] Started (${this.width}x${this.height}, ${this.options.format ?? "jpeg"} q${this.options.quality ?? 80})`,
     );
@@ -139,6 +174,11 @@ export class ScreencastManager {
     this.running = false;
     this.frameCallback = null;
     this.currentPage = null;
+
+    if (this.frameWatchdog) {
+      clearInterval(this.frameWatchdog);
+      this.frameWatchdog = null;
+    }
 
     const session = this.cdpSession;
     this.cdpSession = null;

--- a/packages/embedded-browser/src/screencast.ts
+++ b/packages/embedded-browser/src/screencast.ts
@@ -38,11 +38,13 @@ type FrameCallback = (frame: {
 
 export class ScreencastManager {
   private cdpSession: CDPSession | null = null;
+  private currentPage: Page | null = null;
   private running = false;
   private frameCallback: FrameCallback | null = null;
   private width: number;
   private height: number;
   private ackFailCount = 0;
+  private recovering = false;
 
   constructor(private options: ScreencastOptions = {}) {
     this.width = options.maxWidth ?? 1280;
@@ -50,19 +52,22 @@ export class ScreencastManager {
   }
 
   async start(page: Page, onFrame: FrameCallback): Promise<void> {
-    // If already running, stop first (prevents "already running" deadlock)
-    if (this.running) {
-      console.warn("[Screencast] Already running — stopping before restart");
-      await this.stop();
-    }
+    // Always tear down any previous CDP session first. The old guard only
+    // stopped when `running` was true, but the ack-failure path clears
+    // `running` WITHOUT detaching — restarting on top of that leaked the old
+    // session + frame listener, whose stale acks then poisoned the new stream.
+    await this.stop();
 
     this.frameCallback = onFrame;
     this.ackFailCount = 0;
-    this.cdpSession = await page.context().newCDPSession(page);
+    this.currentPage = page;
+    const session = await page.context().newCDPSession(page);
+    this.cdpSession = session;
     this.running = true;
 
-    this.cdpSession.on("Page.screencastFrame", (frame: ScreencastFrame) => {
-      if (!this.running) return;
+    session.on("Page.screencastFrame", (frame: ScreencastFrame) => {
+      // Ignore frames from a superseded session (start() was called again).
+      if (!this.running || this.cdpSession !== session) return;
 
       // Relay frame to callback
       this.frameCallback?.({
@@ -73,24 +78,28 @@ export class ScreencastManager {
       });
 
       // MUST acknowledge to receive next frame
-      this.cdpSession
-        ?.send("Page.screencastFrameAck", {
+      session
+        .send("Page.screencastFrameAck", {
           sessionId: frame.sessionId,
         })
+        .then(() => {
+          this.ackFailCount = 0;
+        })
         .catch(() => {
+          if (this.cdpSession !== session) return;
           // Track consecutive ack failures — if CDP session is broken,
-          // Chrome stops sending frames and the stream silently dies
+          // Chrome stops sending frames and the stream silently dies.
           this.ackFailCount++;
           if (this.ackFailCount >= 3) {
             console.error(
-              "[Screencast] Multiple frame ack failures — CDP session likely broken",
+              "[Screencast] Multiple frame ack failures — CDP session likely broken, attempting restart",
             );
-            this.running = false;
+            void this.recover(session);
           }
         });
     });
 
-    await this.cdpSession.send("Page.startScreencast", {
+    await session.send("Page.startScreencast", {
       format: this.options.format ?? "jpeg",
       quality: this.options.quality ?? 80,
       maxWidth: this.width,
@@ -103,20 +112,49 @@ export class ScreencastManager {
     );
   }
 
-  async stop(): Promise<void> {
-    if (!this.running || !this.cdpSession) return;
+  /**
+   * Tear down the broken CDP session and re-attach to the same page so the
+   * stream self-heals instead of freezing until the next recording/debug
+   * transition restarts it.
+   */
+  private async recover(fromSession: CDPSession): Promise<void> {
+    if (this.recovering || this.cdpSession !== fromSession) return;
+    this.recovering = true;
+    const page = this.currentPage;
+    const callback = this.frameCallback;
+    try {
+      await this.stop();
+      if (page && callback && !page.isClosed()) {
+        await this.start(page, callback);
+        console.log("[Screencast] Recovered after ack failures");
+      }
+    } catch (err) {
+      console.error("[Screencast] Recovery failed:", err);
+    } finally {
+      this.recovering = false;
+    }
+  }
 
+  async stop(): Promise<void> {
     this.running = false;
     this.frameCallback = null;
+    this.currentPage = null;
+
+    const session = this.cdpSession;
+    this.cdpSession = null;
+    if (!session) return;
 
     try {
-      await this.cdpSession.send("Page.stopScreencast");
-      await this.cdpSession.detach();
+      await session.send("Page.stopScreencast");
+    } catch {
+      // Ignore errors during cleanup
+    }
+    try {
+      await session.detach();
     } catch {
       // Ignore errors during cleanup
     }
 
-    this.cdpSession = null;
     console.log("[Screencast] Stopped");
   }
 

--- a/packages/embedded-browser/src/stream-server.ts
+++ b/packages/embedded-browser/src/stream-server.ts
@@ -93,13 +93,15 @@ export class StreamServer {
         `[StreamServer] Client connected: ${clientId} (total: ${this.clients.size})`,
       );
 
-      // Send current status
+      // Send the CURRENT status (not a hardcoded "connected") so a viewer
+      // that (re)connects mid-phase — e.g. while setup streams frames and no
+      // keepalive fires — immediately knows the EB is in setup/recording/etc.
       this.sendToClient(ws, {
         type: "stream:status",
         id: crypto.randomUUID(),
         timestamp: Date.now(),
         payload: {
-          status: "connected",
+          status: this.lastStatus,
         },
       });
 

--- a/packages/embedded-browser/src/stream-server.ts
+++ b/packages/embedded-browser/src/stream-server.ts
@@ -31,6 +31,7 @@ export class StreamServer {
   private pingInterval: ReturnType<typeof setInterval> | null = null;
   private keepaliveInterval: ReturnType<typeof setInterval> | null = null;
   private lastBroadcastTime = 0;
+  private lastStatus = "idle";
 
   /** Callback for navigate requests from stream clients */
   onNavigate?: (url: string) => Promise<void>;
@@ -42,6 +43,10 @@ export class StreamServer {
   onDomSnapshot?: () => Promise<object>;
   /** Callback when inspect mode toggles (for CDP overlay) */
   onInspectModeChange?: (enabled: boolean) => void;
+  /** Called on any forwarded input event — used as a liveness signal so the
+   *  recording inactivity watchdog doesn't kill a session the user is
+   *  actively looking at / interacting with. */
+  onInputActivity?: () => void;
   /** Whether inspect mode is active (suppresses non-mouse input forwarding) */
   inspectMode = false;
 
@@ -152,11 +157,21 @@ export class StreamServer {
 
     // Send keepalive status when no frames have been broadcast recently,
     // so clients don't mistake an idle page for a broken connection.
+    //
+    // Two fixes vs the original 5s/"idle" keepalive:
+    //  - Re-broadcast the CURRENT status, not a hardcoded "idle". During a
+    //    recording, an "idle" keepalive flipped the viewer's stall-detection
+    //    suppression off; a short user pause then raced the keepalive against
+    //    the viewer's stall timeout and intermittently forced a reconnect
+    //    (canvas freeze + viewport reset mid-recording).
+    //  - Fire every 2s instead of 5s — the old cadence could deliver the
+    //    first keepalive ~8s after the last frame, exactly at the viewer's
+    //    stall deadline, making the false-stall race tight and frequent.
     this.keepaliveInterval = setInterval(() => {
       if (this.clients.size === 0) return;
-      if (Date.now() - this.lastBroadcastTime < 3000) return;
-      this.broadcastStatus("idle");
-    }, 5000);
+      if (Date.now() - this.lastBroadcastTime < 2000) return;
+      this.broadcastStatus(this.lastStatus);
+    }, 2000);
 
     console.log(`[StreamServer] Listening on port ${this.options.port}`);
   }
@@ -200,6 +215,7 @@ export class StreamServer {
     viewport?: { width: number; height: number },
     fileChooserPending?: boolean,
   ): void {
+    this.lastStatus = status;
     const message = JSON.stringify({
       type: "stream:status",
       id: crypto.randomUUID(),
@@ -224,6 +240,7 @@ export class StreamServer {
       case "stream:input": {
         const payload = (message as { payload: InputEvent }).payload;
         if (!payload) break;
+        this.onInputActivity?.();
         // In inspect mode, only forward mouse moves (for CDP overlay highlighting)
         if (
           this.inspectMode &&
@@ -232,7 +249,21 @@ export class StreamServer {
         )
           break;
         if (this.inputHandler) {
-          this.inputHandler.handleInput(payload);
+          const handled = this.inputHandler.handleInput(payload);
+          // Once a file upload is applied, tell all viewers the chooser is
+          // resolved so their "File upload requested" overlay clears.
+          if (payload.type === "file_upload") {
+            handled
+              .then(() =>
+                this.broadcastStatus(
+                  this.lastStatus,
+                  undefined,
+                  undefined,
+                  false,
+                ),
+              )
+              .catch(() => {});
+          }
         }
         break;
       }

--- a/src/app/(app)/builds/[buildId]/page.tsx
+++ b/src/app/(app)/builds/[buildId]/page.tsx
@@ -10,6 +10,7 @@ import { BuildActionsClient } from "./build-actions-client";
 import { BuildPollingWrapper } from "./build-polling-wrapper";
 import { PublishShareDialog, type ShareRecord } from "./publish-share-dialog";
 import { getStreamUrlForRunner } from "@/server/actions/embedded-sessions";
+import { appendStreamToken } from "@/lib/eb/stream-token";
 import { buildShareUrl } from "@/lib/share/slug";
 import * as queries from "@/lib/db/queries";
 import { isVerifyPhaseEnabled } from "@/lib/verify/feature-flag";
@@ -45,11 +46,11 @@ export default async function BuildPage({ params }: PageProps) {
     if (testRun?.runnerId) {
       const streamInfo = await getStreamUrlForRunner(testRun.runnerId);
       if (streamInfo?.streamUrl) {
-        const token = streamInfo.streamAuthToken;
         // Pass direct stream URL — BrowserViewer will replace hostname for remote access
-        embeddedStreamUrl = token
-          ? `${streamInfo.streamUrl}?token=${encodeURIComponent(token)}`
-          : streamInfo.streamUrl;
+        embeddedStreamUrl = appendStreamToken(
+          streamInfo.streamUrl,
+          streamInfo.streamAuthToken,
+        );
       }
     }
   }

--- a/src/app/(app)/record/recording-client.tsx
+++ b/src/app/(app)/record/recording-client.tsx
@@ -102,6 +102,7 @@ import { TraceScrub } from "@/components/recording/trace-scrub";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { track } from "@/lib/analytics/umami";
 import { Events } from "@/lib/analytics/events";
+import { appendStreamToken } from "@/lib/eb/stream-token";
 
 interface SetupStepInfo {
   id: string;
@@ -1012,11 +1013,11 @@ export function RecordingClient({
                         s.runnerId === resolvedTarget,
                     );
                     if (session?.streamUrl) {
-                      const token = data.streamAuthToken;
                       setEmbeddedStreamUrl(
-                        token
-                          ? `${session.streamUrl}?token=${encodeURIComponent(token)}`
-                          : session.streamUrl,
+                        appendStreamToken(
+                          session.streamUrl,
+                          data.streamAuthToken,
+                        ),
                       );
                       return;
                     }
@@ -1347,11 +1348,8 @@ export function RecordingClient({
               (s: { runnerId: string }) => s.runnerId === runnerId,
             );
             if (session?.streamUrl) {
-              const token = data.streamAuthToken;
               setPlaybackStreamUrl(
-                token
-                  ? `${session.streamUrl}?token=${encodeURIComponent(token)}`
-                  : session.streamUrl,
+                appendStreamToken(session.streamUrl, data.streamAuthToken),
               );
               return;
             }

--- a/src/app/(app)/tests/[id]/debug/debug-client.tsx
+++ b/src/app/(app)/tests/[id]/debug/debug-client.tsx
@@ -63,6 +63,7 @@ import {
 } from "@/components/embedded-browser/browser-viewer-client";
 import { Input } from "@/components/ui/input";
 import { getStreamUrlForRunner } from "@/server/actions/embedded-sessions";
+import { appendStreamToken } from "@/lib/eb/stream-token";
 
 interface DebugClientProps {
   test: Test;
@@ -414,11 +415,11 @@ export function DebugClient({ test, repositoryId }: DebugClientProps) {
           const streamInfo = await getStreamUrlForRunner(resolvedRunnerId);
           if (cancelled) return;
           if (streamInfo?.streamUrl) {
-            const token = streamInfo.streamAuthToken;
             setStreamUrl(
-              token
-                ? `${streamInfo.streamUrl}?token=${encodeURIComponent(token)}`
-                : streamInfo.streamUrl,
+              appendStreamToken(
+                streamInfo.streamUrl,
+                streamInfo.streamAuthToken,
+              ),
             );
           } else {
             setStreamUrl(null);

--- a/src/app/(app)/tests/[id]/debug/debug-client.tsx
+++ b/src/app/(app)/tests/[id]/debug/debug-client.tsx
@@ -602,8 +602,9 @@ export function DebugClient({ test, repositoryId }: DebugClientProps) {
                 {hasPastStepWarning && (
                   <div className="flex items-center gap-2 px-3 py-1.5 bg-yellow-500/10 border-b border-yellow-500/20">
                     <p className="text-xs text-yellow-600 flex-1">
-                      Code changed at an already-executed step. Step back to
-                      apply changes.
+                      Code changed after steps already ran. The next Step / Run
+                      / step click re-runs the test from the start with the new
+                      code.
                     </p>
                     <Button
                       variant="outline"

--- a/src/app/(app)/tests/[id]/test-detail-client.tsx
+++ b/src/app/(app)/tests/[id]/test-detail-client.tsx
@@ -132,6 +132,7 @@ import { SheetReferenceInserter } from "@/components/test-data/sheet-reference-i
 import { VarReferenceInserter } from "@/components/test-data/var-reference-inserter";
 import { BrowserViewer } from "@/components/embedded-browser/browser-viewer-client";
 import { getStreamUrlForRunner } from "@/server/actions/embedded-sessions";
+import { appendStreamToken } from "@/lib/eb/stream-token";
 import { TestSpecEditor } from "@/components/tests/test-spec-editor";
 import { PublishShareDialog } from "@/app/(app)/builds/[buildId]/publish-share-dialog";
 import { diffLines as diffTextLines, diffStats } from "@/lib/diff/text-diff";
@@ -730,11 +731,11 @@ export function TestDetailClient({
           try {
             const streamInfo = await getStreamUrlForRunner(actualRunnerId);
             if (streamInfo?.streamUrl) {
-              const token = streamInfo.streamAuthToken;
               setStreamUrl(
-                token
-                  ? `${streamInfo.streamUrl}?token=${encodeURIComponent(token)}`
-                  : streamInfo.streamUrl,
+                appendStreamToken(
+                  streamInfo.streamUrl,
+                  streamInfo.streamAuthToken,
+                ),
               );
             }
           } catch {

--- a/src/app/api/ws/runner/route.ts
+++ b/src/app/api/ws/runner/route.ts
@@ -617,24 +617,48 @@ export async function POST(request: NextRequest) {
             const { db: dbRw } = await import("@/lib/db");
             const { remoteRecordingEvents: remoteEventsTable } =
               await import("@/lib/db/schema");
+            const { sql: sqlOp } = await import("drizzle-orm");
+            // Upsert on (sessionId, sequence): the EB re-emits the same
+            // sequence when verification settles / a thumbnail arrives, and
+            // replaces trailing hover-previews in place — the latest copy is
+            // canonical. A batch can also legally contain the same sequence
+            // twice (event + its late update flushed together), so dedupe
+            // within the batch first; multi-row upserts hitting the same
+            // conflict target twice make Postgres error out.
+            const latestBySeq = new Map<number, RemoteRecordingEvent>();
+            for (const e of events) {
+              const ev = e as RemoteRecordingEvent;
+              latestBySeq.set(ev.sequence, ev);
+            }
             await dbRw
               .insert(remoteEventsTable)
               .values(
-                events.map((e) => ({
+                Array.from(latestBySeq.values()).map((e) => ({
                   sessionId: recSessionId,
-                  sequence: (e as RemoteRecordingEvent).sequence,
-                  type: (e as RemoteRecordingEvent).type,
-                  timestamp: (e as RemoteRecordingEvent).timestamp,
-                  status: (e as RemoteRecordingEvent).status,
-                  verification: ((e as RemoteRecordingEvent).verification ??
-                    null) as Record<string, unknown> | null,
-                  data: (e as RemoteRecordingEvent).data as Record<
+                  sequence: e.sequence,
+                  type: e.type,
+                  timestamp: e.timestamp,
+                  status: e.status,
+                  verification: (e.verification ?? null) as Record<
                     string,
                     unknown
-                  >,
+                  > | null,
+                  data: e.data as Record<string, unknown>,
                 })),
               )
-              .onConflictDoNothing();
+              .onConflictDoUpdate({
+                target: [
+                  remoteEventsTable.sessionId,
+                  remoteEventsTable.sequence,
+                ],
+                set: {
+                  type: sqlOp`excluded.type`,
+                  timestamp: sqlOp`excluded.timestamp`,
+                  status: sqlOp`excluded.status`,
+                  verification: sqlOp`excluded.verification`,
+                  data: sqlOp`excluded.data`,
+                },
+              });
           } catch (err) {
             console.warn(
               `[Recording] Failed to persist events for session ${recSessionId}:`,

--- a/src/components/embedded-browser/browser-viewer-client.tsx
+++ b/src/components/embedded-browser/browser-viewer-client.tsx
@@ -560,6 +560,14 @@ export const BrowserViewer = forwardRef<
         x,
         y,
         button: e.button === 2 ? "right" : e.button === 1 ? "middle" : "left",
+        // Live modifier truth from the event — overrides any stale keyboard
+        // state tracked on the EB (see StreamMouseEvent.modifiers).
+        modifiers: {
+          ctrl: e.ctrlKey,
+          shift: e.shiftKey,
+          alt: e.altKey,
+          meta: e.metaKey,
+        },
       };
 
       if (action === "down" || action === "up") {
@@ -649,6 +657,12 @@ export const BrowserViewer = forwardRef<
     }
   }, [interactive]);
 
+  // Modifier keys whose keydown was forwarded to the EB but whose keyup may
+  // never arrive (focus left the canvas while the key was held — clicking the
+  // timeline, alt-tab, …). The EB would keep the key pressed forever and
+  // treat every later click as a Ctrl/Alt+click. Released on textarea blur.
+  const heldModifierKeysRef = useRef<Set<string>>(new Set());
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       // During IME composition, let the browser handle everything
@@ -682,6 +696,14 @@ export const BrowserViewer = forwardRef<
 
       // Everything else (non-printable keys, modifier combos): forward directly
       e.preventDefault();
+      if (
+        e.key === "Control" ||
+        e.key === "Shift" ||
+        e.key === "Alt" ||
+        e.key === "Meta"
+      ) {
+        heldModifierKeysRef.current.add(e.key);
+      }
       sendWs({
         type: "stream:input",
         payload: {
@@ -705,6 +727,7 @@ export const BrowserViewer = forwardRef<
   const handleKeyUp = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (composingRef.current || e.key === "Dead") return;
+      heldModifierKeysRef.current.delete(e.key);
       // Only forward non-printable keyups (printable chars handled via input event)
       if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) return;
       e.preventDefault();
@@ -744,6 +767,21 @@ export const BrowserViewer = forwardRef<
       } satisfies StreamKeyboardEvent,
     });
     ta.value = "";
+  }, [sendWs]);
+
+  const releaseHeldModifiers = useCallback(() => {
+    for (const key of heldModifierKeysRef.current) {
+      sendWs({
+        type: "stream:input",
+        payload: {
+          type: "keyboard",
+          action: "keyup",
+          key,
+          modifiers: { ctrl: false, shift: false, alt: false, meta: false },
+        } satisfies StreamKeyboardEvent,
+      });
+    }
+    heldModifierKeysRef.current.clear();
   }, [sendWs]);
 
   // IME composition handlers for accented/special characters (á, ú, ő, ó, ü, é, etc.)
@@ -1087,6 +1125,7 @@ export const BrowserViewer = forwardRef<
             onInput={handleTextareaInput}
             onCompositionStart={handleCompositionStart}
             onCompositionEnd={handleCompositionEnd}
+            onBlur={releaseHeldModifiers}
           />
         )}
       </div>

--- a/src/components/embedded-browser/browser-viewer-client.tsx
+++ b/src/components/embedded-browser/browser-viewer-client.tsx
@@ -26,7 +26,12 @@ type ConnectionStatus =
 
 const MAX_RECONNECT_ATTEMPTS = 5;
 const RECONNECT_BASE_DELAY_MS = 1000;
-const FRAME_STALL_TIMEOUT_MS = 8000; // Reconnect if no frames for 8s while "connected"
+// Reconnect if no frames/status for this long while "connected". Must be
+// comfortably larger than the EB stream-server's keepalive cadence (2s) —
+// the previous 8s value raced the old 5s keepalive (which could legally
+// arrive ~8s after the last frame) and false-positived on short user pauses,
+// force-reconnecting mid-recording.
+const FRAME_STALL_TIMEOUT_MS = 15000;
 
 const SESSION_EXPIRY_WARN_MS = 5 * 60 * 1000; // Warn when <5 min remain
 
@@ -315,16 +320,23 @@ export const BrowserViewer = forwardRef<
           }
         }, 3000);
 
-        // Apply the initial viewport size to the remote browser
-        ws.send(
-          JSON.stringify({
-            type: "stream:session",
-            payload: {
-              action: "resize",
-              viewport: initialViewport ?? { width: 1280, height: 720 },
-            },
-          }),
-        );
+        // Apply the initial viewport size to the remote browser — but only
+        // when the caller explicitly provided one. The old unconditional
+        // 1280×720 fallback was re-sent on every (re)connect and the EB
+        // routes resizes to the ACTIVE page, so a mid-session reconnect
+        // resized a live recording/debug page to the default and restarted
+        // the screencast at the wrong dimensions.
+        if (initialViewport) {
+          ws.send(
+            JSON.stringify({
+              type: "stream:session",
+              payload: {
+                action: "resize",
+                viewport: initialViewport,
+              },
+            }),
+          );
+        }
       };
 
       ws.onmessage = (event) => {
@@ -367,9 +379,12 @@ export const BrowserViewer = forwardRef<
               if (message.payload.viewport) {
                 setViewport(message.payload.viewport);
               }
-              setFileChooserPending(
-                message.payload.fileChooserPending ?? false,
-              );
+              // Only honor explicit values — keepalive status messages omit
+              // the field, and the old `?? false` cleared the "File upload
+              // requested" overlay within seconds of it appearing.
+              if (message.payload.fileChooserPending !== undefined) {
+                setFileChooserPending(message.payload.fileChooserPending);
+              }
 
               // Any status message from the server proves the connection is alive
               lastFrameTimeRef.current = Date.now();

--- a/src/components/embedded-browser/browser-viewer-client.tsx
+++ b/src/components/embedded-browser/browser-viewer-client.tsx
@@ -153,10 +153,13 @@ export const BrowserViewer = forwardRef<
   const [reconnectAttempt, setReconnectAttempt] = useState(0);
   const [timeRemaining, setTimeRemaining] = useState<number | null>(null);
   const [fileChooserPending, setFileChooserPending] = useState(false);
-  // True while the EB reports status "busy" (e.g. running setup steps before
-  // a recording) and no frames are arriving — drives a "please wait" overlay
-  // so the user doesn't stare at a blank/stale canvas wondering if it broke.
-  const [busyNoFrames, setBusyNoFrames] = useState(false);
+  // True while the EB reports status "setup" (running setup steps before a
+  // recording / headed run). Drives a blocking "please wait" overlay for the
+  // WHOLE setup phase — input is detached on the EB during setup, so clicks
+  // would be silently ignored. Status-driven only: an earlier "busy + no
+  // frames recently" heuristic flapped during headed replay every time the
+  // page paused repainting for a few seconds.
+  const [setupActive, setSetupActive] = useState(false);
 
   // FPS counter refs — initialized in useEffect to avoid impure render calls
   const frameCountRef = useRef(0);
@@ -167,10 +170,8 @@ export const BrowserViewer = forwardRef<
   const stallCheckRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const screencastPausedRef = useRef(false);
   // Unlike lastFrameTimeRef (which status keepalives also bump, for stall
-  // detection), this tracks ACTUAL frames only — used for the FPS readout and
-  // the busy overlay.
+  // detection), this tracks ACTUAL frames only — used for the FPS readout.
   const lastRealFrameRef = useRef(0);
-  const remoteStatusRef = useRef<string>("");
 
   // Session expiry countdown
   useEffect(() => {
@@ -327,12 +328,6 @@ export const BrowserViewer = forwardRef<
             frameCountRef.current = 0;
             lastFpsUpdateRef.current = now;
           }
-          // Busy overlay: EB reports "busy" (setup running) and nothing is
-          // being streamed right now.
-          setBusyNoFrames(
-            remoteStatusRef.current === "busy" &&
-              now - lastRealFrameRef.current > 2500,
-          );
           if (
             lastFrameTimeRef.current > 0 &&
             now - lastFrameTimeRef.current > FRAME_STALL_TIMEOUT_MS &&
@@ -375,7 +370,6 @@ export const BrowserViewer = forwardRef<
               // Reset stall timer on every frame
               lastFrameTimeRef.current = Date.now();
               lastRealFrameRef.current = Date.now();
-              setBusyNoFrames(false);
 
               // Update FPS
               frameCountRef.current++;
@@ -417,9 +411,10 @@ export const BrowserViewer = forwardRef<
 
               // Track intentional screencast pauses to suppress stall detection
               const status = message.payload.status;
-              remoteStatusRef.current = status;
+              setSetupActive(status === "setup");
               if (
                 status === "busy" ||
+                status === "setup" ||
                 status === "recording" ||
                 status === "debugging"
               ) {
@@ -989,13 +984,17 @@ export const BrowserViewer = forwardRef<
           </div>
         )}
 
-        {connectionStatus === "connected" && busyNoFrames && (
-          <div className="absolute inset-0 layer-canvas-overlay flex items-center justify-center bg-black/60">
+        {/* Blocking setup overlay — translucent so setup progress stays
+            visible behind it; absorbs pointer events (the EB ignores input
+            during setup anyway). Shown for the entire setup phase, cleared
+            by the next status broadcast (recording / busy / ready). */}
+        {connectionStatus === "connected" && setupActive && (
+          <div className="absolute inset-0 layer-canvas-overlay flex items-center justify-center bg-black/50">
             <div className="flex flex-col items-center gap-2 text-white">
               <Loader2 className="h-8 w-8 animate-spin" />
-              <span className="text-sm">Preparing browser…</span>
+              <span className="text-sm">Running setup steps…</span>
               <span className="text-xs text-white/70">
-                Running setup steps — the live view starts shortly
+                Interaction is disabled until setup finishes
               </span>
             </div>
           </div>

--- a/src/components/embedded-browser/browser-viewer-client.tsx
+++ b/src/components/embedded-browser/browser-viewer-client.tsx
@@ -153,6 +153,10 @@ export const BrowserViewer = forwardRef<
   const [reconnectAttempt, setReconnectAttempt] = useState(0);
   const [timeRemaining, setTimeRemaining] = useState<number | null>(null);
   const [fileChooserPending, setFileChooserPending] = useState(false);
+  // True while the EB reports status "busy" (e.g. running setup steps before
+  // a recording) and no frames are arriving — drives a "please wait" overlay
+  // so the user doesn't stare at a blank/stale canvas wondering if it broke.
+  const [busyNoFrames, setBusyNoFrames] = useState(false);
 
   // FPS counter refs — initialized in useEffect to avoid impure render calls
   const frameCountRef = useRef(0);
@@ -162,6 +166,11 @@ export const BrowserViewer = forwardRef<
   const lastFrameTimeRef = useRef(0);
   const stallCheckRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const screencastPausedRef = useRef(false);
+  // Unlike lastFrameTimeRef (which status keepalives also bump, for stall
+  // detection), this tracks ACTUAL frames only — used for the FPS readout and
+  // the busy overlay.
+  const lastRealFrameRef = useRef(0);
+  const remoteStatusRef = useRef<string>("");
 
   // Session expiry countdown
   useEffect(() => {
@@ -309,16 +318,31 @@ export const BrowserViewer = forwardRef<
         // the CDP screencast likely died silently. Force reconnect to recover.
         if (stallCheckRef.current) clearInterval(stallCheckRef.current);
         stallCheckRef.current = setInterval(() => {
+          const now = Date.now();
+          // FPS readout honesty: when frames stop, the counter previously
+          // froze on its last value (it only updated when a frame arrived),
+          // masking dead streams as "2 FPS". Zero it after 2s of silence.
+          if (now - lastRealFrameRef.current > 2000) {
+            setFps(0);
+            frameCountRef.current = 0;
+            lastFpsUpdateRef.current = now;
+          }
+          // Busy overlay: EB reports "busy" (setup running) and nothing is
+          // being streamed right now.
+          setBusyNoFrames(
+            remoteStatusRef.current === "busy" &&
+              now - lastRealFrameRef.current > 2500,
+          );
           if (
             lastFrameTimeRef.current > 0 &&
-            Date.now() - lastFrameTimeRef.current > FRAME_STALL_TIMEOUT_MS &&
+            now - lastFrameTimeRef.current > FRAME_STALL_TIMEOUT_MS &&
             wsRef.current?.readyState === WebSocket.OPEN &&
             !screencastPausedRef.current
           ) {
             console.warn("[BrowserViewer] Frame stall detected — reconnecting");
             wsRef.current?.close();
           }
-        }, 3000);
+        }, 1000);
 
         // Apply the initial viewport size to the remote browser — but only
         // when the caller explicitly provided one. The old unconditional
@@ -350,6 +374,8 @@ export const BrowserViewer = forwardRef<
 
               // Reset stall timer on every frame
               lastFrameTimeRef.current = Date.now();
+              lastRealFrameRef.current = Date.now();
+              setBusyNoFrames(false);
 
               // Update FPS
               frameCountRef.current++;
@@ -391,6 +417,7 @@ export const BrowserViewer = forwardRef<
 
               // Track intentional screencast pauses to suppress stall detection
               const status = message.payload.status;
+              remoteStatusRef.current = status;
               if (
                 status === "busy" ||
                 status === "recording" ||
@@ -921,6 +948,18 @@ export const BrowserViewer = forwardRef<
                 </Button>
               </div>
             )}
+          </div>
+        )}
+
+        {connectionStatus === "connected" && busyNoFrames && (
+          <div className="absolute inset-0 layer-canvas-overlay flex items-center justify-center bg-black/60">
+            <div className="flex flex-col items-center gap-2 text-white">
+              <Loader2 className="h-8 w-8 animate-spin" />
+              <span className="text-sm">Preparing browser…</span>
+              <span className="text-xs text-white/70">
+                Running setup steps — the live view starts shortly
+              </span>
+            </div>
           </div>
         )}
 

--- a/src/lib/db/queries/runners.ts
+++ b/src/lib/db/queries/runners.ts
@@ -25,6 +25,17 @@ const REDISPATCH_TTL_MS = 10_000;
 // executor test timeout.
 const MAX_CLAIMED_NO_RESULT_MS = 90_000;
 
+// Command types that terminate by inserting a `runner_command_results` row.
+// Everything else (start/stop recording & debug, debug_action, assertions,
+// cancel, ping, shutdown, …) is a session-control command: receipt IS
+// completion. Those used to sit at status='claimed' forever, which (a) made
+// the claimed-no-result reaper bounce them back to 'pending' every ~90s —
+// redispatching start_recording/start_debug into a LIVE session and resetting
+// it (the "recording/debug randomly restarts" flakiness) — and (b) forced
+// teardownPoolEB to burn its full shutdown grace waiting for rows that could
+// never reach a terminal state.
+const RESULT_BEARING_COMMAND_TYPES = ["command:run_test", "command:run_setup"];
+
 // Runner queries
 export async function getRunnerById(runnerId: string) {
   const [row] = await db.select().from(runners).where(eq(runners.id, runnerId));
@@ -92,11 +103,32 @@ export async function dispatchPendingCommands(
  * the `response:command_ack` handler in /api/ws/runner. Idempotent — only
  * flips rows still at status='pending' so a duplicate ack (from redispatch +
  * EB dedup-retry) is a no-op.
+ *
+ * Result-bearing commands (run_test / run_setup) move to 'claimed' and wait
+ * for their result row. Session-control commands are complete the moment the
+ * runner receives them — flip straight to 'completed' so they can't be
+ * reaped/redispatched into a live session.
  */
 export async function ackDispatchedCommand(commandId: string) {
+  const [cmd] = await db
+    .select({ type: runnerCommands.type })
+    .from(runnerCommands)
+    .where(eq(runnerCommands.id, commandId));
+  if (!cmd) return;
+
+  const now = new Date();
+  const resultBearing = RESULT_BEARING_COMMAND_TYPES.includes(cmd.type);
   await db
     .update(runnerCommands)
-    .set({ status: "claimed" as RunnerCommandStatus, claimedAt: new Date() })
+    .set(
+      resultBearing
+        ? { status: "claimed" as RunnerCommandStatus, claimedAt: now }
+        : {
+            status: "completed" as RunnerCommandStatus,
+            claimedAt: now,
+            completedAt: now,
+          },
+    )
     .where(
       and(
         eq(runnerCommands.id, commandId),
@@ -323,6 +355,12 @@ export async function timeoutStaleCommands(
   //    Chromium/CDP init hang inside the EB pod. Reset to pending so the next
   //    heartbeat redelivers; EB dedup prevents the original pod from running
   //    it twice if it's just slow.
+  //
+  //    Only result-bearing types qualify — session-control commands
+  //    (start_recording, start_debug, …) never produce result rows, so
+  //    reclaiming them here redispatches them into live sessions. They now
+  //    complete on ack, but the type filter also protects rows acked by older
+  //    runner builds.
   await db
     .update(runnerCommands)
     .set({
@@ -333,6 +371,7 @@ export async function timeoutStaleCommands(
     .where(
       and(
         eq(runnerCommands.status, "claimed"),
+        inArray(runnerCommands.type, RESULT_BEARING_COMMAND_TYPES),
         lt(runnerCommands.claimedAt, noResultCutoff),
         notExists(
           db

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -2781,7 +2781,14 @@ export const remoteRecordingEvents = pgTable(
       .notNull(),
   },
   (table) => [
-    index("idx_remote_recording_events_session_seq").on(
+    // MUST be unique: the recording_event ingest upserts on (sessionId,
+    // sequence) — the EB re-emits an event with the same sequence when its
+    // verification settles or a thumbnail arrives, and replaces trailing
+    // hover-previews in place. With a plain index the insert's ON CONFLICT
+    // never fired and every re-emit piled up a duplicate row; the merged
+    // timeline (and the code generated from it at stop time) then picked an
+    // arbitrary stale/new copy per sequence.
+    uniqueIndex("idx_remote_recording_events_session_seq").on(
       table.sessionId,
       table.sequence,
     ),

--- a/src/lib/eb/provisioner.ts
+++ b/src/lib/eb/provisioner.ts
@@ -761,9 +761,14 @@ export async function prewarmForBuild(targetCount: number): Promise<number> {
   if (!isKubernetesMode()) return 0;
   if (targetCount <= 0) return 0;
 
+  // Builds must respect the interactive reservation here too —
+  // claimOrProvisionPoolEB({purpose:'build'}) enforces it on demand-provision,
+  // but prewarming to the full hard cap let a build occupy the slots reserved
+  // for recording/debug before any interactive caller could claim one.
   const cap = await poolMax();
   const size = await currentPoolSize();
-  const canLaunch = Math.min(targetCount, Math.max(0, cap - size));
+  const effectiveCap = Math.max(0, cap - interactiveReservedSlots());
+  const canLaunch = Math.min(targetCount, Math.max(0, effectiveCap - size));
   if (canLaunch <= 0) return 0;
 
   let launched = 0;

--- a/src/lib/eb/stream-token.ts
+++ b/src/lib/eb/stream-token.ts
@@ -1,0 +1,19 @@
+/**
+ * Client-safe helper (no node imports — imported by client components).
+ *
+ * Appends the stream auth token to a stream URL with the correct separator.
+ * Proxy-routed stream URLs already carry a query string
+ * (`/api/embedded/stream/ws?target=host:port`), so the previous blanket
+ * `${url}?token=...` produced `...?target=host:port?token=...` — the token was
+ * swallowed into the `target` param and dropped by the WS proxy, so the EB
+ * never saw it and rejected the stream with 401 whenever STREAM_AUTH_TOKEN
+ * was configured.
+ */
+export function appendStreamToken(
+  streamUrl: string,
+  token: string | null | undefined,
+): string {
+  if (!token) return streamUrl;
+  const sep = streamUrl.includes("?") ? "&" : "?";
+  return `${streamUrl}${sep}token=${encodeURIComponent(token)}`;
+}

--- a/src/lib/ws/protocol.ts
+++ b/src/lib/ws/protocol.ts
@@ -848,6 +848,18 @@ export interface StreamMouseEvent {
   clickCount?: number;
   deltaX?: number;
   deltaY?: number;
+  // Authoritative modifier state sampled from the browser event itself.
+  // Without it the EB infers modifiers from previously-forwarded keyboard
+  // events — if a modifier keyup is lost (focus left the canvas while the key
+  // was held), that state sticks and every later click dispatches as
+  // Ctrl/Alt+click, which links treat as open-in-new-tab (the page visibly
+  // ignores the click).
+  modifiers?: {
+    ctrl?: boolean;
+    shift?: boolean;
+    alt?: boolean;
+    meta?: boolean;
+  };
 }
 
 export interface StreamKeyboardEvent {

--- a/src/server/actions/embedded-sessions.ts
+++ b/src/server/actions/embedded-sessions.ts
@@ -741,7 +741,9 @@ export async function processPoolQueue(): Promise<void> {
   // Don't bother if no EBs are available — avoids churning jobs
   if (await isPoolBusy()) return;
 
-  // Find first pending job with no target runner (queued because all EBs were busy)
+  // Find the OLDEST pending job with no target runner (queued because all EBs
+  // were busy). Without the explicit ordering, Postgres returns an arbitrary
+  // row — newer jobs could jump the queue and starve older ones.
   const [pendingJob] = await db
     .select()
     .from(backgroundJobs)
@@ -751,6 +753,7 @@ export async function processPoolQueue(): Promise<void> {
         isNull(backgroundJobs.targetRunnerId),
       ),
     )
+    .orderBy(backgroundJobs.createdAt)
     .limit(1);
 
   if (!pendingJob) return;

--- a/src/server/actions/runners.ts
+++ b/src/server/actions/runners.ts
@@ -400,7 +400,8 @@ export async function updateRunnerStatus(
  * Called when a runner transitions to 'online'.
  */
 async function pickUpQueuedJobs(runnerId: string): Promise<void> {
-  // Find first pending job with no target runner (queued because no runner was available)
+  // Find the OLDEST pending job with no target runner (queued because no
+  // runner was available) — explicit ordering keeps the queue FIFO.
   const [pendingJob] = await db
     .select()
     .from(backgroundJobs)
@@ -410,6 +411,7 @@ async function pickUpQueuedJobs(runnerId: string): Promise<void> {
         isNull(backgroundJobs.targetRunnerId),
       ),
     )
+    .orderBy(backgroundJobs.createdAt)
     .limit(1);
 
   if (!pendingJob) return;


### PR DESCRIPTION
## Summary

This PR fixes multiple critical issues with recording and debug session management, stream reliability, and command deduplication that were causing sessions to restart unexpectedly, recordings to freeze, and resource leaks.

## Key Changes

### Embedded Browser Session Management
- **Session ID tracking**: Added `currentRecordingSessionId` and `currentDebugSessionId` to prevent redispatched start commands from restarting live sessions
- **Command deduplication**: Implemented `isDuplicateCommand()` to drop redispatched commands after acking (mirrors server-side dedup in runner client)
- **Debug session cleanup**: When a new debug session arrives, properly tear down the previous one (stop executor, clear intervals) instead of leaking resources
- **Recording inactivity timeout**: Increased from 60s to 5 minutes and now counts live viewer input as activity (via `streamServer.onInputActivity`)
- **Watchdog improvements**: Clear previous interval before re-arming to prevent double-fire; route synthesized stop commands through `enqueueCommand()` for proper ordering

### Screencast Stream Reliability
- **Session tracking**: Store `currentPage` and validate session identity in frame callbacks to ignore frames from superseded sessions
- **Ack failure recovery**: Implement automatic recovery mechanism that restarts the screencast when consecutive ack failures indicate a broken CDP session, instead of silently freezing
- **Cleanup robustness**: Always tear down previous CDP session on `start()` (not just when `running` is true) to prevent session leaks and stale frame listeners

### Stream Server & Viewer
- **Input activity signal**: Added `onInputActivity` callback so recording inactivity watchdog doesn't kill sessions the user is actively viewing
- **Keepalive improvements**: 
  - Re-broadcast current status instead of hardcoded "idle" (was suppressing stall detection during recordings)
  - Fire every 2s instead of 5s (old cadence could deliver first keepalive ~8s after last frame, racing the viewer's 8s stall timeout)
- **File chooser handling**: Only honor explicit `fileChooserPending` values in status messages; keepalive messages omit the field and shouldn't clear the overlay
- **Viewport resize guard**: Only send initial viewport if explicitly provided; unconditional 1280×720 fallback was resizing live sessions on reconnect

### Command Ordering & Serialization
- **Command queue**: Added `commandChain` promise to serialize command execution so start/stop pairs can't interleave their teardown
- **Public enqueue method**: `enqueueCommand()` allows locally-synthesized commands (e.g., watchdog stop) to go through the same ordering chain

### Database & Event Ingestion
- **Recording event upserts**: Changed from `onConflictDoNothing()` to `onConflictDoUpdate()` on (sessionId, sequence) unique index
  - EB re-emits events when verification settles or thumbnails arrive; latest copy is canonical
  - Dedup within batch first to prevent Postgres multi-row upsert conflicts
- **Command status transitions**: Session-control commands (start_recording, start_debug, etc.) now complete on ack instead of sitting at 'claimed' forever
  - Prevents reaper from bouncing them back to 'pending' and redispatching into live sessions
  - Only result-bearing commands (run_test, run_setup) wait for result rows
- **Pool prewarming**: Respect interactive reservation cap to prevent builds from occupying recording/debug slots

### Utilities & Helpers
- **Stream token helper**: New `appendStreamToken()` utility correctly appends auth token with proper query string separator (fixes token being swallowed into proxy target param)
- **Job queue ordering**: Explicit `ORDER BY` when claiming oldest pending jobs (was returning arbitrary rows, allowing newer jobs to jump queue)

### Debug Executor
- **Resume queueing**: Buffer resume commands that arrive while a step is executing (previous step was still running) instead of silently dropping them
  - User actions (step_forward, run_to_end) during step execution are now queued and processed at the next checkpoint

## Notable Implementation Details

- Recording inactivity now counts live viewer input, fixing the "recording froze after 60s of reading" issue
-

https://claude.ai/code/session_01Ajb3LE2aoji1FJ3BFhmXwh