### PR TITLE
fix: fullscreen live view — black screen, lost tooltips, blank canvas after exit

### DIFF
--- a/packages/embedded-browser/src/index.ts
+++ b/packages/embedded-browser/src/index.ts
@@ -492,7 +492,15 @@ async function startup(): Promise<void> {
         const isHeaded = !!payload.headed;
         if (activeTasks === 1) {
           capturedClient.setStatus("busy", payload.testId);
-          streamServer?.broadcastStatus("busy", payload.targetUrl);
+          // Headed playback gets a distinct "starting" status: the screencast
+          // is still bound to the idle page until onPageCreated re-attaches
+          // it to the test page, so viewers show a "Starting test…"
+          // placeholder instead of a stale/blank idle frame. Cleared by the
+          // "running" broadcast once the test page is streaming.
+          streamServer?.broadcastStatus(
+            isHeaded ? "starting" : "busy",
+            payload.targetUrl,
+          );
           if (!isHeaded) {
             // Pause screencast to free Chromium CPU for test execution
             await screencast?.stop();
@@ -545,12 +553,24 @@ async function startup(): Promise<void> {
                             frame.timestamp,
                           );
                         });
+                        // Test page is live on the stream — clear the
+                        // viewer's "Starting test…" placeholder.
+                        capturedStreamServer.broadcastStatus(
+                          "running",
+                          payload.targetUrl,
+                        );
                       } catch (err) {
                         console.error(
                           "[Command] Failed to attach screencast to test page:",
                           err,
                         );
                       }
+                    },
+                    onActionProgress: (progress) => {
+                      // Countdown telemetry for the live viewer (selector
+                      // waits, load waits, fallback clicks). Stream-only —
+                      // never blocks the test.
+                      capturedStreamServer.broadcastActionProgress(progress);
                     },
                     onBeforePageClose: async () => {
                       try {

--- a/packages/embedded-browser/src/stream-server.ts
+++ b/packages/embedded-browser/src/stream-server.ts
@@ -22,6 +22,13 @@ interface StreamClient {
   alive: boolean;
 }
 
+export interface ActionProgressPayload {
+  active: boolean;
+  label?: string;
+  kind?: "selector" | "wait" | "navigation" | "fallback";
+  timeoutMs?: number;
+}
+
 export class StreamServer {
   private wss: WebSocketServer | null = null;
   private clients = new Map<string, StreamClient>();
@@ -32,6 +39,14 @@ export class StreamServer {
   private keepaliveInterval: ReturnType<typeof setInterval> | null = null;
   private lastBroadcastTime = 0;
   private lastStatus = "idle";
+  // Last in-flight action progress (selector wait / load wait / fallback
+  // click) with the wall-clock time it started — replayed to late-joining
+  // viewers with an adjusted remaining budget so their countdown bar lines
+  // up with the action's real deadline.
+  private lastActionProgress: {
+    payload: ActionProgressPayload;
+    startedAt: number;
+  } | null = null;
 
   /** Callback for navigate requests from stream clients */
   onNavigate?: (url: string) => Promise<void>;
@@ -104,6 +119,24 @@ export class StreamServer {
           status: this.lastStatus,
         },
       });
+
+      // Replay any in-flight action countdown with the remaining (not the
+      // original) budget so a viewer joining mid-wait sees an accurate bar.
+      if (this.lastActionProgress?.payload.active) {
+        const { payload, startedAt } = this.lastActionProgress;
+        const remaining =
+          payload.timeoutMs !== undefined
+            ? payload.timeoutMs - (Date.now() - startedAt)
+            : undefined;
+        if (remaining === undefined || remaining > 250) {
+          this.sendToClient(ws, {
+            type: "stream:action_progress",
+            id: crypto.randomUUID(),
+            timestamp: Date.now(),
+            payload: { ...payload, timeoutMs: remaining },
+          });
+        }
+      }
 
       // Mark alive on pong response
       ws.on("pong", () => {
@@ -217,12 +250,40 @@ export class StreamServer {
     viewport?: { width: number; height: number },
     fileChooserPending?: boolean,
   ): void {
+    // A phase change (setup → busy → ready …) obsoletes any in-flight action
+    // countdown; keepalives re-broadcast the same status and must not clear it.
+    if (status !== this.lastStatus) {
+      this.lastActionProgress = null;
+    }
     this.lastStatus = status;
     const message = JSON.stringify({
       type: "stream:status",
       id: crypto.randomUUID(),
       timestamp: Date.now(),
       payload: { status, currentUrl, viewport, fileChooserPending },
+    });
+
+    for (const [clientId, client] of this.clients) {
+      if (client.ws.readyState === WebSocket.OPEN) {
+        client.ws.send(message);
+      } else {
+        this.clients.delete(clientId);
+      }
+    }
+  }
+
+  /** Broadcast the start/end of a deadline-bound action (selector wait,
+   *  page-load wait, fallback click). Viewers animate the countdown locally
+   *  from `timeoutMs`, so only the start and the clear are sent — no ticks. */
+  broadcastActionProgress(payload: ActionProgressPayload): void {
+    this.lastActionProgress = payload.active
+      ? { payload, startedAt: Date.now() }
+      : null;
+    const message = JSON.stringify({
+      type: "stream:action_progress",
+      id: crypto.randomUUID(),
+      timestamp: Date.now(),
+      payload,
     });
 
     for (const [clientId, client] of this.clients) {

--- a/packages/embedded-browser/src/stream-server.ts
+++ b/packages/embedded-browser/src/stream-server.ts
@@ -27,6 +27,7 @@ export interface ActionProgressPayload {
   label?: string;
   kind?: "selector" | "wait" | "navigation" | "fallback";
   timeoutMs?: number;
+  stepIndex?: number;
 }
 
 export class StreamServer {

--- a/packages/embedded-browser/src/stream-server.ts
+++ b/packages/embedded-browser/src/stream-server.ts
@@ -48,6 +48,16 @@ export class StreamServer {
     payload: ActionProgressPayload;
     startedAt: number;
   } | null = null;
+  // Last broadcast frame, replayed to newly connected clients. CDP only
+  // emits frames on repaint — without the replay, a viewer that (re)connects
+  // mid-wait (fullscreen toggle remount, reconnect) stares at a blank canvas
+  // until the page next repaints, which can be the rest of a long wait.
+  private lastFrame: {
+    data: string;
+    width: number;
+    height: number;
+    timestamp: number;
+  } | null = null;
 
   /** Callback for navigate requests from stream clients */
   onNavigate?: (url: string) => Promise<void>;
@@ -120,6 +130,17 @@ export class StreamServer {
           status: this.lastStatus,
         },
       });
+
+      // Replay the most recent frame so the canvas paints immediately
+      // instead of staying blank until the page next repaints.
+      if (this.lastFrame) {
+        this.sendToClient(ws, {
+          type: "stream:frame",
+          id: crypto.randomUUID(),
+          timestamp: Date.now(),
+          payload: this.lastFrame,
+        });
+      }
 
       // Replay any in-flight action countdown with the remaining (not the
       // original) budget so a viewer joining mid-wait sees an accurate bar.
@@ -228,6 +249,7 @@ export class StreamServer {
     timestamp: number,
   ): void {
     this.lastBroadcastTime = Date.now();
+    this.lastFrame = { data, width, height, timestamp };
     const message = JSON.stringify({
       type: "stream:frame",
       id: crypto.randomUUID(),

--- a/packages/embedded-browser/src/test-executor.ts
+++ b/packages/embedded-browser/src/test-executor.ts
@@ -460,12 +460,16 @@ export class EmbeddedTestExecutor {
       }) => void;
       /** Start/end of a deadline-bound operation (selector wait, page-load
        *  wait, navigation, fallback click). `timeoutMs` is the full budget —
-       *  consumers animate the countdown locally. `active: false` clears. */
+       *  consumers animate the countdown locally. `stepIndex` ties the
+       *  operation to the instrumented step it runs inside (-1 before the
+       *  first step) so UIs can render it under the right timeline row.
+       *  `active: false` clears. */
       onActionProgress?: (progress: {
         active: boolean;
         label?: string;
         kind?: "selector" | "wait" | "navigation" | "fallback";
         timeoutMs?: number;
+        stepIndex?: number;
       }) => void;
     },
   ): Promise<EmbeddedTestResult> {
@@ -513,7 +517,14 @@ export class EmbeddedTestExecutor {
       if (!onActionProgress) return () => {};
       actionProgressDepth++;
       try {
-        onActionProgress({ active: true, ...progress });
+        // outerCurrentStepIdx is declared further down (hoisted step-tracking
+        // state) but is always initialized before any instrumented operation
+        // runs — the closure only reads it at emit time.
+        onActionProgress({
+          active: true,
+          stepIndex: outerCurrentStepIdx,
+          ...progress,
+        });
       } catch {
         /* telemetry must never break the test */
       }

--- a/packages/embedded-browser/src/test-executor.ts
+++ b/packages/embedded-browser/src/test-executor.ts
@@ -458,6 +458,15 @@ export class EmbeddedTestExecutor {
         durationMs?: number;
         error?: string;
       }) => void;
+      /** Start/end of a deadline-bound operation (selector wait, page-load
+       *  wait, navigation, fallback click). `timeoutMs` is the full budget —
+       *  consumers animate the countdown locally. `active: false` clears. */
+      onActionProgress?: (progress: {
+        active: boolean;
+        label?: string;
+        kind?: "selector" | "wait" | "navigation" | "fallback";
+        timeoutMs?: number;
+      }) => void;
     },
   ): Promise<EmbeddedTestResult> {
     const abortCtrl = new AbortController();
@@ -487,6 +496,41 @@ export class EmbeddedTestExecutor {
       console.log(
         `  [${level.toUpperCase()}] [embedded:${command.testId}] ${message}`,
       );
+    };
+
+    // Action-progress telemetry: live viewers render a decreasing countdown
+    // bar for whatever deadline-bound operation is in flight. Depth-counted
+    // so nested instrumented calls (a wait inside a wait) don't clear the
+    // outer operation's bar early — the innermost start wins the display,
+    // the outermost end clears it.
+    const onActionProgress = callbacks?.onActionProgress;
+    let actionProgressDepth = 0;
+    const beginActionProgress = (progress: {
+      label: string;
+      kind: "selector" | "wait" | "navigation" | "fallback";
+      timeoutMs: number;
+    }): (() => void) => {
+      if (!onActionProgress) return () => {};
+      actionProgressDepth++;
+      try {
+        onActionProgress({ active: true, ...progress });
+      } catch {
+        /* telemetry must never break the test */
+      }
+      let ended = false;
+      return () => {
+        if (ended) return;
+        ended = true;
+        actionProgressDepth--;
+        if (actionProgressDepth <= 0) {
+          actionProgressDepth = 0;
+          try {
+            onActionProgress({ active: false });
+          } catch {
+            /* ignore */
+          }
+        }
+      };
     };
 
     const viewport = command.viewport || { width: 1280, height: 720 };
@@ -776,6 +820,103 @@ export class EmbeddedTestExecutor {
       // Set default timeouts (mirrors standard runner)
       page.setDefaultNavigationTimeout(30000);
       page.setDefaultTimeout(15000);
+
+      // Shadow the page's deadline-bound methods with progress-emitting
+      // wrappers (own properties over the prototype methods) so live viewers
+      // get a countdown for navigations and load/URL/selector waits. The
+      // page is per-test and closed afterwards, so the shadowing never leaks.
+      if (onActionProgress) {
+        const NAV_DEFAULT_TIMEOUT = 30000; // mirrors setDefaultNavigationTimeout above
+        const WAIT_DEFAULT_TIMEOUT = 15000; // mirrors setDefaultTimeout above
+        const timeoutFrom = (opts: unknown, fallback: number): number => {
+          const t = (opts as { timeout?: unknown } | undefined)?.timeout;
+          return typeof t === "number" && t > 0 ? t : fallback;
+        };
+        const describeTarget = (target: unknown): string => {
+          // String() renders RegExp as /pattern/ and functions readably;
+          // JSON.stringify would collapse both to "{}"/undefined.
+          const s = typeof target === "string" ? target : String(target);
+          return s.length > 60 ? `${s.slice(0, 57)}…` : s;
+        };
+        const instrument = <A extends unknown[], R>(
+          method: (...args: A) => R,
+          describe: (...args: A) => {
+            label: string;
+            kind: "wait" | "navigation";
+            timeoutMs: number;
+          } | null,
+        ) => {
+          const original = method.bind(page);
+          return (...args: A): R => {
+            const progress = describe(...args);
+            if (!progress) return original(...args);
+            const end = beginActionProgress(progress);
+            const result = original(...args);
+            void Promise.resolve(result).then(end, end);
+            return result;
+          };
+        };
+        page.goto = instrument(page.goto, (url, opts) => ({
+          label: `Loading ${describeTarget(url)}`,
+          kind: "navigation",
+          timeoutMs: timeoutFrom(opts, NAV_DEFAULT_TIMEOUT),
+        }));
+        page.reload = instrument(page.reload, (opts) => ({
+          label: "Reloading page",
+          kind: "navigation",
+          timeoutMs: timeoutFrom(opts, NAV_DEFAULT_TIMEOUT),
+        }));
+        page.waitForLoadState = instrument(
+          page.waitForLoadState,
+          (state, opts) => ({
+            label: `Waiting for page ${state ?? "load"}`,
+            kind: "wait",
+            timeoutMs: timeoutFrom(opts, NAV_DEFAULT_TIMEOUT),
+          }),
+        );
+        page.waitForURL = instrument(page.waitForURL, (url, opts) => ({
+          label: `Waiting for URL ${describeTarget(url)}`,
+          kind: "wait",
+          timeoutMs: timeoutFrom(opts, NAV_DEFAULT_TIMEOUT),
+        }));
+        // waitForSelector / waitForFunction are overloaded — collapse them to
+        // a plain signature for the wrapper and cast back (runtime-identical).
+        page.waitForSelector = instrument(
+          page.waitForSelector as (
+            selector: string,
+            opts?: { timeout?: number },
+          ) => Promise<unknown>,
+          (selector, opts) => ({
+            label: `Waiting for ${describeTarget(selector)}`,
+            kind: "wait",
+            timeoutMs: timeoutFrom(opts, WAIT_DEFAULT_TIMEOUT),
+          }),
+        ) as Page["waitForSelector"];
+        page.waitForFunction = instrument(
+          page.waitForFunction as (
+            fn: unknown,
+            arg?: unknown,
+            opts?: { timeout?: number },
+          ) => Promise<unknown>,
+          (_fn, _arg, opts) => ({
+            label: "Waiting for condition",
+            kind: "wait",
+            timeoutMs: timeoutFrom(opts, WAIT_DEFAULT_TIMEOUT),
+          }),
+        ) as Page["waitForFunction"];
+        // Fixed sleeps: only surface the long ones — cursor-path replay and
+        // helper polling issue hundreds of sub-second waitForTimeout calls
+        // that would just flicker the bar (and flood the stream socket).
+        page.waitForTimeout = instrument(page.waitForTimeout, (ms) =>
+          typeof ms === "number" && ms >= 1000
+            ? {
+                label: `Waiting ${(ms / 1000).toFixed(1)}s`,
+                kind: "wait",
+                timeoutMs: ms,
+              }
+            : null,
+        );
+      }
 
       // Intercept File System Access API so blob downloads trigger Playwright's download event.
       // Always inject — native file dialogs hang forever in headless mode.
@@ -1625,7 +1766,16 @@ export class EmbeddedTestExecutor {
               lwfDefaultTimeoutMs,
               rank,
             );
-            await target.waitFor({ timeout: lwfCandidateTimeout });
+            const endLocateProgress = beginActionProgress({
+              label: `${action}: waiting for ${sel.type} selector (${rank + 1}/${ordered.length})`,
+              kind: "selector",
+              timeoutMs: lwfCandidateTimeout,
+            });
+            try {
+              await target.waitFor({ timeout: lwfCandidateTimeout });
+            } finally {
+              endLocateProgress();
+            }
           } catch {
             selectorOutcomes.push({
               hash: lwfHash,
@@ -1664,8 +1814,15 @@ export class EmbeddedTestExecutor {
           } catch {
             // One retry on the matched element before trying the next
             // candidate — transient overlays/detach races usually clear.
-            await pg.waitForTimeout(250);
+            // Actionability checks inside the retry wait up to the page
+            // default timeout (15s), so surface a countdown for it.
+            const endRetryProgress = beginActionProgress({
+              label: `Retrying ${action} on matched ${sel.type}`,
+              kind: "fallback",
+              timeoutMs: 250 + 15000,
+            });
             try {
+              await pg.waitForTimeout(250);
               await performAction();
             } catch (actionErr) {
               logFn(
@@ -1673,6 +1830,8 @@ export class EmbeddedTestExecutor {
                 `[action] ${action} failed on matched ${sel.type}: ${actionErr instanceof Error ? actionErr.message : String(actionErr)}`,
               );
               continue;
+            } finally {
+              endRetryProgress();
             }
           }
           return target;
@@ -1684,7 +1843,16 @@ export class EmbeddedTestExecutor {
             "info",
             `Falling back to coordinate click at (${coords.x}, ${coords.y})`,
           );
-          await pg.mouse.click(coords.x, coords.y, options || {});
+          const endFallbackProgress = beginActionProgress({
+            label: `Fallback click at (${coords.x}, ${coords.y})`,
+            kind: "fallback",
+            timeoutMs: 1000,
+          });
+          try {
+            await pg.mouse.click(coords.x, coords.y, options || {});
+          } finally {
+            endFallbackProgress();
+          }
           return;
         }
 
@@ -1694,10 +1862,19 @@ export class EmbeddedTestExecutor {
             "info",
             `Falling back to coordinate fill at (${coords.x}, ${coords.y})`,
           );
-          await pg.mouse.click(coords.x, coords.y);
-          await pg.waitForTimeout(100);
-          await pg.keyboard.press("Control+a");
-          await pg.keyboard.type(value || "");
+          const endFallbackProgress = beginActionProgress({
+            label: `Fallback fill at (${coords.x}, ${coords.y})`,
+            kind: "fallback",
+            timeoutMs: 2000,
+          });
+          try {
+            await pg.mouse.click(coords.x, coords.y);
+            await pg.waitForTimeout(100);
+            await pg.keyboard.press("Control+a");
+            await pg.keyboard.type(value || "");
+          } finally {
+            endFallbackProgress();
+          }
           return;
         }
 
@@ -1867,6 +2044,16 @@ export class EmbeddedTestExecutor {
         ]);
       } finally {
         clearTimeout(timeoutTimer);
+        // Force-clear any lingering countdown — the test body is done (or
+        // timed out with its in-flight op killed by the context close).
+        if (actionProgressDepth > 0) {
+          actionProgressDepth = 0;
+          try {
+            onActionProgress?.({ active: false });
+          } catch {
+            /* ignore */
+          }
+        }
         clearInterval(heartbeat);
       }
 

--- a/src/app/(app)/tests/[id]/test-detail-client.tsx
+++ b/src/app/(app)/tests/[id]/test-detail-client.tsx
@@ -402,13 +402,13 @@ function ViewerProvisioningPlaceholder({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        "flex flex-col items-center justify-center gap-2 bg-black text-white",
+        "flex flex-col items-center justify-center gap-2 bg-background",
         className,
       )}
     >
-      <Loader2 className="h-8 w-8 animate-spin" />
-      <span className="text-sm">Provisioning browser…</span>
-      <span className="text-xs text-white/70">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      <span className="text-sm text-foreground">Provisioning browser…</span>
+      <span className="text-xs text-muted-foreground">
         Live playback starts as soon as the browser pod is ready
       </span>
     </div>

--- a/src/app/(app)/tests/[id]/test-detail-client.tsx
+++ b/src/app/(app)/tests/[id]/test-detail-client.tsx
@@ -1391,7 +1391,10 @@ export function TestDetailClient({
                     isRunning={isRunning}
                     selectorStats={selectorStats}
                     actionProgress={actionProgress}
-                    className="h-[540px]"
+                    // Side-by-side (lg): stretch to the viewer card's full row
+                    // height so the panels line up; stacked (mobile): keep a
+                    // fixed height (h-full would collapse against the auto row).
+                    className="h-[540px] lg:h-full"
                   />
                 )}
               </div>

--- a/src/app/(app)/tests/[id]/test-detail-client.tsx
+++ b/src/app/(app)/tests/[id]/test-detail-client.tsx
@@ -1277,70 +1277,39 @@ export function TestDetailClient({
         {isRunning && (streamUrl || headedRunActive) && (
           <div
             ref={viewerLayoutRef}
+            // Opaque bg-background in fullscreen: the browser paints a black
+            // ::backdrop behind the fullscreen element, so a translucent fill
+            // rendered everything near-black.
             className={
               isViewerFullscreen
-                ? "flex-1 flex flex-col h-full overflow-hidden bg-muted/50"
+                ? "flex flex-col h-full overflow-hidden bg-background"
                 : ""
             }
           >
-            {isViewerFullscreen ? (
-              <>
-                <div className="flex-1 relative flex flex-col overflow-hidden min-h-0">
-                  {streamUrl ? (
-                    <BrowserViewer
-                      streamUrl={streamUrl}
-                      hideControls
-                      fit
-                      className="flex-1 min-h-0"
-                      onActionProgress={setActionProgress}
-                    />
-                  ) : (
-                    <ViewerProvisioningPlaceholder className="flex-1 min-h-0" />
-                  )}
-                  {plannedSteps.length > 0 && (
-                    <div className="pointer-events-none absolute right-4 top-4 bottom-4 w-72 layer-playback-timeline hidden md:block">
-                      <PlaybackTimeline
-                        steps={plannedSteps}
-                        currentStepIndex={liveStepIndex}
-                        results={stepResults}
-                        isRunning={isRunning}
-                        selectorStats={selectorStats}
-                        actionProgress={actionProgress}
-                        compact
-                        className="h-full pointer-events-auto"
-                      />
-                    </div>
-                  )}
-                </div>
-                <div className="fixed bottom-6 left-1/2 -translate-x-1/2 layer-playback-controls flex items-center gap-1.5 px-3 py-1.5 bg-card/95 backdrop-blur-sm border border-border rounded-full shadow-2xl">
-                  <div className="flex items-center gap-2 px-1">
-                    <div className="h-2.5 w-2.5 rounded-full bg-green-500 animate-pulse" />
-                    <span className="text-sm font-medium text-foreground">
-                      Running
-                    </span>
-                  </div>
-                  <div className="w-px h-5 bg-border" />
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8"
-                    onClick={toggleViewerFullscreen}
-                    title="Exit fullscreen"
-                  >
-                    <Minimize2 className="h-4 w-4" />
-                  </Button>
-                </div>
-              </>
-            ) : (
-              <div
-                className={cn(
-                  "grid gap-3",
-                  plannedSteps.length > 0
-                    ? "lg:grid-cols-[minmax(0,1fr)_320px]"
-                    : "grid-cols-1",
-                )}
+            {/* One persistent tree for both layouts — toggling fullscreen
+                only swaps classNames. Branching the JSX remounted
+                BrowserViewer, which dropped the WebSocket + canvas and left
+                the stream black until the page next repainted. */}
+            <div
+              className={
+                isViewerFullscreen
+                  ? "flex-1 relative flex flex-col overflow-hidden min-h-0"
+                  : cn(
+                      "grid gap-3",
+                      plannedSteps.length > 0
+                        ? "lg:grid-cols-[minmax(0,1fr)_320px]"
+                        : "grid-cols-1",
+                    )
+              }
+            >
+              <Card
+                className={
+                  isViewerFullscreen
+                    ? "flex-1 min-h-0 flex flex-col overflow-hidden gap-0 rounded-none border-0 py-0 shadow-none"
+                    : "overflow-hidden py-0 min-w-0"
+                }
               >
-                <Card className="overflow-hidden py-0 min-w-0">
+                {!isViewerFullscreen && (
                   <div className="flex items-center gap-2 w-full px-3 py-2 text-sm font-medium bg-muted/50">
                     <button
                       type="button"
@@ -1367,23 +1336,46 @@ export function TestDetailClient({
                       </Button>
                     )}
                   </div>
-                  {showViewer &&
-                    (streamUrl ? (
-                      <BrowserViewer
-                        streamUrl={streamUrl}
-                        className="h-[500px]"
-                        fit
-                        hideFullscreenToggle
-                        hideScreenshot
-                        hideViewportSelector
-                        readOnlyUrl
-                        onActionProgress={setActionProgress}
-                      />
-                    ) : (
-                      <ViewerProvisioningPlaceholder className="h-[500px]" />
-                    ))}
-                </Card>
-                {plannedSteps.length > 0 && showViewer && (
+                )}
+                {(showViewer || isViewerFullscreen) &&
+                  (streamUrl ? (
+                    <BrowserViewer
+                      streamUrl={streamUrl}
+                      className={
+                        isViewerFullscreen ? "flex-1 min-h-0" : "h-[500px]"
+                      }
+                      fit
+                      hideControls={isViewerFullscreen}
+                      hideFullscreenToggle
+                      hideScreenshot
+                      hideViewportSelector
+                      readOnlyUrl
+                      onActionProgress={setActionProgress}
+                    />
+                  ) : (
+                    <ViewerProvisioningPlaceholder
+                      className={
+                        isViewerFullscreen ? "flex-1 min-h-0" : "h-[500px]"
+                      }
+                    />
+                  ))}
+              </Card>
+              {plannedSteps.length > 0 &&
+                (showViewer || isViewerFullscreen) &&
+                (isViewerFullscreen ? (
+                  <div className="pointer-events-none absolute right-4 top-4 bottom-4 w-72 layer-playback-timeline hidden md:block">
+                    <PlaybackTimeline
+                      steps={plannedSteps}
+                      currentStepIndex={liveStepIndex}
+                      results={stepResults}
+                      isRunning={isRunning}
+                      selectorStats={selectorStats}
+                      actionProgress={actionProgress}
+                      compact
+                      className="h-full pointer-events-auto"
+                    />
+                  </div>
+                ) : (
                   <PlaybackTimeline
                     steps={plannedSteps}
                     currentStepIndex={liveStepIndex}
@@ -1396,7 +1388,26 @@ export function TestDetailClient({
                     // fixed height (h-full would collapse against the auto row).
                     className="h-[540px] lg:h-full"
                   />
-                )}
+                ))}
+            </div>
+            {isViewerFullscreen && (
+              <div className="fixed bottom-6 left-1/2 -translate-x-1/2 layer-playback-controls flex items-center gap-1.5 px-3 py-1.5 bg-card/95 backdrop-blur-sm border border-border rounded-full shadow-2xl">
+                <div className="flex items-center gap-2 px-1">
+                  <div className="h-2.5 w-2.5 rounded-full bg-green-500 animate-pulse" />
+                  <span className="text-sm font-medium text-foreground">
+                    Running
+                  </span>
+                </div>
+                <div className="w-px h-5 bg-border" />
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={toggleViewerFullscreen}
+                  title="Exit fullscreen"
+                >
+                  <Minimize2 className="h-4 w-4" />
+                </Button>
               </div>
             )}
           </div>

--- a/src/app/(app)/tests/[id]/test-detail-client.tsx
+++ b/src/app/(app)/tests/[id]/test-detail-client.tsx
@@ -130,7 +130,10 @@ import type { ScreenshotGroup } from "@/server/actions/tests";
 import { SheetDataPreview } from "@/components/test-data/sheet-data-preview";
 import { SheetReferenceInserter } from "@/components/test-data/sheet-reference-inserter";
 import { VarReferenceInserter } from "@/components/test-data/var-reference-inserter";
-import { BrowserViewer } from "@/components/embedded-browser/browser-viewer-client";
+import {
+  BrowserViewer,
+  type ActionProgressInfo,
+} from "@/components/embedded-browser/browser-viewer-client";
 import { getStreamUrlForRunner } from "@/server/actions/embedded-sessions";
 import { appendStreamToken } from "@/lib/eb/stream-token";
 import { TestSpecEditor } from "@/components/tests/test-spec-editor";
@@ -393,6 +396,25 @@ function CollapsibleTestCode({
   );
 }
 
+/** Shown in place of the BrowserViewer while a headed run's EB pod is being
+ *  provisioned (streamUrl resolves only once the actual runner is known). */
+function ViewerProvisioningPlaceholder({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-2 bg-black text-white",
+        className,
+      )}
+    >
+      <Loader2 className="h-8 w-8 animate-spin" />
+      <span className="text-sm">Provisioning browser…</span>
+      <span className="text-xs text-white/70">
+        Live playback starts as soon as the browser pod is ready
+      </span>
+    </div>
+  );
+}
+
 export function TestDetailClient({
   test,
   results,
@@ -483,6 +505,10 @@ export function TestDetailClient({
 
   // Live browser viewer state
   const [streamUrl, setStreamUrl] = useState<string | null>(null);
+  // True for the whole lifetime of a headed run — the viewer panel renders
+  // immediately on Run (with a provisioning placeholder) instead of popping
+  // in ~10s later when the EB pod is assigned and streamUrl resolves.
+  const [headedRunActive, setHeadedRunActive] = useState(false);
   const [showViewer, setShowViewer] = useState(true);
   const [isViewerFullscreen, setIsViewerFullscreen] = useState(false);
   const viewerLayoutRef = useRef<HTMLDivElement>(null);
@@ -490,6 +516,31 @@ export function TestDetailClient({
   // Live step timeline state
   const [currentStepIndex, setCurrentStepIndex] = useState<number>(-1);
   const [stepResults, setStepResults] = useState<StepResultsMap>({});
+  // In-flight action countdown from the live stream (selector wait, page
+  // load, fallback click). Carries the EB-reported stepIndex, so it both
+  // anchors the bar under the right timeline row AND advances the highlight
+  // ahead of the slower DB-polled step state.
+  const [actionProgress, setActionProgress] =
+    useState<ActionProgressInfo | null>(null);
+
+  // Safety net: expire a countdown whose `clear` event was lost (stream
+  // reconnect, killed pod) shortly after its own deadline.
+  useEffect(() => {
+    if (!actionProgress) return;
+    const timer = setTimeout(
+      () => setActionProgress(null),
+      actionProgress.timeoutMs + 3000,
+    );
+    return () => clearTimeout(timer);
+  }, [actionProgress]);
+
+  // The freshest known step: stream-reported action progress beats the
+  // DB-polled step state (the poll lags by a second or more, which used to
+  // leave the highlight stuck several steps behind the live browser).
+  const liveStepIndex = Math.max(
+    currentStepIndex,
+    actionProgress?.stepIndex ?? -1,
+  );
 
   // Per-step selector fallback stats from the selector_stats table. Loaded
   // once on mount and refreshed when a run completes so newly recorded
@@ -689,6 +740,10 @@ export function TestDetailClient({
     setIsRunning(true);
     setCurrentStepIndex(-1);
     setStepResults({});
+    setActionProgress(null);
+    // Show the viewer panel (with its provisioning placeholder) immediately —
+    // streamUrl resolves only once the EB pod is assigned, ~10s later.
+    setHeadedRunActive(!headless);
     try {
       track(Events.test_run_started, {
         trigger: "manual",
@@ -764,6 +819,8 @@ export function TestDetailClient({
           }
           setIsRunning(false);
           setStreamUrl(null);
+          setHeadedRunActive(false);
+          setActionProgress(null);
           router.refresh();
           // Pull fresh selector_stats so the per-step hover reflects this
           // run's outcomes. Best-effort.
@@ -788,6 +845,7 @@ export function TestDetailClient({
       }, 1000);
     } catch (error) {
       setIsRunning(false);
+      setHeadedRunActive(false);
       toast.error(
         error instanceof Error ? error.message : "Failed to run test",
       );
@@ -1213,8 +1271,10 @@ export function TestDetailClient({
           </Card>
         )}
 
-        {/* Live Browser Viewer (headed runs on embedded/system runners) */}
-        {streamUrl && isRunning && (
+        {/* Live Browser Viewer (headed runs on embedded/system runners).
+            Rendered from the moment a headed run starts — with a provisioning
+            placeholder until the EB pod is assigned and streamUrl resolves. */}
+        {isRunning && (streamUrl || headedRunActive) && (
           <div
             ref={viewerLayoutRef}
             className={
@@ -1226,20 +1286,26 @@ export function TestDetailClient({
             {isViewerFullscreen ? (
               <>
                 <div className="flex-1 relative flex flex-col overflow-hidden min-h-0">
-                  <BrowserViewer
-                    streamUrl={streamUrl}
-                    hideControls
-                    fit
-                    className="flex-1 min-h-0"
-                  />
+                  {streamUrl ? (
+                    <BrowserViewer
+                      streamUrl={streamUrl}
+                      hideControls
+                      fit
+                      className="flex-1 min-h-0"
+                      onActionProgress={setActionProgress}
+                    />
+                  ) : (
+                    <ViewerProvisioningPlaceholder className="flex-1 min-h-0" />
+                  )}
                   {plannedSteps.length > 0 && (
                     <div className="pointer-events-none absolute right-4 top-4 bottom-4 w-72 layer-playback-timeline hidden md:block">
                       <PlaybackTimeline
                         steps={plannedSteps}
-                        currentStepIndex={currentStepIndex}
+                        currentStepIndex={liveStepIndex}
                         results={stepResults}
                         isRunning={isRunning}
                         selectorStats={selectorStats}
+                        actionProgress={actionProgress}
                         compact
                         className="h-full pointer-events-auto"
                       />
@@ -1301,25 +1367,30 @@ export function TestDetailClient({
                       </Button>
                     )}
                   </div>
-                  {showViewer && (
-                    <BrowserViewer
-                      streamUrl={streamUrl}
-                      className="h-[500px]"
-                      fit
-                      hideFullscreenToggle
-                      hideScreenshot
-                      hideViewportSelector
-                      readOnlyUrl
-                    />
-                  )}
+                  {showViewer &&
+                    (streamUrl ? (
+                      <BrowserViewer
+                        streamUrl={streamUrl}
+                        className="h-[500px]"
+                        fit
+                        hideFullscreenToggle
+                        hideScreenshot
+                        hideViewportSelector
+                        readOnlyUrl
+                        onActionProgress={setActionProgress}
+                      />
+                    ) : (
+                      <ViewerProvisioningPlaceholder className="h-[500px]" />
+                    ))}
                 </Card>
                 {plannedSteps.length > 0 && showViewer && (
                   <PlaybackTimeline
                     steps={plannedSteps}
-                    currentStepIndex={currentStepIndex}
+                    currentStepIndex={liveStepIndex}
                     results={stepResults}
                     isRunning={isRunning}
                     selectorStats={selectorStats}
+                    actionProgress={actionProgress}
                     className="h-[540px]"
                   />
                 )}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -333,6 +333,17 @@
   animation: step-rise 320ms ease-out both;
 }
 
+/* Live-stream action countdown — bar drains over the action's timeout budget.
+   Duration is set inline per action (BrowserViewer), only the shape lives here. */
+@keyframes stream-action-countdown {
+  from {
+    width: 100%;
+  }
+  to {
+    width: 0%;
+  }
+}
+
 /* ---------- Z-index layer scale ---------------------------------------------
    Centralizes stacking order for the headed-playback / recording surfaces so
    ad-hoc `z-10/40/50` values don't drift out of sync.

--- a/src/components/embedded-browser/browser-viewer-client.tsx
+++ b/src/components/embedded-browser/browser-viewer-client.tsx
@@ -153,13 +153,27 @@ export const BrowserViewer = forwardRef<
   const [reconnectAttempt, setReconnectAttempt] = useState(0);
   const [timeRemaining, setTimeRemaining] = useState<number | null>(null);
   const [fileChooserPending, setFileChooserPending] = useState(false);
-  // True while the EB reports status "setup" (running setup steps before a
-  // recording / headed run). Drives a blocking "please wait" overlay for the
-  // WHOLE setup phase — input is detached on the EB during setup, so clicks
-  // would be silently ignored. Status-driven only: an earlier "busy + no
-  // frames recently" heuristic flapped during headed replay every time the
-  // page paused repainting for a few seconds.
-  const [setupActive, setSetupActive] = useState(false);
+  // Blocking placeholder phase reported by the EB:
+  //  - "setup":    setup steps are running before a recording / headed run.
+  //  - "starting": headed playback accepted but the screencast is still bound
+  //                to the idle page until the test page attaches.
+  // Both drive a "please wait" overlay — input is detached on the EB during
+  // these phases, so clicks would be silently ignored. Status-driven only:
+  // an earlier "busy + no frames recently" heuristic flapped during headed
+  // replay every time the page paused repainting for a few seconds.
+  const [blockingPhase, setBlockingPhase] = useState<
+    "setup" | "starting" | null
+  >(null);
+  // In-flight action countdown (selector wait / page-load wait / fallback
+  // click) reported by the EB. Only the start is sent — the bar animates
+  // down locally over timeoutMs from receipt; `key` remounts the bar so each
+  // new action restarts it full.
+  const [actionProgress, setActionProgress] = useState<{
+    key: string;
+    label: string;
+    kind: string;
+    timeoutMs: number;
+  } | null>(null);
 
   // FPS counter refs — initialized in useEffect to avoid impure render calls
   const frameCountRef = useRef(0);
@@ -186,6 +200,17 @@ export const BrowserViewer = forwardRef<
     const interval = setInterval(tick, 1000);
     return () => clearInterval(interval);
   }, [expiresAt]);
+
+  // Safety net: if the EB's `active: false` clear is lost (reconnect race,
+  // killed pod), expire the countdown bar shortly after its own deadline.
+  useEffect(() => {
+    if (!actionProgress) return;
+    const timer = setTimeout(
+      () => setActionProgress(null),
+      actionProgress.timeoutMs + 3000,
+    );
+    return () => clearTimeout(timer);
+  }, [actionProgress]);
 
   // Track the latest frame dimensions so the canvas/wrapper can match the
   // *real* stream aspect ratio. CDP's deviceWidth/Height drifts from the
@@ -411,16 +436,56 @@ export const BrowserViewer = forwardRef<
 
               // Track intentional screencast pauses to suppress stall detection
               const status = message.payload.status;
-              setSetupActive(status === "setup");
+              setBlockingPhase(
+                status === "setup"
+                  ? "setup"
+                  : status === "starting"
+                    ? "starting"
+                    : null,
+              );
+              // A phase transition obsoletes any in-flight action countdown
+              // (the EB also clears it, but don't rely on message ordering).
+              if (status === "setup" || status === "starting") {
+                setActionProgress(null);
+              }
               if (
                 status === "busy" ||
                 status === "setup" ||
+                status === "starting" ||
                 status === "recording" ||
                 status === "debugging"
               ) {
                 screencastPausedRef.current = true;
               } else {
                 screencastPausedRef.current = false;
+              }
+              break;
+            }
+
+            case "stream:action_progress": {
+              const p = message.payload as
+                | {
+                    active?: boolean;
+                    label?: string;
+                    kind?: string;
+                    timeoutMs?: number;
+                  }
+                | undefined;
+              // Counts as liveness — the EB is mid-action, not stalled.
+              lastFrameTimeRef.current = Date.now();
+              if (
+                p?.active &&
+                typeof p.timeoutMs === "number" &&
+                p.timeoutMs > 0
+              ) {
+                setActionProgress({
+                  key: message.id ?? String(Date.now()),
+                  label: p.label ?? "Working…",
+                  kind: p.kind ?? "wait",
+                  timeoutMs: p.timeoutMs,
+                });
+              } else {
+                setActionProgress(null);
               }
               break;
             }
@@ -984,21 +1049,54 @@ export const BrowserViewer = forwardRef<
           </div>
         )}
 
-        {/* Blocking setup overlay — translucent so setup progress stays
-            visible behind it; absorbs pointer events (the EB ignores input
-            during setup anyway). Shown for the entire setup phase, cleared
-            by the next status broadcast (recording / busy / ready). */}
-        {connectionStatus === "connected" && setupActive && (
+        {/* Blocking placeholder overlay — translucent so any streamed
+            progress stays visible behind it; absorbs pointer events (the EB
+            ignores input during these phases anyway). Shown while setup runs
+            or while headed playback waits for the test page to attach;
+            cleared by the next status broadcast (running / recording /
+            busy / ready). */}
+        {connectionStatus === "connected" && blockingPhase && (
           <div className="absolute inset-0 layer-canvas-overlay flex items-center justify-center bg-black/50">
             <div className="flex flex-col items-center gap-2 text-white">
               <Loader2 className="h-8 w-8 animate-spin" />
-              <span className="text-sm">Running setup steps…</span>
+              <span className="text-sm">
+                {blockingPhase === "setup"
+                  ? "Running setup steps…"
+                  : "Starting test…"}
+              </span>
               <span className="text-xs text-white/70">
-                Interaction is disabled until setup finishes
+                {blockingPhase === "setup"
+                  ? "Interaction is disabled until setup finishes"
+                  : "Live playback will appear here in a moment"}
               </span>
             </div>
           </div>
         )}
+
+        {/* In-flight action countdown — label + bar that drains over the
+            action's timeout budget (selector wait, page-load wait, fallback
+            click). Animated locally; the EB only sends start/clear. */}
+        {connectionStatus === "connected" &&
+          !blockingPhase &&
+          actionProgress && (
+            <div className="absolute bottom-2 left-2 right-2 layer-canvas-overlay pointer-events-none flex justify-center">
+              <div className="w-full max-w-md rounded-md bg-black/70 px-3 py-2 text-white shadow-lg">
+                <div className="mb-1.5 flex items-center gap-2 text-xs">
+                  <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
+                  <span className="truncate">{actionProgress.label}</span>
+                </div>
+                <div className="h-1 w-full overflow-hidden rounded-full bg-white/20">
+                  <div
+                    key={actionProgress.key}
+                    className={`h-full rounded-full ${actionProgress.kind === "fallback" ? "bg-amber-400" : "bg-sky-400"}`}
+                    style={{
+                      animation: `stream-action-countdown ${actionProgress.timeoutMs}ms linear forwards`,
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          )}
 
         {fileChooserPending && (
           <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 layer-canvas-overlay bg-background/90 border rounded-lg p-6 shadow-lg flex flex-col items-center gap-3">

--- a/src/components/embedded-browser/browser-viewer-client.tsx
+++ b/src/components/embedded-browser/browser-viewer-client.tsx
@@ -49,6 +49,19 @@ export interface DomSnapshotResult {
   timestamp: number;
 }
 
+/** In-flight deadline-bound action reported by the EB over the stream
+ *  (selector wait, page-load wait, fallback click). `timeoutMs` is the
+ *  remaining budget at receipt — consumers animate the countdown locally.
+ *  `key` changes per action so bars restart full; `stepIndex` ties the
+ *  action to the playback-timeline row it runs inside (-1 = pre-step). */
+export interface ActionProgressInfo {
+  key: string;
+  stepIndex: number;
+  label: string;
+  kind: string;
+  timeoutMs: number;
+}
+
 interface BrowserViewerProps {
   streamUrl: string;
   initialViewport?: { width: number; height: number };
@@ -75,6 +88,10 @@ interface BrowserViewerProps {
   onInspectResult?: (result: InspectElementResult | null) => void;
   onDomSnapshot?: (result: DomSnapshotResult) => void;
   onViewportChange?: (viewport: { width: number; height: number }) => void;
+  /** Live action countdown events from the EB (null = cleared). The viewer
+   *  doesn't render these itself — the parent attaches them to the playback
+   *  timeline so the bar sits under the step it belongs to. */
+  onActionProgress?: (progress: ActionProgressInfo | null) => void;
 }
 
 export interface BrowserViewerHandle {
@@ -105,6 +122,7 @@ export const BrowserViewer = forwardRef<
     onInspectResult,
     onDomSnapshot,
     onViewportChange,
+    onActionProgress,
   },
   ref,
 ) {
@@ -164,16 +182,6 @@ export const BrowserViewer = forwardRef<
   const [blockingPhase, setBlockingPhase] = useState<
     "setup" | "starting" | null
   >(null);
-  // In-flight action countdown (selector wait / page-load wait / fallback
-  // click) reported by the EB. Only the start is sent — the bar animates
-  // down locally over timeoutMs from receipt; `key` remounts the bar so each
-  // new action restarts it full.
-  const [actionProgress, setActionProgress] = useState<{
-    key: string;
-    label: string;
-    kind: string;
-    timeoutMs: number;
-  } | null>(null);
 
   // FPS counter refs — initialized in useEffect to avoid impure render calls
   const frameCountRef = useRef(0);
@@ -201,17 +209,6 @@ export const BrowserViewer = forwardRef<
     return () => clearInterval(interval);
   }, [expiresAt]);
 
-  // Safety net: if the EB's `active: false` clear is lost (reconnect race,
-  // killed pod), expire the countdown bar shortly after its own deadline.
-  useEffect(() => {
-    if (!actionProgress) return;
-    const timer = setTimeout(
-      () => setActionProgress(null),
-      actionProgress.timeoutMs + 3000,
-    );
-    return () => clearTimeout(timer);
-  }, [actionProgress]);
-
   // Track the latest frame dimensions so the canvas/wrapper can match the
   // *real* stream aspect ratio. CDP's deviceWidth/Height drifts from the
   // requested viewport (browser chrome, scrollbar, device-metrics rounding)
@@ -221,6 +218,8 @@ export const BrowserViewer = forwardRef<
   );
   const onViewportChangeRef = useRef(onViewportChange);
   onViewportChangeRef.current = onViewportChange;
+  const onActionProgressRef = useRef(onActionProgress);
+  onActionProgressRef.current = onActionProgress;
 
   // Render a frame onto the canvas. CDP's metadata width/height can drift
   // from the encoded JPEG's natural dimensions (DPR, scrollbar, device-metrics
@@ -446,7 +445,7 @@ export const BrowserViewer = forwardRef<
               // A phase transition obsoletes any in-flight action countdown
               // (the EB also clears it, but don't rely on message ordering).
               if (status === "setup" || status === "starting") {
-                setActionProgress(null);
+                onActionProgressRef.current?.(null);
               }
               if (
                 status === "busy" ||
@@ -469,6 +468,7 @@ export const BrowserViewer = forwardRef<
                     label?: string;
                     kind?: string;
                     timeoutMs?: number;
+                    stepIndex?: number;
                   }
                 | undefined;
               // Counts as liveness — the EB is mid-action, not stalled.
@@ -478,14 +478,15 @@ export const BrowserViewer = forwardRef<
                 typeof p.timeoutMs === "number" &&
                 p.timeoutMs > 0
               ) {
-                setActionProgress({
+                onActionProgressRef.current?.({
                   key: message.id ?? String(Date.now()),
+                  stepIndex: typeof p.stepIndex === "number" ? p.stepIndex : -1,
                   label: p.label ?? "Working…",
                   kind: p.kind ?? "wait",
                   timeoutMs: p.timeoutMs,
                 });
               } else {
-                setActionProgress(null);
+                onActionProgressRef.current?.(null);
               }
               break;
             }
@@ -1072,31 +1073,6 @@ export const BrowserViewer = forwardRef<
             </div>
           </div>
         )}
-
-        {/* In-flight action countdown — label + bar that drains over the
-            action's timeout budget (selector wait, page-load wait, fallback
-            click). Animated locally; the EB only sends start/clear. */}
-        {connectionStatus === "connected" &&
-          !blockingPhase &&
-          actionProgress && (
-            <div className="absolute bottom-2 left-2 right-2 layer-canvas-overlay pointer-events-none flex justify-center">
-              <div className="w-full max-w-md rounded-md bg-black/70 px-3 py-2 text-white shadow-lg">
-                <div className="mb-1.5 flex items-center gap-2 text-xs">
-                  <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
-                  <span className="truncate">{actionProgress.label}</span>
-                </div>
-                <div className="h-1 w-full overflow-hidden rounded-full bg-white/20">
-                  <div
-                    key={actionProgress.key}
-                    className={`h-full rounded-full ${actionProgress.kind === "fallback" ? "bg-amber-400" : "bg-sky-400"}`}
-                    style={{
-                      animation: `stream-action-countdown ${actionProgress.timeoutMs}ms linear forwards`,
-                    }}
-                  />
-                </div>
-              </div>
-            </div>
-          )}
 
         {fileChooserPending && (
           <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 layer-canvas-overlay bg-background/90 border rounded-lg p-6 shadow-lg flex flex-col items-center gap-3">

--- a/src/components/embedded-browser/browser-viewer-client.tsx
+++ b/src/components/embedded-browser/browser-viewer-client.tsx
@@ -1018,7 +1018,7 @@ export const BrowserViewer = forwardRef<
            • default:        1:1 pixels with intrinsic-height container —
                              scrolls only when parent imposes a height. */}
       <div
-        className={`relative ${hideToolbar ? "" : "rounded-b-lg border"} ${hideToolbar && hideStatusBar ? "" : "bg-black"} ${fit ? "flex-1 min-h-0 overflow-hidden flex items-center justify-center" : cropIndicators ? "flex-1 min-h-0 overflow-hidden" : "overflow-auto"}`}
+        className={`relative ${hideToolbar ? "" : "rounded-b-lg border"} ${hideToolbar && hideStatusBar ? "" : "bg-background"} ${fit ? "flex-1 min-h-0 overflow-hidden flex items-center justify-center" : cropIndicators ? "flex-1 min-h-0 overflow-hidden" : "overflow-auto"}`}
       >
         {connectionStatus !== "connected" && (
           <div className="absolute inset-0 layer-canvas-overlay flex items-center justify-center bg-black/80">

--- a/src/components/playback/playback-timeline.tsx
+++ b/src/components/playback/playback-timeline.tsx
@@ -29,6 +29,7 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
+import type { ActionProgressInfo } from "@/components/embedded-browser/browser-viewer-client";
 
 export type StepResultsMap = Record<
   number,
@@ -51,6 +52,10 @@ interface PlaybackTimelineProps {
    *  present, action steps with a parseable `locateWithFallback` array
    *  show a hover panel with per-candidate success/fail history. */
   selectorStats?: SelectorStatRow[];
+  /** In-flight deadline-bound action from the live stream. Rendered as a
+   *  decreasing countdown bar under the step row it belongs to
+   *  (`stepIndex`); stale entries for already-passed steps are dropped. */
+  actionProgress?: ActionProgressInfo | null;
 }
 
 const ITEM_HEIGHT = 64; // px — used to compute the wheel translate
@@ -77,6 +82,7 @@ export function PlaybackTimeline({
   className,
   compact = false,
   selectorStats,
+  actionProgress,
 }: PlaybackTimelineProps) {
   const stripRef = useRef<HTMLDivElement>(null);
   const total = steps.length;
@@ -86,8 +92,12 @@ export function PlaybackTimeline({
   const centerIdx = currentStepIndex < 0 ? 0 : currentStepIndex;
 
   const translateY = useMemo(() => {
-    // viewport center is at half its height; offset so the active row sits there.
-    return -(centerIdx * ITEM_HEIGHT);
+    // The strip is anchored at the viewport's vertical center (top: 50%), so
+    // shifting it up by the active row's center puts that row in the middle.
+    // (The previous `calc(-50% + …)` form subtracted half the STRIP height,
+    // which only centered correctly when the active row was the middle step —
+    // for late steps the active row scrolled clean out of the viewport.)
+    return -((centerIdx + 0.5) * ITEM_HEIGHT);
   }, [centerIdx]);
 
   // Auto-scroll wheel transform is driven by translateY; nothing else to do.
@@ -140,7 +150,7 @@ export function PlaybackTimeline({
           className="absolute inset-x-0 transition-transform duration-500 ease-out will-change-transform"
           style={{
             top: "50%",
-            transform: `translateY(calc(-50% + ${translateY}px))`,
+            transform: `translateY(${translateY}px)`,
           }}
         >
           {steps.map((step, idx) => (
@@ -152,6 +162,15 @@ export function PlaybackTimeline({
               result={results[idx]}
               compact={compact}
               selectorStats={selectorStats}
+              // Attach the countdown to the exact step the EB reports it for,
+              // and drop it once that step has a recorded result (stale clear).
+              progress={
+                actionProgress &&
+                actionProgress.stepIndex === idx &&
+                results[idx] === undefined
+                  ? actionProgress
+                  : undefined
+              }
             />
           ))}
         </div>
@@ -167,6 +186,7 @@ interface StepRowProps {
   result?: StepResultsMap[number];
   compact: boolean;
   selectorStats?: SelectorStatRow[];
+  progress?: ActionProgressInfo;
 }
 
 function StepRow({
@@ -176,6 +196,7 @@ function StepRow({
   result,
   compact,
   selectorStats,
+  progress,
 }: StepRowProps) {
   const isCurrent = index === currentStepIndex;
   const isCompleted = result !== undefined;
@@ -288,6 +309,31 @@ function StepRow({
             title={result.error}
           >
             {result.error}
+          </div>
+        )}
+        {/* In-flight action countdown — drains over the action's configured
+            timeout budget; `key` remounts the bar so each new action (next
+            selector candidate, fallback click) restarts it full. */}
+        {progress && (
+          <div className="mt-1">
+            <div
+              className="truncate text-[9px] leading-3 text-muted-foreground"
+              title={progress.label}
+            >
+              {progress.label}
+            </div>
+            <div className="mt-0.5 h-1 w-full overflow-hidden rounded-full bg-muted">
+              <div
+                key={progress.key}
+                className={cn(
+                  "h-full rounded-full",
+                  progress.kind === "fallback" ? "bg-amber-400" : "bg-primary",
+                )}
+                style={{
+                  animation: `stream-action-countdown ${progress.timeoutMs}ms linear forwards`,
+                }}
+              />
+            </div>
           </div>
         )}
       </div>

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -25,8 +25,15 @@ function HoverCardContent({
   sideOffset = 4,
   ...props
 }: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
+  // Portal into the fullscreen element when one is active — content portaled
+  // to document.body is not rendered while another element is fullscreen
+  // (e.g. selector-stats hover panels next to the fullscreen live viewer).
+  const portalContainer =
+    typeof document !== "undefined"
+      ? ((document.fullscreenElement as HTMLElement | null) ?? undefined)
+      : undefined;
   return (
-    <HoverCardPrimitive.Portal>
+    <HoverCardPrimitive.Portal container={portalContainer}>
       <HoverCardPrimitive.Content
         data-slot="hover-card-content"
         align={align}

--- a/src/lib/execution/executor.ts
+++ b/src/lib/execution/executor.ts
@@ -555,6 +555,11 @@ async function executeViaRunner(
       viewport,
       options.playwrightSettings?.navigationTimeout ?? undefined,
       options.playwrightSettings,
+      undefined,
+      // Headed playback: stream the setup pages live so the viewer's
+      // "Running setup steps…" overlay sits over real progress instead of a
+      // frozen idle frame.
+      options.headless === false,
     );
     // Merge remote setup results into setupContext for test commands
     options.setupContext = {

--- a/src/lib/ws/protocol.ts
+++ b/src/lib/ws/protocol.ts
@@ -53,7 +53,8 @@ export type MessageType =
   | "stream:inspect_element_response"
   | "stream:dom_snapshot_request"
   | "stream:dom_snapshot_response"
-  | "stream:inspect_mode";
+  | "stream:inspect_mode"
+  | "stream:action_progress";
 
 export interface BaseMessage {
   id: string;
@@ -960,6 +961,23 @@ export interface InspectModeMessage extends BaseMessage {
   payload: { enabled: boolean };
 }
 
+/** Server → Client: An action with a deadline is in flight (selector wait,
+ *  page-load wait, fallback click). Viewers render a decreasing countdown
+ *  bar locally from `timeoutMs` starting at message receipt — no per-tick
+ *  updates are sent. `active: false` clears the bar (also auto-expires
+ *  client-side after timeoutMs as a safety net). */
+export interface StreamActionProgressPayload {
+  active: boolean;
+  label?: string;
+  kind?: "selector" | "wait" | "navigation" | "fallback";
+  timeoutMs?: number;
+}
+
+export interface StreamActionProgressMessage extends BaseMessage {
+  type: "stream:action_progress";
+  payload: StreamActionProgressPayload;
+}
+
 export type StreamMessage =
   | ScreencastFrameMessage
   | StreamInputMessage
@@ -969,7 +987,8 @@ export type StreamMessage =
   | InspectElementResponseMessage
   | DomSnapshotRequestMessage
   | DomSnapshotResponseMessage
-  | InspectModeMessage;
+  | InspectModeMessage
+  | StreamActionProgressMessage;
 
 export function isStreamMessage(msg: { type: string }): boolean {
   return msg.type.startsWith("stream:");

--- a/src/lib/ws/protocol.ts
+++ b/src/lib/ws/protocol.ts
@@ -971,6 +971,9 @@ export interface StreamActionProgressPayload {
   label?: string;
   kind?: "selector" | "wait" | "navigation" | "fallback";
   timeoutMs?: number;
+  /** Instrumented step the operation runs inside (-1 before the first step)
+   *  — lets UIs attach the countdown to the matching timeline row. */
+  stepIndex?: number;
 }
 
 export interface StreamActionProgressMessage extends BaseMessage {


### PR DESCRIPTION
Three fullscreen bugs in the headed live viewer:

- Entering fullscreen rendered everything near-black: the fullscreened wrapper used translucent bg-muted/50, which composited over the browser's black ::backdrop. Now opaque bg-background.

- Toggling fullscreen swapped between two separate JSX branches, so BrowserViewer unmounted/remounted (new WebSocket, blank canvas) — and since CDP only emits frames on repaint, the canvas stayed empty until the next step caused one. The section is now a single persistent tree that only swaps classNames, so the viewer instance (socket + canvas) survives the toggle. The stream-server additionally caches the last broadcast frame and replays it to (re)connecting clients, so any reconnect paints immediately instead of waiting for a repaint.

- Step-list hover panels never appeared in fullscreen: Radix portals content to document.body, which isn't rendered while another element is fullscreen. HoverCardContent now portals into document.fullscreenElement when one is active.

https://claude.ai/code/session_01NSAQWHZzBZJJ1ewzfHwCLn