### PR TITLE
QuickStart: surface the published /r/ share (streamline)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -97,8 +97,12 @@ const nextConfig: NextConfig = {
           source: "/_umami/recorder.js",
           destination: `${umamiUrl}/recorder.js`,
         },
-        { source: "/_umami/api/send", destination: `${umamiUrl}/api/send` },
-        { source: "/_umami/api/record", destination: `${umamiUrl}/api/record` },
+        // Ingest beacons go through a resilient route handler that ACKs the
+        // browser immediately and forwards to umami in the background, so a slow
+        // umami can never stall navigation (e.g. submitting the login form).
+        // The handler reads UMAMI_INTERNAL_URL itself at runtime.
+        { source: "/_umami/api/send", destination: "/api/umami/send" },
+        { source: "/_umami/api/record", destination: "/api/umami/record" },
       );
     }
 

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.las-team/lastest",
   "description": "Run visual regression tests, review diffs, and manage baselines on a Lastest instance.",
   "repository": {
@@ -7,13 +7,13 @@
     "source": "github",
     "subfolder": "packages/mcp-server"
   },
-  "version": "0.3.4",
+  "version": "0.3.7",
   "websiteUrl": "https://github.com/las-team/lastest/wiki/MCP-Server",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@lastest/mcp-server",
-      "version": "0.3.4",
+      "version": "0.3.7",
       "transport": { "type": "stdio" },
       "runtimeArguments": [
         {

--- a/scripts/backfill-encrypt-tokens.ts
+++ b/scripts/backfill-encrypt-tokens.ts
@@ -17,6 +17,9 @@ import {
   oauthAccounts,
   googleSheetsAccounts,
   aiSettings,
+  storageStates,
+  setupConfigs,
+  agentSessions,
 } from "../src/lib/db/schema";
 import { encrypt, ENC_PREFIX } from "../src/lib/crypto";
 import { eq } from "drizzle-orm";
@@ -151,6 +154,102 @@ async function backfillAISettings() {
   }
 }
 
+// ── User-provided app credentials (added later) ──────────────────────────────
+
+// storage_states.storageStateJson — flat text column holding a live Playwright
+// storageState() blob (cookies + localStorage = live session tokens).
+async function backfillStorageStates() {
+  console.log("\n[storageStates]");
+  const rows = await db.select().from(storageStates);
+  for (const row of rows) {
+    await encryptRow(
+      "storageState",
+      row.id,
+      { storageStateJson: row.storageStateJson },
+      async (id, updates) => {
+        await db
+          .update(storageStates)
+          .set(updates)
+          .where(eq(storageStates.id, id));
+      },
+    );
+  }
+}
+
+// setup_configs.authConfig — JSONB; encrypt token / password / header values
+// in place (username left plaintext, matching the query layer).
+async function backfillSetupConfigs() {
+  console.log("\n[setupConfigs]");
+  const rows = await db.select().from(setupConfigs);
+  for (const row of rows) {
+    const cfg = row.authConfig;
+    if (!cfg) {
+      skipped++;
+      continue;
+    }
+    const next = { ...cfg };
+    let changed = false;
+    if (needsEncryption(next.token)) {
+      next.token = encrypt(next.token);
+      changed = true;
+    }
+    if (needsEncryption(next.password)) {
+      next.password = encrypt(next.password);
+      changed = true;
+    }
+    if (next.headers) {
+      const headers: Record<string, string> = {};
+      for (const [k, v] of Object.entries(next.headers)) {
+        if (needsEncryption(v)) {
+          headers[k] = encrypt(v);
+          changed = true;
+        } else {
+          headers[k] = v;
+        }
+      }
+      next.headers = headers;
+    }
+    if (!changed) {
+      skipped++;
+      continue;
+    }
+    console.log(`  setupConfig ${row.id}: encrypting authConfig secrets`);
+    if (!dryRun)
+      await db
+        .update(setupConfigs)
+        .set({ authConfig: next })
+        .where(eq(setupConfigs.id, row.id));
+    encrypted++;
+  }
+}
+
+// agent_sessions.metadata.quickstartPassword — JSONB; encrypt the password
+// sub-field (email left plaintext).
+async function backfillAgentSessions() {
+  console.log("\n[agentSessions]");
+  const rows = await db.select().from(agentSessions);
+  for (const row of rows) {
+    const meta = row.metadata;
+    if (!meta || !needsEncryption(meta.quickstartPassword)) {
+      skipped++;
+      continue;
+    }
+    const next = {
+      ...meta,
+      quickstartPassword: encrypt(meta.quickstartPassword),
+    };
+    console.log(
+      `  agentSession ${row.id}: encrypting metadata.quickstartPassword`,
+    );
+    if (!dryRun)
+      await db
+        .update(agentSessions)
+        .set({ metadata: next })
+        .where(eq(agentSessions.id, row.id));
+    encrypted++;
+  }
+}
+
 async function main() {
   if (dryRun) console.log("DRY RUN — no changes will be written\n");
 
@@ -159,6 +258,9 @@ async function main() {
   await backfillOAuthAccounts();
   await backfillGoogleSheetsAccounts();
   await backfillAISettings();
+  await backfillStorageStates();
+  await backfillSetupConfigs();
+  await backfillAgentSessions();
 
   console.log(
     `\nDone. ${encrypted} field(s) encrypted, ${skipped} already encrypted (skipped).`,

--- a/scripts/migrate-drop-default-baseurl.sql
+++ b/scripts/migrate-drop-default-baseurl.sql
@@ -1,0 +1,33 @@
+-- Drop the legacy repo-wide "default" key from repositories.branch_base_urls.
+--
+-- Background: base URLs are per-branch (branch_base_urls keyed by branch name).
+-- A special "default" key used to be written at repo creation + onboarding as a
+-- fallback, but the per-branch base-URL UI never updated it, so it went stale
+-- and (via pickRepoBaseUrl) shadowed real branch URLs — sending the QuickStart
+-- scout to the wrong site (e.g. an excalidraw repo whose stale default was
+-- https://playwright.dev). The code no longer reads or writes "default"; this
+-- migration removes it from existing data.
+--
+-- The URL it held is preserved: it is folded into the repo's default branch
+-- (or "main" when default_branch is null/empty) ONLY if that branch has no URL
+-- yet. An explicit branch URL always wins. Empty "default" values are dropped.
+--
+-- Idempotent: only rows that still carry a "default" key are touched.
+-- Run on every environment (local + each prod DB) BEFORE/with the code deploy.
+
+UPDATE repositories
+SET branch_base_urls =
+  (branch_base_urls - 'default')
+  || CASE
+       -- branch already has a URL, or "default" is empty → just drop the key
+       WHEN branch_base_urls ? COALESCE(NULLIF(default_branch, ''), 'main')
+         THEN '{}'::jsonb
+       WHEN COALESCE(branch_base_urls ->> 'default', '') = ''
+         THEN '{}'::jsonb
+       -- otherwise preserve the URL under the default branch
+       ELSE jsonb_build_object(
+              COALESCE(NULLIF(default_branch, ''), 'main'),
+              branch_base_urls ->> 'default'
+            )
+     END
+WHERE branch_base_urls ? 'default';

--- a/scripts/rotate-encryption-key.ts
+++ b/scripts/rotate-encryption-key.ts
@@ -25,6 +25,9 @@ import {
   oauthAccounts,
   googleSheetsAccounts,
   aiSettings,
+  storageStates,
+  setupConfigs,
+  agentSessions,
 } from "../src/lib/db/schema";
 import { encrypt, decryptWithKey, ENC_PREFIX } from "../src/lib/crypto";
 import { eq } from "drizzle-orm";
@@ -183,6 +186,101 @@ async function rotateAISettings(oldKey: Buffer) {
   }
 }
 
+// ── User-provided app credentials (added later) ──────────────────────────────
+
+// storage_states.storageStateJson — flat text column.
+async function rotateStorageStates(oldKey: Buffer) {
+  console.log("\n[storageStates]");
+  const rows = await db.select().from(storageStates);
+  for (const row of rows) {
+    await rotateRow(
+      "storageState",
+      row.id,
+      { storageStateJson: row.storageStateJson },
+      oldKey,
+      async (id, updates) => {
+        await db
+          .update(storageStates)
+          .set(updates)
+          .where(eq(storageStates.id, id));
+      },
+    );
+  }
+}
+
+// setup_configs.authConfig — JSONB; re-encrypt token / password / header values.
+async function rotateSetupConfigs(oldKey: Buffer) {
+  console.log("\n[setupConfigs]");
+  const rows = await db.select().from(setupConfigs);
+  for (const row of rows) {
+    const cfg = row.authConfig;
+    if (!cfg) {
+      skipped++;
+      continue;
+    }
+    const next = { ...cfg };
+    let changed = false;
+    const token = reEncryptField(next.token, oldKey);
+    if (token != null) {
+      next.token = token;
+      changed = true;
+    }
+    const password = reEncryptField(next.password, oldKey);
+    if (password != null) {
+      next.password = password;
+      changed = true;
+    }
+    if (next.headers) {
+      const headers: Record<string, string> = {};
+      for (const [k, v] of Object.entries(next.headers)) {
+        const re = reEncryptField(v, oldKey);
+        if (re != null) {
+          headers[k] = re;
+          changed = true;
+        } else {
+          headers[k] = v;
+        }
+      }
+      next.headers = headers;
+    }
+    if (!changed) {
+      skipped++;
+      continue;
+    }
+    console.log(`  setupConfig ${row.id}: rotating authConfig secrets`);
+    if (!dryRun)
+      await db
+        .update(setupConfigs)
+        .set({ authConfig: next })
+        .where(eq(setupConfigs.id, row.id));
+    rotated++;
+  }
+}
+
+// agent_sessions.metadata.quickstartPassword — JSONB.
+async function rotateAgentSessions(oldKey: Buffer) {
+  console.log("\n[agentSessions]");
+  const rows = await db.select().from(agentSessions);
+  for (const row of rows) {
+    const meta = row.metadata;
+    const re = reEncryptField(meta?.quickstartPassword, oldKey);
+    if (!meta || re == null) {
+      skipped++;
+      continue;
+    }
+    const next = { ...meta, quickstartPassword: re };
+    console.log(
+      `  agentSession ${row.id}: rotating metadata.quickstartPassword`,
+    );
+    if (!dryRun)
+      await db
+        .update(agentSessions)
+        .set({ metadata: next })
+        .where(eq(agentSessions.id, row.id));
+    rotated++;
+  }
+}
+
 async function main() {
   const oldKey = getOldKey();
   if (dryRun) console.log("DRY RUN — no changes will be written\n");
@@ -192,6 +290,9 @@ async function main() {
   await rotateOAuthAccounts(oldKey);
   await rotateGoogleSheetsAccounts(oldKey);
   await rotateAISettings(oldKey);
+  await rotateStorageStates(oldKey);
+  await rotateSetupConfigs(oldKey);
+  await rotateAgentSessions(oldKey);
 
   console.log(
     `\nDone. ${rotated} row(s) re-encrypted, ${skipped} skipped (already rotated or plaintext).`,

--- a/scripts/sync-docker-pins.mjs
+++ b/scripts/sync-docker-pins.mjs
@@ -56,11 +56,20 @@ const dockerfile = readFileSync(dockerfilePath, "utf8");
 
 // Every pinned path appears as `.pnpm/<token>` where <token> = <name>@<version>.
 // Capture each unique token. Token runs until `/`, whitespace, or end-of-token.
-// The version must start with a digit, so illustrative placeholders in comments
-// (e.g. `.pnpm/@anthropic-ai+claude-agent-sdk@...`) are ignored, not treated as pins.
+//
+// Two guards keep prose out of the token set:
+//   1. Skip whole-comment lines. The explanatory comments in this Dockerfile
+//      reference `.pnpm/<pkg>@...` with a literal `...` placeholder (not a real
+//      pin); real pins only ever live on COPY/RUN lines.
+//   2. Require the version to start with a digit (`@\d`). Every pnpm store dir is
+//      `<name>@<semver>` so the version begins with a digit — this rejects the
+//      `@...` placeholder even if it ever appears outside a comment.
 const tokens = new Set();
-for (const m of dockerfile.matchAll(/\.pnpm\/([^/\s\\]+@\d[^/\s\\]*)/g))
-  tokens.add(m[1]);
+for (const line of dockerfile.split("\n")) {
+  if (/^\s*#/.test(line)) continue; // Dockerfile comment — never a real pin
+  for (const m of line.matchAll(/\.pnpm\/([^/\s\\]+@\d[^/\s\\]*)/g))
+    tokens.add(m[1]);
+}
 
 // name = everything up to the first `@` that is followed by a digit (version start).
 // Handles scoped/peer-hashed names like `@anthropic-ai+claude-agent-sdk@0.2.141_zod@4.4.3`.

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -370,6 +370,7 @@ export default async function DashboardPage({
             <QuickstartPanel
               repositoryId={selectedRepo.id}
               enabled={quickstartGate.enabled}
+              defaultBranch={selectedRepo.defaultBranch}
               reason={
                 quickstartGate.enabled
                   ? undefined

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -180,8 +180,11 @@ export default async function DashboardPage({
           latestBuildId={recentBuilds[0]?.id ?? null}
         />
 
-        {/* Health Score + Stats Cards */}
-        <div className="grid grid-cols-2 md:grid-cols-5 gap-3 md:gap-4">
+        {/* Health Score + Stats Cards — auto-fit so the row always spans full
+            width whether 4 or 5 cards render (the Health Score card is the only
+            tooltip-wrapped one and can be absent, which left an empty column
+            under the old fixed 5-col grid). */}
+        <div className="grid grid-cols-2 gap-3 md:gap-4 md:[grid-template-columns:repeat(auto-fit,minmax(11rem,1fr))]">
           {/* Health Score */}
           <Tooltip>
             <TooltipTrigger asChild>
@@ -313,6 +316,27 @@ export default async function DashboardPage({
           </Card>
         </div>
 
+        {/* QuickStart Agent (baseUrl required) — surfaced high, above coverage */}
+        {!session?.team?.banAiMode && selectedRepo && (
+          <QuickstartPanel
+            repositoryId={selectedRepo.id}
+            enabled={quickstartGate.enabled}
+            baseUrl={
+              "baseUrl" in quickstartGate ? quickstartGate.baseUrl : null
+            }
+            defaultBranch={selectedRepo.defaultBranch}
+            reason={
+              quickstartGate.enabled
+                ? undefined
+                : (quickstartGate.reason as
+                    | "no_team"
+                    | "not_early_adopter"
+                    | "no_base_url"
+                    | undefined)
+            }
+          />
+        )}
+
         {/* Coverage + Last Build Row */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3 md:gap-4">
           <Card>
@@ -356,27 +380,6 @@ export default async function DashboardPage({
             )}
           </Card>
         </div>
-
-        {/* QuickStart Agent (baseUrl required) */}
-        {!session?.team?.banAiMode && selectedRepo && (
-          <QuickstartPanel
-            repositoryId={selectedRepo.id}
-            enabled={quickstartGate.enabled}
-            baseUrl={
-              "baseUrl" in quickstartGate ? quickstartGate.baseUrl : null
-            }
-            defaultBranch={selectedRepo.defaultBranch}
-            reason={
-              quickstartGate.enabled
-                ? undefined
-                : (quickstartGate.reason as
-                    | "no_team"
-                    | "not_early_adopter"
-                    | "no_base_url"
-                    | undefined)
-            }
-          />
-        )}
 
         {/* Selector Stats */}
         {selectorStats.length > 0 && (

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -35,7 +35,6 @@ import {
   getBaselinesByRepo,
 } from "@/lib/db/queries";
 import { getCurrentSession } from "@/lib/auth";
-import { PlayAgentTimeline } from "@/components/play-agent/play-agent-timeline";
 import { QuickstartPanel } from "@/components/quickstart/quickstart-panel";
 import { isQuickstartEnabled } from "@/lib/quickstart/gating";
 import { SelectorStatsChartClient } from "@/components/dashboard/selector-stats-chart-client";
@@ -358,30 +357,23 @@ export default async function DashboardPage({
           </Card>
         </div>
 
-        {/* Auto Setup Agent */}
-        {!session?.team?.banAiMode && (
-          <PlayAgentTimeline repositoryId={selectedRepo?.id} />
+        {/* QuickStart Agent (baseUrl required) */}
+        {!session?.team?.banAiMode && selectedRepo && (
+          <QuickstartPanel
+            repositoryId={selectedRepo.id}
+            enabled={quickstartGate.enabled}
+            defaultBranch={selectedRepo.defaultBranch}
+            reason={
+              quickstartGate.enabled
+                ? undefined
+                : (quickstartGate.reason as
+                    | "no_team"
+                    | "not_early_adopter"
+                    | "no_base_url"
+                    | undefined)
+            }
+          />
         )}
-
-        {/* QuickStart Agent (early-adopter, baseUrl required) */}
-        {!session?.team?.banAiMode &&
-          session?.team?.earlyAdopterMode &&
-          selectedRepo && (
-            <QuickstartPanel
-              repositoryId={selectedRepo.id}
-              enabled={quickstartGate.enabled}
-              defaultBranch={selectedRepo.defaultBranch}
-              reason={
-                quickstartGate.enabled
-                  ? undefined
-                  : (quickstartGate.reason as
-                      | "no_team"
-                      | "not_early_adopter"
-                      | "no_base_url"
-                      | undefined)
-              }
-            />
-          )}
 
         {/* Selector Stats */}
         {selectorStats.length > 0 && (

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -362,6 +362,9 @@ export default async function DashboardPage({
           <QuickstartPanel
             repositoryId={selectedRepo.id}
             enabled={quickstartGate.enabled}
+            baseUrl={
+              "baseUrl" in quickstartGate ? quickstartGate.baseUrl : null
+            }
             defaultBranch={selectedRepo.defaultBranch}
             reason={
               quickstartGate.enabled

--- a/src/app/(onboarding)/onboarding/page.tsx
+++ b/src/app/(onboarding)/onboarding/page.tsx
@@ -53,9 +53,12 @@ export default async function OnboardingPage({
       }))}
       selectedRepoId={selectedRepo?.id ?? null}
       selectedRepoBaseUrl={
-        selectedRepo?.branchBaseUrls?.default ??
         (selectedRepo?.defaultBranch
           ? selectedRepo.branchBaseUrls?.[selectedRepo.defaultBranch]
+          : undefined) ??
+        selectedRepo?.branchBaseUrls?.main ??
+        (selectedRepo?.branchBaseUrls
+          ? Object.values(selectedRepo.branchBaseUrls)[0]
           : undefined) ??
         null
       }

--- a/src/app/(public)/r/[slug]/page.tsx
+++ b/src/app/(public)/r/[slug]/page.tsx
@@ -15,7 +15,12 @@ import {
   getLatestDemoNotesForRepo,
 } from "@/lib/db/queries/demo-notes";
 import { getRepoAward } from "@/lib/db/queries/awards";
-import type { DemoNotes, DomDiffResult, RepoAward } from "@/lib/db/schema";
+import type {
+  DemoNotes,
+  DomDiffResult,
+  RepoAward,
+  WebVitalsSample,
+} from "@/lib/db/schema";
 import { isValidShareSlug, buildShareUrl } from "@/lib/share/slug";
 import { resolveTestVideoUrl } from "@/lib/share/video-fallback";
 import { ShareVideoPlayer } from "./share-video-player";
@@ -239,6 +244,10 @@ export default async function PublicSharePage({ params }: PageProps) {
     0,
   );
 
+  // Absolute Core-Web-Vitals "Fast" grade for the share. Null when no vitals
+  // were captured (renders "—"); see computePerfScore.
+  const perfScore = computePerfScore(scopedResults);
+
   // Recording clips, hoisted to page level so the player renders as the FIRST
   // element in <main> — above the fold, at actual size, highest in the HTML.
   // Google only indexes videos on "watch pages" where the video is the main
@@ -358,6 +367,7 @@ export default async function PublicSharePage({ params }: PageProps) {
             results={scopedResults}
             toUrl={toUrl}
             build={build}
+            perfScore={perfScore}
             testResult={primaryResult}
             shareUrl={shareUrl}
             testName={test?.name ?? displayDomain}
@@ -382,6 +392,7 @@ export default async function PublicSharePage({ params }: PageProps) {
               build={build}
               targetDomain={share.targetDomain}
               branch={testRun?.gitBranch ?? null}
+              perfScore={perfScore}
             />
             <BuildDiffsGallery
               diffs={diffs}
@@ -1343,10 +1354,12 @@ function BuildSummary({
   build,
   targetDomain,
   branch,
+  perfScore,
 }: {
   build: Build;
   targetDomain: string | null;
   branch: string | null;
+  perfScore: number | null;
 }) {
   const total = build.totalTests ?? 0;
   const passed = build.passedCount ?? 0;
@@ -1354,6 +1367,10 @@ function BuildSummary({
   const changed = build.changesDetected ?? 0;
   const pending = Math.max(0, total - passed - failed - changed);
   const a11y = build.a11yScore;
+  const design = build.designSystemScore;
+  // passed/failed/changed + Accessible, then any of Design / Fast that reported.
+  const tileCount =
+    4 + (design != null ? 1 : 0) + (perfScore != null ? 1 : 0);
 
   const configBits: string[] = [];
   if (build.triggerType) configBits.push(humanize(build.triggerType));
@@ -1376,21 +1393,16 @@ function BuildSummary({
         changed={changed}
       />
 
-      <div
-        className={`grid grid-cols-2 gap-3 ${
-          build.designSystemScore == null ? "sm:grid-cols-4" : "sm:grid-cols-5"
-        }`}
-      >
+      <div className={`grid gap-3 ${gridColsClass(tileCount)}`}>
         <StatCard value={passed} label="Passed" tone="ok" />
         <StatCard value={failed} label="Failed" tone="danger" />
         <StatCard value={changed} label="Changed" tone="warn" />
         <GradeCard score={a11y} label="Accessible" sub="WCAG 2.2" />
-        {build.designSystemScore != null && (
-          <GradeCard
-            score={build.designSystemScore}
-            label="Design"
-            sub="Design system"
-          />
+        {design != null && (
+          <GradeCard score={design} label="Design" sub="Design system" />
+        )}
+        {perfScore != null && (
+          <GradeCard score={perfScore} label="Fast" sub="Web Vitals" />
         )}
       </div>
 
@@ -1520,6 +1532,40 @@ function GradeCard({
   );
 }
 
+// Absolute "Fast" score from captured Core Web Vitals. Each metric is scored
+// against Google's standard good/needs-improvement/poor thresholds (good=100,
+// NI=70, poor=40); we take the worst (most conservative) observed value per
+// metric across all samples, then average the metrics we have. Returns null
+// when no vitals were captured so the tile renders a neutral "—".
+function computePerfScore(results: ShareTestResult[]): number | null {
+  const samples: WebVitalsSample[] = results.flatMap((r) => r.webVitals ?? []);
+  if (samples.length === 0) return null;
+  const worst = (pick: (s: WebVitalsSample) => number | undefined) => {
+    const vals = samples
+      .map(pick)
+      .filter((v): v is number => typeof v === "number");
+    return vals.length ? Math.max(...vals) : undefined;
+  };
+  const band = (v: number | undefined, good: number, poor: number) =>
+    v == null ? null : v <= good ? 100 : v <= poor ? 70 : 40;
+  const scores = [
+    band(worst((s) => s.lcp), 2500, 4000), // LCP ms
+    band(worst((s) => s.inp), 200, 500), // INP ms
+    band(worst((s) => s.cls), 0.1, 0.25), // CLS (unitless)
+  ].filter((x): x is number => x != null);
+  if (scores.length === 0) return null;
+  return Math.round(scores.reduce((a, b) => a + b, 0) / scores.length);
+}
+
+// Static (Tailwind-scannable) column classes for the quality stat grid, sized
+// to the number of tiles present (3–6).
+function gridColsClass(n: number): string {
+  if (n <= 3) return "grid-cols-2 sm:grid-cols-3";
+  if (n === 4) return "grid-cols-2 sm:grid-cols-4";
+  if (n === 5) return "grid-cols-2 sm:grid-cols-5";
+  return "grid-cols-2 sm:grid-cols-3 lg:grid-cols-6";
+}
+
 // Diffs + gallery for build-scoped shares (no video, no step strip).
 function BuildDiffsGallery({
   diffs,
@@ -1570,6 +1616,7 @@ function TestShareBody({
   results,
   toUrl,
   build,
+  perfScore,
   testResult,
   shareUrl,
   testName,
@@ -1583,6 +1630,7 @@ function TestShareBody({
   results: ShareTestResult[];
   toUrl: (p: string | null | undefined) => string | null;
   build: Build;
+  perfScore: number | null;
   testResult: ShareTestResult | null;
   shareUrl: string;
   testName: string;
@@ -1633,9 +1681,11 @@ function TestShareBody({
       {steps.length > 0 && <StepStripClient steps={steps} />}
 
       <div
-        className={`grid gap-3 ${
-          build.designSystemScore == null ? "grid-cols-3" : "grid-cols-2 sm:grid-cols-4"
-        }`}
+        className={`grid gap-3 ${gridColsClass(
+          3 +
+            (build.designSystemScore != null ? 1 : 0) +
+            (perfScore != null ? 1 : 0),
+        )}`}
       >
         <StatCard
           value={pixelsChanged > 0 ? pixelsChanged.toLocaleString() : "0"}
@@ -1658,6 +1708,9 @@ function TestShareBody({
             label="Design"
             sub="Design system"
           />
+        )}
+        {perfScore != null && (
+          <GradeCard score={perfScore} label="Fast" sub="Web Vitals" />
         )}
       </div>
 

--- a/src/app/(public)/r/[slug]/page.tsx
+++ b/src/app/(public)/r/[slug]/page.tsx
@@ -1376,16 +1376,22 @@ function BuildSummary({
         changed={changed}
       />
 
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      <div
+        className={`grid grid-cols-2 gap-3 ${
+          build.designSystemScore == null ? "sm:grid-cols-4" : "sm:grid-cols-5"
+        }`}
+      >
         <StatCard value={passed} label="Passed" tone="ok" />
         <StatCard value={failed} label="Failed" tone="danger" />
         <StatCard value={changed} label="Changed" tone="warn" />
-        <StatCard
-          value={a11y == null ? "—" : a11y}
-          label="A11y"
-          sublabel={a11y == null ? undefined : "WCAG 2.2"}
-          tone="neutral"
-        />
+        <GradeCard score={a11y} label="Accessible" sub="WCAG 2.2" />
+        {build.designSystemScore != null && (
+          <GradeCard
+            score={build.designSystemScore}
+            label="Design"
+            sub="Design system"
+          />
+        )}
       </div>
 
       {pending > 0 && (
@@ -1479,6 +1485,38 @@ function StatCard({
         </div>
       )}
     </div>
+  );
+}
+
+// Map a 0–100 quality score to a presentable letter grade + tone. Bands mirror
+// the internal compliance cards (90+ green, 70+ amber, else red).
+function scoreGrade(score: number): {
+  grade: string;
+  tone: "ok" | "warn" | "danger";
+} {
+  if (score >= 90) return { grade: "A", tone: "ok" };
+  if (score >= 80) return { grade: "B", tone: "ok" };
+  if (score >= 70) return { grade: "C", tone: "warn" };
+  if (score >= 60) return { grade: "D", tone: "warn" };
+  return { grade: "F", tone: "danger" };
+}
+
+// Presentable quality tile: a letter grade headline (color-toned by band) with
+// the raw score + standard label as sublabel. Renders a neutral "—" when the
+// layer didn't report a score. Reuses StatCard so it inherits share styling.
+function GradeCard({
+  score,
+  label,
+  sub,
+}: {
+  score: number | null | undefined;
+  label: string;
+  sub: string;
+}) {
+  if (score == null) return <StatCard value="—" label={label} tone="neutral" />;
+  const { grade, tone } = scoreGrade(score);
+  return (
+    <StatCard value={grade} label={label} sublabel={`${sub} · ${score}`} tone={tone} />
   );
 }
 
@@ -1594,7 +1632,11 @@ function TestShareBody({
 
       {steps.length > 0 && <StepStripClient steps={steps} />}
 
-      <div className="grid grid-cols-3 gap-3">
+      <div
+        className={`grid gap-3 ${
+          build.designSystemScore == null ? "grid-cols-3" : "grid-cols-2 sm:grid-cols-4"
+        }`}
+      >
         <StatCard
           value={pixelsChanged > 0 ? pixelsChanged.toLocaleString() : "0"}
           label="Diff px"
@@ -1609,12 +1651,14 @@ function TestShareBody({
           label="Duration"
           tone="neutral"
         />
-        <StatCard
-          value={build.a11yScore == null ? "—" : build.a11yScore}
-          label="A11y"
-          sublabel={build.a11yScore == null ? undefined : "WCAG 2.2"}
-          tone="neutral"
-        />
+        <GradeCard score={build.a11yScore} label="Accessible" sub="WCAG 2.2" />
+        {build.designSystemScore != null && (
+          <GradeCard
+            score={build.designSystemScore}
+            label="Design"
+            sub="Design system"
+          />
+        )}
       </div>
 
       {hasDemoContent(demoNotes) ? (

--- a/src/app/api/activity-feed/sessions/route.ts
+++ b/src/app/api/activity-feed/sessions/route.ts
@@ -45,6 +45,14 @@ export async function GET(_request: NextRequest) {
     return 0;
   });
 
+  // This raw select bypasses the decrypting getStorageState/getAgentSession
+  // getters, so metadata.quickstartPassword would arrive encrypted — and the
+  // feed UI never needs it regardless. Strip it before returning.
+  const safe = sorted.map((s) => {
+    const { quickstartPassword: _omit, ...metadata } = s.metadata ?? {};
+    return { ...s, metadata };
+  });
+
   // Find a ready EB stream URL for the monitor icon
   const [eb] = await db
     .select({ streamUrl: embeddedSessions.streamUrl })
@@ -53,7 +61,7 @@ export async function GET(_request: NextRequest) {
     .limit(1);
 
   return NextResponse.json({
-    sessions: sorted,
+    sessions: safe,
     ebStreamUrl: eb?.streamUrl ?? null,
   });
 }

--- a/src/app/api/umami/[event]/route.ts
+++ b/src/app/api/umami/[event]/route.ts
@@ -1,0 +1,70 @@
+import { after, type NextRequest } from "next/server";
+
+// Resilient umami ingest proxy.
+//
+// The umami session-replay recorder (recorder.js) and tracker (script.js) POST
+// batches to /_umami/api/record and /_umami/api/send. next.config rewrites those
+// public paths to this handler. Rather than reverse-proxying straight through to
+// the internal umami server (which made the browser wait for umami's response —
+// a slow/unreachable umami would stall the very navigation that triggered the
+// flush, e.g. submitting the login form), we ACK the beacon immediately and
+// forward to umami in the background.
+//
+// Priority: never block the user on analytics. A dropped recording is fine; a
+// stuck login is not. So the forward is best-effort with a hard timeout and the
+// 204 goes back to the browser before umami is ever contacted.
+
+const UMAMI_URL = process.env.UMAMI_INTERNAL_URL?.replace(/\/$/, "");
+const ALLOWED_EVENTS = new Set(["record", "send"]);
+const FORWARD_TIMEOUT_MS = 3000;
+
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ event: string }> },
+) {
+  const { event } = await params;
+
+  // Unknown event, or no umami configured (self-hosted/local dev): swallow the
+  // beacon so the client still gets a fast, successful response.
+  if (!UMAMI_URL || !ALLOWED_EVENTS.has(event)) {
+    return new Response(null, { status: 204 });
+  }
+
+  // Read the body now — the request stream is gone by the time after() runs.
+  const body = await request.text();
+
+  // Forward only the headers umami uses to attribute the hit (device/browser
+  // via UA, geo + cookieless visitor hash via client IP, locale).
+  const headers: Record<string, string> = {
+    "content-type": request.headers.get("content-type") ?? "application/json",
+  };
+  const userAgent = request.headers.get("user-agent");
+  if (userAgent) headers["user-agent"] = userAgent;
+  const acceptLanguage = request.headers.get("accept-language");
+  if (acceptLanguage) headers["accept-language"] = acceptLanguage;
+  const forwardedFor =
+    request.headers.get("x-forwarded-for") ??
+    request.headers.get("x-real-ip") ??
+    undefined;
+  if (forwardedFor) headers["x-forwarded-for"] = forwardedFor;
+
+  // after() runs the forward once the response has been sent; the standalone
+  // Node server keeps the process alive for it. A slow umami can no longer
+  // affect the browser.
+  after(async () => {
+    try {
+      await fetch(`${UMAMI_URL}/api/${event}`, {
+        method: "POST",
+        headers,
+        body,
+        signal: AbortSignal.timeout(FORWARD_TIMEOUT_MS),
+      });
+    } catch {
+      // Best-effort: a dropped recording beats a blocked user.
+    }
+  });
+
+  return new Response(null, { status: 204 });
+}

--- a/src/app/api/v1/[...slug]/route.ts
+++ b/src/app/api/v1/[...slug]/route.ts
@@ -2055,7 +2055,7 @@ export async function POST(
     }
 
     // QuickStart agent: POST /api/v1/repos/:id/quickstart
-    // Body: { emailTemplate?: string }
+    // Body: { emailTemplate?: string, appEmail?: string, appPassword?: string }
     if (resource === "repos" && id && subResource === "quickstart") {
       if (!(await verifyRepoOwnership(id, session))) {
         return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -2065,12 +2065,22 @@ export async function POST(
         typeof body?.emailTemplate === "string"
           ? body.emailTemplate
           : undefined;
+      const appEmail =
+        typeof body?.appEmail === "string" && body.appEmail.trim().length > 0
+          ? body.appEmail.trim()
+          : undefined;
+      const appPassword =
+        typeof body?.appPassword === "string" && body.appPassword.length > 0
+          ? body.appPassword
+          : undefined;
       try {
         const { startQuickstart } =
           await import("@/server/actions/quickstart-agent");
         const result = await startQuickstart(
           id,
-          emailTemplate ? { emailTemplate } : undefined,
+          emailTemplate || appEmail || appPassword
+            ? { emailTemplate, appEmail, appPassword }
+            : undefined,
         );
         return NextResponse.json(result, { status: 201 });
       } catch (err) {

--- a/src/components/quickstart/quickstart-panel.tsx
+++ b/src/components/quickstart/quickstart-panel.tsx
@@ -22,9 +22,14 @@ import {
   X,
   ChevronDown,
   KeyRound,
+  Monitor,
 } from "lucide-react";
 import { BrowserViewer } from "@/components/embedded-browser/browser-viewer-client";
-import { useQuickstart, type QuickstartStep } from "./use-quickstart";
+import {
+  useQuickstart,
+  type QuickstartStep,
+  type QuickstartSessionView,
+} from "./use-quickstart";
 
 interface QuickstartPanelProps {
   repositoryId?: string | null;
@@ -53,6 +58,89 @@ function StepIcon({ status }: { status: QuickstartStep["status"] }) {
   return <Circle className="size-3.5 text-muted-foreground/40" />;
 }
 
+/** Founder-facing demo notes, rendered inline once the run writes them. */
+function NotesPanel({
+  notes,
+}: {
+  notes: NonNullable<QuickstartSessionView["metadata"]["demoNotes"]>;
+}) {
+  return (
+    <div className="rounded-md border bg-muted/30 p-3 space-y-2">
+      <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        Demo notes
+      </p>
+      {notes.uxSummary && (
+        <p className="text-xs text-foreground/90">{notes.uxSummary}</p>
+      )}
+      {notes.highlights.length > 0 && (
+        <ul className="space-y-1">
+          {notes.highlights.slice(0, 4).map((h, i) => (
+            <li key={`h-${i}`} className="flex gap-1.5 text-[11px]">
+              <CheckCircle2 className="size-3 text-success shrink-0 mt-0.5" />
+              <span>
+                <span className="font-medium">{h.label}</span>
+                {h.note ? ` — ${h.note}` : ""}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+      {notes.frictionPoints.length > 0 && (
+        <ul className="space-y-1">
+          {notes.frictionPoints.slice(0, 3).map((f, i) => (
+            <li key={`f-${i}`} className="flex gap-1.5 text-[11px]">
+              <CircleDot className="size-3 text-warning shrink-0 mt-0.5" />
+              <span>
+                <span className="font-medium">{f.label}</span>
+                {f.note ? ` — ${f.note}` : ""}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/** Live browser column — the scout, then the walkthrough run, drive this view. */
+function BrowserColumn({
+  streamUrl,
+  queued,
+}: {
+  streamUrl?: string;
+  queued?: boolean;
+}) {
+  return (
+    <div className="min-w-0">
+      <div className="lg:sticky lg:top-4 space-y-1.5">
+        <p className="flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+          <Monitor className="size-3" />
+          Live browser
+        </p>
+        {streamUrl ? (
+          <div className="rounded-md overflow-hidden border">
+            <BrowserViewer
+              streamUrl={streamUrl}
+              initialViewport={{ width: 1280, height: 720 }}
+              interactive={false}
+              hideControls
+            />
+          </div>
+        ) : queued ? (
+          <div className="flex aspect-video items-center justify-center gap-2 rounded-md border border-dashed text-[11px] text-muted-foreground">
+            <Loader2 className="size-3 animate-spin" />
+            Waiting for a browser from the pool&hellip;
+          </div>
+        ) : (
+          <div className="flex aspect-video items-center justify-center rounded-md border border-dashed px-4 text-center text-[11px] text-muted-foreground/70">
+            The live browser appears here while the agent is driving it.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function QuickstartPanel({
   repositoryId,
   enabled,
@@ -69,7 +157,7 @@ export function QuickstartPanel({
     dismiss,
   } = useQuickstart(repositoryId);
 
-  const [showCreds, setShowCreds] = useState(false);
+  const [showCreds, setShowCreds] = useState(true);
   const [appEmail, setAppEmail] = useState("");
   const [appPassword, setAppPassword] = useState("");
   const handleStart = () =>
@@ -104,7 +192,158 @@ export function QuickstartPanel({
   const authSetup = session?.metadata.authSetup;
   const streamUrl = session?.metadata.streamUrl;
   const queuedForBrowser = session?.metadata.queuedForBrowser;
+  const demoNotes = session?.metadata.demoNotes;
+  const usedEmail = session?.metadata.quickstartEmail;
   const failedStep = session?.steps.find((s) => s.status === "failed");
+
+  // The browser column is shown whenever a run is live or a stream is attached.
+  const showBrowserColumn = !!session && (isActive || !!streamUrl);
+
+  // Credentials block — open by default and always rendered (even mid-run, where
+  // it degrades to a read-only summary of the account the agent is using).
+  const credsBlock = (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={() => setShowCreds((v) => !v)}
+        className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <KeyRound className="size-3" />
+        {session ? "App login" : "Use my app login (optional)"}
+        <ChevronDown
+          className={`size-3 transition-transform ${showCreds ? "rotate-180" : ""}`}
+        />
+      </button>
+      {showCreds &&
+        (session ? (
+          <p className="text-[11px] text-muted-foreground pt-0.5">
+            {usedEmail ? (
+              <>
+                Account in use:{" "}
+                <span className="font-medium text-foreground">{usedEmail}</span>
+              </>
+            ) : (
+              "Using a throwaway demo account on your app."
+            )}
+          </p>
+        ) : (
+          <div className="space-y-2 pt-1">
+            <p className="text-[11px] text-muted-foreground">
+              QuickStart runs against your app&rsquo;s base URL. Provide a
+              working login to capture an authenticated walkthrough; leave blank
+              to register a throwaway demo account instead. Credentials stay on
+              your team and are never shown on the public share.
+            </p>
+            <Input
+              type="email"
+              autoComplete="off"
+              placeholder="you@yourapp.com"
+              aria-label="App login email"
+              value={appEmail}
+              onChange={(e) => setAppEmail(e.target.value)}
+              className="h-8 text-sm"
+            />
+            <Input
+              type="password"
+              autoComplete="off"
+              placeholder="App login password"
+              aria-label="App login password"
+              value={appPassword}
+              onChange={(e) => setAppPassword(e.target.value)}
+              className="h-8 text-sm"
+            />
+          </div>
+        ))}
+    </div>
+  );
+
+  const stepsList = session && (
+    <ol className="space-y-1.5">
+      {session.steps.map((step) => {
+        const label = STEP_LABELS[step.id] ?? step.label;
+        return (
+          <li key={step.id} className="flex items-start gap-2 text-sm">
+            <StepIcon status={step.status} />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span
+                  className={
+                    step.status === "pending" ? "text-muted-foreground/70" : ""
+                  }
+                >
+                  {label}
+                </span>
+                {step.id === "qs_scout_public" &&
+                  publicScout?.classification &&
+                  step.status === "completed" && (
+                    <Badge variant="secondary" className="text-[10px]">
+                      {publicScout.classification.replace(/_/g, " ")}
+                    </Badge>
+                  )}
+                {step.id === "qs_auth_setup" && step.status === "skipped" && (
+                  <span className="text-[11px] text-muted-foreground/70">
+                    not automatable
+                  </span>
+                )}
+                {step.id === "qs_auth_setup" &&
+                  authSetup?.captured === false &&
+                  step.status === "completed" && (
+                    <span className="text-[11px] text-warning">
+                      auth rejected
+                    </span>
+                  )}
+              </div>
+              {step.status === "failed" && step.error && (
+                <p className="text-[11px] text-destructive mt-0.5 line-clamp-3">
+                  {step.error}
+                </p>
+              )}
+              {step.id === "qs_auth_setup" &&
+                authSetup?.captured === false &&
+                authSetup?.failureReason && (
+                  <p className="text-[11px] text-warning/90 mt-0.5 line-clamp-3 break-words">
+                    {authSetup.failureReason}
+                  </p>
+                )}
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+
+  const leftColumn = session && (
+    <div className="space-y-3 min-w-0">
+      {stepsList}
+
+      {demoNotes && <NotesPanel notes={demoNotes} />}
+
+      {(buildId || walkthroughTestId) && (
+        <div className="flex flex-wrap items-center gap-2 pt-2 border-t">
+          {buildId && (
+            <Button size="sm" variant="outline" asChild>
+              <Link href={`/builds/${buildId}`}>Open build</Link>
+            </Button>
+          )}
+          {walkthroughTestId && (
+            <Button size="sm" variant="outline" asChild>
+              <Link href={`/tests/${walkthroughTestId}`}>Walkthrough test</Link>
+            </Button>
+          )}
+        </div>
+      )}
+
+      {failedStep && session.status === "failed" && (
+        <p className="text-xs text-muted-foreground">
+          Stopped at{" "}
+          <span className="font-medium">
+            {STEP_LABELS[failedStep.id] ?? failedStep.label}
+          </span>
+          . Dismiss and start again to retry.
+        </p>
+      )}
+    </div>
+  );
 
   return (
     <Card>
@@ -162,168 +401,21 @@ export function QuickstartPanel({
         </div>
       </CardHeader>
 
-      {!session && (
-        <CardContent className="pt-0 space-y-2">
-          <button
-            type="button"
-            onClick={() => setShowCreds((v) => !v)}
-            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
-          >
-            <KeyRound className="size-3" />
-            Use my app login (optional)
-            <ChevronDown
-              className={`size-3 transition-transform ${showCreds ? "rotate-180" : ""}`}
-            />
-          </button>
-          {showCreds && (
-            <div className="space-y-2 pt-1">
-              <p className="text-[11px] text-muted-foreground">
-                QuickStart runs against your app&rsquo;s base URL. Provide a
-                working login to capture an authenticated walkthrough; leave
-                blank to register a throwaway demo account instead. Credentials
-                stay on your team and are never shown on the public share.
-              </p>
-              <Input
-                type="email"
-                autoComplete="off"
-                placeholder="you@yourapp.com"
-                aria-label="App login email"
-                value={appEmail}
-                onChange={(e) => setAppEmail(e.target.value)}
-                className="h-8 text-sm"
-              />
-              <Input
-                type="password"
-                autoComplete="off"
-                placeholder="App login password"
-                aria-label="App login password"
-                value={appPassword}
-                onChange={(e) => setAppPassword(e.target.value)}
-                className="h-8 text-sm"
-              />
+      <CardContent className="pt-0 space-y-3">
+        {credsBlock}
+
+        {session &&
+          (showBrowserColumn ? (
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)]">
+              {leftColumn}
+              <BrowserColumn streamUrl={streamUrl} queued={queuedForBrowser} />
             </div>
-          )}
-        </CardContent>
-      )}
+          ) : (
+            leftColumn
+          ))}
 
-      {session && (
-        <CardContent className="pt-0 space-y-3">
-          <ol className="space-y-1.5">
-            {session.steps.map((step) => {
-              const label = STEP_LABELS[step.id] ?? step.label;
-              return (
-                <li key={step.id} className="flex items-start gap-2 text-sm">
-                  <StepIcon status={step.status} />
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <span
-                        className={
-                          step.status === "pending"
-                            ? "text-muted-foreground/70"
-                            : ""
-                        }
-                      >
-                        {label}
-                      </span>
-                      {step.id === "qs_scout_public" &&
-                        publicScout?.classification &&
-                        step.status === "completed" && (
-                          <Badge variant="secondary" className="text-[10px]">
-                            {publicScout.classification.replace(/_/g, " ")}
-                          </Badge>
-                        )}
-                      {step.id === "qs_auth_setup" &&
-                        step.status === "skipped" && (
-                          <span className="text-[11px] text-muted-foreground/70">
-                            not automatable
-                          </span>
-                        )}
-                      {step.id === "qs_auth_setup" &&
-                        authSetup?.captured === false &&
-                        step.status === "completed" && (
-                          <span className="text-[11px] text-warning">
-                            auth rejected
-                          </span>
-                        )}
-                    </div>
-                    {step.status === "failed" && step.error && (
-                      <p className="text-[11px] text-destructive mt-0.5 line-clamp-3">
-                        {step.error}
-                      </p>
-                    )}
-                    {step.id === "qs_auth_setup" &&
-                      authSetup?.captured === false &&
-                      authSetup?.failureReason && (
-                        <p className="text-[11px] text-warning/90 mt-0.5 line-clamp-3 break-words">
-                          {authSetup.failureReason}
-                        </p>
-                      )}
-                  </div>
-                </li>
-              );
-            })}
-          </ol>
-
-          {isActive && streamUrl && (
-            <div className="rounded-md overflow-hidden border">
-              <BrowserViewer
-                streamUrl={streamUrl}
-                initialViewport={{ width: 1280, height: 720 }}
-                interactive={false}
-                hideControls
-              />
-            </div>
-          )}
-          {isActive && !streamUrl && queuedForBrowser && (
-            <div className="flex items-center gap-2 rounded-md border border-dashed px-3 py-2 text-[11px] text-muted-foreground">
-              <Loader2 className="size-3 animate-spin" />
-              Waiting for a browser from the pool&hellip;
-            </div>
-          )}
-
-          {error && !session && (
-            <p className="text-xs text-destructive">{error}</p>
-          )}
-
-          {(buildId || walkthroughTestId) && (
-            <div className="flex flex-wrap items-center gap-2 pt-2 border-t">
-              {buildId && (
-                <Button size="sm" variant="outline" asChild>
-                  <Link href={`/builds/${buildId}`}>Open build</Link>
-                </Button>
-              )}
-              {walkthroughTestId && (
-                <Button size="sm" variant="outline" asChild>
-                  <Link href={`/tests/${walkthroughTestId}`}>
-                    Walkthrough test
-                  </Link>
-                </Button>
-              )}
-              {session.metadata.demoNotesId && (
-                <span className="text-[11px] text-muted-foreground">
-                  demo notes written
-                </span>
-              )}
-            </div>
-          )}
-
-          {failedStep && session.status === "failed" && (
-            <p className="text-xs text-muted-foreground">
-              Stopped at{" "}
-              <span className="font-medium">
-                {STEP_LABELS[failedStep.id] ?? failedStep.label}
-              </span>
-              . Dismiss and start again to retry.
-            </p>
-          )}
-        </CardContent>
-      )}
-
-      {!session && error && (
-        <CardContent className="pt-0">
-          <p className="text-xs text-destructive">{error}</p>
-        </CardContent>
-      )}
+        {error && <p className="text-xs text-destructive">{error}</p>}
+      </CardContent>
     </Card>
   );
 }

--- a/src/components/quickstart/quickstart-panel.tsx
+++ b/src/components/quickstart/quickstart-panel.tsx
@@ -174,12 +174,19 @@ function BrowserColumn({
           Live browser
         </p>
         {streamUrl ? (
-          <div className="rounded-md overflow-hidden border">
+          // `fit` scales the 1280×720 canvas down to the column width inside a
+          // fixed 16:9 box (matches the placeholders below — no layout shift
+          // when the stream attaches). Without it the canvas renders at native
+          // 1:1 inside `overflow-hidden`, so only the top-left corner showed.
+          <div className="overflow-hidden rounded-md border bg-muted/20">
             <BrowserViewer
               streamUrl={streamUrl}
               initialViewport={{ width: 1280, height: 720 }}
               interactive={false}
-              hideControls
+              fit
+              hideToolbar
+              hideStatusBar
+              className="aspect-video w-full"
             />
           </div>
         ) : queued ? (
@@ -454,7 +461,8 @@ export function QuickstartPanel({
           <span className="font-medium">
             {STEP_LABELS[failedStep.id] ?? failedStep.label}
           </span>
-          . Dismiss and start again to retry.
+          . Use <span className="font-medium">Retry</span> above to run again,
+          or dismiss.
         </p>
       )}
     </div>
@@ -499,6 +507,22 @@ export function QuickstartPanel({
                 Cancel
               </Button>
             )}
+            {session && isTerminal && session.status !== "completed" && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleStart}
+                disabled={loading || !repositoryId}
+                title="Dismiss this run and start a fresh one"
+              >
+                {loading ? (
+                  <Loader2 className="size-3.5 mr-1.5 animate-spin" />
+                ) : (
+                  <Rocket className="size-3.5 mr-1.5" />
+                )}
+                Retry
+              </Button>
+            )}
             {session && isTerminal && (
               <Button
                 size="sm"
@@ -514,17 +538,25 @@ export function QuickstartPanel({
       </CardHeader>
 
       <CardContent className="pt-0 space-y-3">
-        {credsBlock}
-
-        {session &&
-          (showBrowserColumn ? (
-            <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)]">
+        {showBrowserColumn ? (
+          // Unequal split: the live browser is the centerpiece while a run is
+          // active, so give it ~60% and the left side ~40%. The creds block
+          // moves into the left column so the browser shares the grid's first
+          // row and sits in-line with the TOP of the section, rather than being
+          // pushed down below a full-width creds block.
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]">
+            <div className="space-y-3 min-w-0">
+              {credsBlock}
               {leftColumn}
-              <BrowserColumn streamUrl={streamUrl} queued={queuedForBrowser} />
             </div>
-          ) : (
-            leftColumn
-          ))}
+            <BrowserColumn streamUrl={streamUrl} queued={queuedForBrowser} />
+          </div>
+        ) : (
+          <>
+            {credsBlock}
+            {leftColumn}
+          </>
+        )}
 
         {error && <p className="text-xs text-destructive">{error}</p>}
       </CardContent>

--- a/src/components/quickstart/quickstart-panel.tsx
+++ b/src/components/quickstart/quickstart-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import {
   Card,
@@ -28,6 +29,7 @@ import {
   ExternalLink,
 } from "lucide-react";
 import { toast } from "sonner";
+import { saveBranchBaseUrl } from "@/server/actions/environment";
 import { BrowserViewer } from "@/components/embedded-browser/browser-viewer-client";
 import {
   useQuickstart,
@@ -39,6 +41,10 @@ interface QuickstartPanelProps {
   repositoryId?: string | null;
   enabled: boolean;
   reason?: "no_team" | "not_early_adopter" | "no_base_url";
+  /** Repo's default branch — the key the QuickStart gate reads a base URL from.
+   *  When present, the no_base_url empty state offers inline URL entry instead
+   *  of sending the user off to the sidebar. */
+  defaultBranch?: string | null;
 }
 
 const STEP_LABELS: Record<string, string> = {
@@ -195,7 +201,9 @@ export function QuickstartPanel({
   repositoryId,
   enabled,
   reason,
+  defaultBranch,
 }: QuickstartPanelProps) {
+  const router = useRouter();
   const {
     session,
     loading,
@@ -210,8 +218,31 @@ export function QuickstartPanel({
   const [showCreds, setShowCreds] = useState(true);
   const [appEmail, setAppEmail] = useState("");
   const [appPassword, setAppPassword] = useState("");
+  const [baseUrlInput, setBaseUrlInput] = useState("");
+  const [savingBaseUrl, setSavingBaseUrl] = useState(false);
   const handleStart = () =>
     start(appEmail && appPassword ? { appEmail, appPassword } : undefined);
+
+  // Inline base-URL entry for the no_base_url empty state — saves to the repo's
+  // default-branch key (the one the gate reads) and refreshes so the server
+  // re-evaluates the gate and renders the live panel without a sidebar detour.
+  const canInlineBaseUrl = !!repositoryId && !!defaultBranch;
+  const saveBaseUrl = async () => {
+    if (!repositoryId || !defaultBranch) return;
+    let url = baseUrlInput.trim();
+    if (!url) return;
+    if (!/^https?:\/\//i.test(url)) url = `https://${url}`;
+    setSavingBaseUrl(true);
+    try {
+      await saveBranchBaseUrl(repositoryId, defaultBranch, url);
+      toast.success("Base URL saved — QuickStart unlocked");
+      router.refresh();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't save base URL");
+    } finally {
+      setSavingBaseUrl(false);
+    }
+  };
 
   if (!enabled) {
     // Only render the disabled hint when the team IS early-adopter but baseUrl is missing —
@@ -228,10 +259,43 @@ export function QuickstartPanel({
             </Badge>
           </CardTitle>
           <CardDescription>
-            Set a non-local base URL for this repo in the sidebar to enable the
-            QuickStart agent. localhost URLs are skipped.
+            {canInlineBaseUrl
+              ? "Point QuickStart at your app to generate a live walkthrough + shareable report. localhost URLs are skipped."
+              : "Set a non-local base URL for this repo in the sidebar to enable the QuickStart agent. localhost URLs are skipped."}
           </CardDescription>
         </CardHeader>
+        {canInlineBaseUrl && (
+          <CardContent className="pt-0">
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Input
+                type="url"
+                inputMode="url"
+                placeholder="your-app.com"
+                aria-label="App base URL"
+                value={baseUrlInput}
+                onChange={(e) => setBaseUrlInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") saveBaseUrl();
+                }}
+                disabled={savingBaseUrl}
+                className="h-9"
+              />
+              <Button
+                size="sm"
+                onClick={saveBaseUrl}
+                disabled={savingBaseUrl || !baseUrlInput.trim()}
+                className="shrink-0"
+              >
+                {savingBaseUrl ? (
+                  <Loader2 className="size-3.5 mr-1.5 animate-spin" />
+                ) : (
+                  <Rocket className="size-3.5 mr-1.5" />
+                )}
+                Save &amp; enable
+              </Button>
+            </div>
+          </CardContent>
+        )}
       </Card>
     );
   }

--- a/src/components/quickstart/quickstart-panel.tsx
+++ b/src/components/quickstart/quickstart-panel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import {
   Card,
@@ -10,6 +11,7 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import {
   Rocket,
   Loader2,
@@ -18,6 +20,8 @@ import {
   CircleDot,
   Circle,
   X,
+  ChevronDown,
+  KeyRound,
 } from "lucide-react";
 import { useQuickstart, type QuickstartStep } from "./use-quickstart";
 
@@ -63,6 +67,12 @@ export function QuickstartPanel({
     cancel,
     dismiss,
   } = useQuickstart(repositoryId);
+
+  const [showCreds, setShowCreds] = useState(false);
+  const [appEmail, setAppEmail] = useState("");
+  const [appPassword, setAppPassword] = useState("");
+  const handleStart = () =>
+    start(appEmail && appPassword ? { appEmail, appPassword } : undefined);
 
   if (!enabled) {
     // Only render the disabled hint when the team IS early-adopter but baseUrl is missing —
@@ -114,7 +124,7 @@ export function QuickstartPanel({
             {!session && (
               <Button
                 size="sm"
-                onClick={start}
+                onClick={handleStart}
                 disabled={loading || !repositoryId}
               >
                 {loading ? (
@@ -148,6 +158,50 @@ export function QuickstartPanel({
           </div>
         </div>
       </CardHeader>
+
+      {!session && (
+        <CardContent className="pt-0 space-y-2">
+          <button
+            type="button"
+            onClick={() => setShowCreds((v) => !v)}
+            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <KeyRound className="size-3" />
+            Use my app login (optional)
+            <ChevronDown
+              className={`size-3 transition-transform ${showCreds ? "rotate-180" : ""}`}
+            />
+          </button>
+          {showCreds && (
+            <div className="space-y-2 pt-1">
+              <p className="text-[11px] text-muted-foreground">
+                QuickStart runs against your app&rsquo;s base URL. Provide a
+                working login to capture an authenticated walkthrough; leave
+                blank to register a throwaway demo account instead. Credentials
+                stay on your team and are never shown on the public share.
+              </p>
+              <Input
+                type="email"
+                autoComplete="off"
+                placeholder="you@yourapp.com"
+                aria-label="App login email"
+                value={appEmail}
+                onChange={(e) => setAppEmail(e.target.value)}
+                className="h-8 text-sm"
+              />
+              <Input
+                type="password"
+                autoComplete="off"
+                placeholder="App login password"
+                aria-label="App login password"
+                value={appPassword}
+                onChange={(e) => setAppPassword(e.target.value)}
+                className="h-8 text-sm"
+              />
+            </div>
+          )}
+        </CardContent>
+      )}
 
       {session && (
         <CardContent className="pt-0 space-y-3">

--- a/src/components/quickstart/quickstart-panel.tsx
+++ b/src/components/quickstart/quickstart-panel.tsx
@@ -254,9 +254,6 @@ export function QuickstartPanel({
           <CardTitle className="flex items-center gap-2 text-base">
             <Rocket className="size-4 text-pink-600 dark:text-pink-400" />
             QuickStart
-            <Badge variant="outline" className="text-[10px]">
-              early adopter
-            </Badge>
           </CardTitle>
           <CardDescription>
             {canInlineBaseUrl
@@ -471,9 +468,6 @@ export function QuickstartPanel({
             <CardTitle className="flex items-center gap-2 text-base">
               <Rocket className="size-4 text-pink-600 dark:text-pink-400" />
               QuickStart
-              <Badge variant="outline" className="text-[10px]">
-                early adopter
-              </Badge>
             </CardTitle>
             <CardDescription>
               Spin up a 2-test demo (auth setup + app walkthrough) on this

--- a/src/components/quickstart/quickstart-panel.tsx
+++ b/src/components/quickstart/quickstart-panel.tsx
@@ -23,6 +23,7 @@ import {
   ChevronDown,
   KeyRound,
 } from "lucide-react";
+import { BrowserViewer } from "@/components/embedded-browser/browser-viewer-client";
 import { useQuickstart, type QuickstartStep } from "./use-quickstart";
 
 interface QuickstartPanelProps {
@@ -101,6 +102,8 @@ export function QuickstartPanel({
   const walkthroughTestId = session?.metadata.walkthroughTestId;
   const publicScout = session?.metadata.publicScout;
   const authSetup = session?.metadata.authSetup;
+  const streamUrl = session?.metadata.streamUrl;
+  const queuedForBrowser = session?.metadata.queuedForBrowser;
   const failedStep = session?.steps.find((s) => s.status === "failed");
 
   return (
@@ -260,6 +263,23 @@ export function QuickstartPanel({
               );
             })}
           </ol>
+
+          {isActive && streamUrl && (
+            <div className="rounded-md overflow-hidden border">
+              <BrowserViewer
+                streamUrl={streamUrl}
+                initialViewport={{ width: 1280, height: 720 }}
+                interactive={false}
+                hideControls
+              />
+            </div>
+          )}
+          {isActive && !streamUrl && queuedForBrowser && (
+            <div className="flex items-center gap-2 rounded-md border border-dashed px-3 py-2 text-[11px] text-muted-foreground">
+              <Loader2 className="size-3 animate-spin" />
+              Waiting for a browser from the pool&hellip;
+            </div>
+          )}
 
           {error && !session && (
             <p className="text-xs text-destructive">{error}</p>

--- a/src/components/quickstart/quickstart-panel.tsx
+++ b/src/components/quickstart/quickstart-panel.tsx
@@ -23,7 +23,11 @@ import {
   ChevronDown,
   KeyRound,
   Monitor,
+  Share2,
+  Copy,
+  ExternalLink,
 } from "lucide-react";
+import { toast } from "sonner";
 import { BrowserViewer } from "@/components/embedded-browser/browser-viewer-client";
 import {
   useQuickstart,
@@ -44,6 +48,9 @@ const STEP_LABELS: Record<string, string> = {
   qs_scout_authed: "Authed scout",
   qs_generate: "Generate walkthrough",
   qs_run_and_notes: "Run & notes",
+  qs_approve_baselines: "Approve baselines",
+  qs_rerun_after_approval: "Re-run for pairing",
+  qs_publish_share: "Publish share",
 };
 
 function StepIcon({ status }: { status: QuickstartStep["status"] }) {
@@ -98,6 +105,49 @@ function NotesPanel({
           ))}
         </ul>
       )}
+    </div>
+  );
+}
+
+/** Founder-facing share — the payoff. Surfaced prominently once the
+ *  qs_publish_share step writes the public /r/<slug> URL. */
+function ShareBlock({
+  shareUrl,
+  shareSlug,
+}: {
+  shareUrl: string;
+  shareSlug?: string;
+}) {
+  const pretty = shareSlug ? `/r/${shareSlug}` : shareUrl;
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      toast.success("Share link copied");
+    } catch {
+      toast.error("Couldn't copy — select and copy manually");
+    }
+  };
+  return (
+    <div className="rounded-md border border-pink-500/30 bg-pink-500/5 p-3 space-y-2">
+      <p className="flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wider text-pink-600 dark:text-pink-400">
+        <Share2 className="size-3" />
+        Founder share ready
+      </p>
+      <code className="block truncate rounded bg-background/60 px-2 py-1 text-[11px] text-foreground/90">
+        {pretty}
+      </code>
+      <div className="flex flex-wrap items-center gap-2">
+        <Button size="sm" asChild>
+          <a href={shareUrl} target="_blank" rel="noopener noreferrer">
+            <ExternalLink className="size-3.5 mr-1.5" />
+            Open report
+          </a>
+        </Button>
+        <Button size="sm" variant="outline" onClick={copy}>
+          <Copy className="size-3.5 mr-1.5" />
+          Copy link
+        </Button>
+      </div>
     </div>
   );
 }
@@ -193,6 +243,8 @@ export function QuickstartPanel({
   const streamUrl = session?.metadata.streamUrl;
   const queuedForBrowser = session?.metadata.queuedForBrowser;
   const demoNotes = session?.metadata.demoNotes;
+  const shareUrl = session?.metadata.shareUrl;
+  const shareSlug = session?.metadata.shareSlug;
   const usedEmail = session?.metadata.quickstartEmail;
   const failedStep = session?.steps.find((s) => s.status === "failed");
 
@@ -315,6 +367,8 @@ export function QuickstartPanel({
   const leftColumn = session && (
     <div className="space-y-3 min-w-0">
       {stepsList}
+
+      {shareUrl && <ShareBlock shareUrl={shareUrl} shareSlug={shareSlug} />}
 
       {demoNotes && <NotesPanel notes={demoNotes} />}
 

--- a/src/components/quickstart/quickstart-panel.tsx
+++ b/src/components/quickstart/quickstart-panel.tsx
@@ -3,30 +3,26 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import {
   Rocket,
   Loader2,
+  Check,
   CheckCircle2,
-  XCircle,
   CircleDot,
   Circle,
   X,
+  AlertTriangle,
   ChevronDown,
   KeyRound,
-  Monitor,
   Share2,
   Copy,
   ExternalLink,
+  Lock,
+  RotateCw,
+  Terminal,
 } from "lucide-react";
 import { toast } from "sonner";
 import { saveBranchBaseUrl } from "@/server/actions/environment";
@@ -41,6 +37,9 @@ interface QuickstartPanelProps {
   repositoryId?: string | null;
   enabled: boolean;
   reason?: "no_team" | "not_early_adopter" | "no_base_url";
+  /** Repo's resolved (non-local) base URL — surfaced in the header so the
+   *  founder sees exactly what the demo runs against. */
+  baseUrl?: string | null;
   /** Repo's default branch — the key the QuickStart gate reads a base URL from.
    *  When present, the no_base_url empty state offers inline URL entry instead
    *  of sending the user off to the sidebar. */
@@ -59,147 +58,156 @@ const STEP_LABELS: Record<string, string> = {
   qs_publish_share: "Publish share",
 };
 
-function StepIcon({ status }: { status: QuickstartStep["status"] }) {
-  if (status === "active")
-    return <Loader2 className="size-3.5 animate-spin text-info" />;
-  if (status === "completed")
-    return <CheckCircle2 className="size-3.5 text-success" />;
-  if (status === "failed")
-    return <XCircle className="size-3.5 text-destructive" />;
-  if (status === "skipped")
-    return <CircleDot className="size-3.5 text-muted-foreground/60" />;
-  return <Circle className="size-3.5 text-muted-foreground/40" />;
+/** Strip protocol + trailing slash for a compact host display. */
+function hostOf(url?: string | null): string | null {
+  if (!url) return null;
+  return url.replace(/^https?:\/\//i, "").replace(/\/+$/, "");
 }
 
-/** Founder-facing demo notes, rendered inline once the run writes them. */
-function NotesPanel({
+/** Small mono uppercase section label, used like the design's eyebrows. */
+function Eyebrow({
+  children,
+  className = "",
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={`font-mono text-[10.5px] font-medium uppercase tracking-[0.09em] text-muted-foreground ${className}`}
+    >
+      {children}
+    </span>
+  );
+}
+
+/** Pulsing "live" dot (info = agent working, destructive = live stream). */
+function LiveDot({ tone }: { tone: "info" | "destructive" }) {
+  const bg = tone === "info" ? "bg-info" : "bg-destructive";
+  return (
+    <span className="relative flex size-[7px]">
+      <span
+        className={`absolute inline-flex h-full w-full animate-ping rounded-full opacity-60 ${bg}`}
+      />
+      <span className={`relative inline-flex size-[7px] rounded-full ${bg}`} />
+    </span>
+  );
+}
+
+/** Circular pipeline step marker. */
+function StepCircle({ status }: { status: QuickstartStep["status"] }) {
+  const base =
+    "mt-0.5 flex size-[22px] shrink-0 items-center justify-center rounded-full";
+  if (status === "active")
+    return (
+      <span className={`${base} bg-info/15 text-info`}>
+        <Loader2 className="size-3 animate-spin" strokeWidth={3} />
+      </span>
+    );
+  if (status === "completed")
+    return (
+      <span className={`${base} bg-success/15 text-success`}>
+        <Check className="size-3" strokeWidth={3} />
+      </span>
+    );
+  if (status === "failed")
+    return (
+      <span className={`${base} bg-destructive/15 text-destructive`}>
+        <X className="size-3" strokeWidth={3} />
+      </span>
+    );
+  if (status === "skipped")
+    return (
+      <span className={`${base} bg-muted text-muted-foreground`}>
+        <CircleDot className="size-3" />
+      </span>
+    );
+  return (
+    <span className={`${base} bg-muted text-muted-foreground/50`}>
+      <Circle className="size-2.5" />
+    </span>
+  );
+}
+
+/** Browser-chrome frame (traffic lights + URL pill) wrapping live/preview content. */
+function Chrome({
+  url,
+  trailing,
+  children,
+}: {
+  url?: string | null;
+  trailing?: "reload" | "external";
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="overflow-hidden rounded-md border bg-card shadow-sm">
+      <div className="flex h-[38px] items-center gap-2.5 border-b bg-muted/60 px-3">
+        <div className="flex gap-1.5">
+          <span className="size-2.5 rounded-full bg-[#E96A5E]" />
+          <span className="size-2.5 rounded-full bg-[#E0A93B]" />
+          <span className="size-2.5 rounded-full bg-[#5FB98E]" />
+        </div>
+        <div className="flex h-6 flex-1 items-center gap-1.5 overflow-hidden rounded-full border bg-card px-3 font-mono text-[11px] text-muted-foreground">
+          <Lock className="size-3 shrink-0" />
+          <span className="truncate">{url ?? "—"}</span>
+        </div>
+        {trailing === "reload" && (
+          <RotateCw className="size-3.5 shrink-0 text-muted-foreground" />
+        )}
+        {trailing === "external" && (
+          <ExternalLink className="size-3.5 shrink-0 text-muted-foreground" />
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/** Founder-facing demo notes — the qualitative report body. */
+function NotesBody({
   notes,
 }: {
   notes: NonNullable<QuickstartSessionView["metadata"]["demoNotes"]>;
 }) {
   return (
-    <div className="rounded-md border bg-muted/30 p-3 space-y-2">
-      <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-        Demo notes
-      </p>
+    <div className="space-y-3 p-3.5">
       {notes.uxSummary && (
-        <p className="text-xs text-foreground/90">{notes.uxSummary}</p>
+        <p className="text-xs leading-relaxed text-foreground/90">
+          {notes.uxSummary}
+        </p>
       )}
       {notes.highlights.length > 0 && (
-        <ul className="space-y-1">
-          {notes.highlights.slice(0, 4).map((h, i) => (
-            <li key={`h-${i}`} className="flex gap-1.5 text-[11px]">
-              <CheckCircle2 className="size-3 text-success shrink-0 mt-0.5" />
-              <span>
-                <span className="font-medium">{h.label}</span>
-                {h.note ? ` — ${h.note}` : ""}
-              </span>
-            </li>
-          ))}
-        </ul>
+        <div className="space-y-1.5">
+          <Eyebrow className="text-[9px]">Highlights</Eyebrow>
+          <ul className="space-y-1">
+            {notes.highlights.slice(0, 4).map((h, i) => (
+              <li key={`h-${i}`} className="flex gap-1.5 text-[11px]">
+                <CheckCircle2 className="mt-0.5 size-3 shrink-0 text-success" />
+                <span>
+                  <span className="font-medium">{h.label}</span>
+                  {h.note ? ` — ${h.note}` : ""}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
       {notes.frictionPoints.length > 0 && (
-        <ul className="space-y-1">
-          {notes.frictionPoints.slice(0, 3).map((f, i) => (
-            <li key={`f-${i}`} className="flex gap-1.5 text-[11px]">
-              <CircleDot className="size-3 text-warning shrink-0 mt-0.5" />
-              <span>
-                <span className="font-medium">{f.label}</span>
-                {f.note ? ` — ${f.note}` : ""}
-              </span>
-            </li>
-          ))}
-        </ul>
+        <div className="space-y-1.5">
+          <Eyebrow className="text-[9px]">Friction</Eyebrow>
+          <ul className="space-y-1">
+            {notes.frictionPoints.slice(0, 3).map((f, i) => (
+              <li key={`f-${i}`} className="flex gap-1.5 text-[11px]">
+                <CircleDot className="mt-0.5 size-3 shrink-0 text-warning" />
+                <span>
+                  <span className="font-medium">{f.label}</span>
+                  {f.note ? ` — ${f.note}` : ""}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
-    </div>
-  );
-}
-
-/** Founder-facing share — the payoff. Surfaced prominently once the
- *  qs_publish_share step writes the public /r/<slug> URL. */
-function ShareBlock({
-  shareUrl,
-  shareSlug,
-}: {
-  shareUrl: string;
-  shareSlug?: string;
-}) {
-  const pretty = shareSlug ? `/r/${shareSlug}` : shareUrl;
-  const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(shareUrl);
-      toast.success("Share link copied");
-    } catch {
-      toast.error("Couldn't copy — select and copy manually");
-    }
-  };
-  return (
-    <div className="rounded-md border border-pink-500/30 bg-pink-500/5 p-3 space-y-2">
-      <p className="flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wider text-pink-600 dark:text-pink-400">
-        <Share2 className="size-3" />
-        Founder share ready
-      </p>
-      <code className="block truncate rounded bg-background/60 px-2 py-1 text-[11px] text-foreground/90">
-        {pretty}
-      </code>
-      <div className="flex flex-wrap items-center gap-2">
-        <Button size="sm" asChild>
-          <a href={shareUrl} target="_blank" rel="noopener noreferrer">
-            <ExternalLink className="size-3.5 mr-1.5" />
-            Open report
-          </a>
-        </Button>
-        <Button size="sm" variant="outline" onClick={copy}>
-          <Copy className="size-3.5 mr-1.5" />
-          Copy link
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-/** Live browser column — the scout, then the walkthrough run, drive this view. */
-function BrowserColumn({
-  streamUrl,
-  queued,
-}: {
-  streamUrl?: string;
-  queued?: boolean;
-}) {
-  return (
-    <div className="min-w-0">
-      <div className="lg:sticky lg:top-4 space-y-1.5">
-        <p className="flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-          <Monitor className="size-3" />
-          Live browser
-        </p>
-        {streamUrl ? (
-          // `fit` scales the 1280×720 canvas down to the column width inside a
-          // fixed 16:9 box (matches the placeholders below — no layout shift
-          // when the stream attaches). Without it the canvas renders at native
-          // 1:1 inside `overflow-hidden`, so only the top-left corner showed.
-          <div className="overflow-hidden rounded-md border bg-muted/20">
-            <BrowserViewer
-              streamUrl={streamUrl}
-              initialViewport={{ width: 1280, height: 720 }}
-              interactive={false}
-              fit
-              hideToolbar
-              hideStatusBar
-              className="aspect-video w-full"
-            />
-          </div>
-        ) : queued ? (
-          <div className="flex aspect-video items-center justify-center gap-2 rounded-md border border-dashed text-[11px] text-muted-foreground">
-            <Loader2 className="size-3 animate-spin" />
-            Waiting for a browser from the pool&hellip;
-          </div>
-        ) : (
-          <div className="flex aspect-video items-center justify-center rounded-md border border-dashed px-4 text-center text-[11px] text-muted-foreground/70">
-            The live browser appears here while the agent is driving it.
-          </div>
-        )}
-      </div>
     </div>
   );
 }
@@ -208,6 +216,7 @@ export function QuickstartPanel({
   repositoryId,
   enabled,
   reason,
+  baseUrl,
   defaultBranch,
 }: QuickstartPanelProps) {
   const router = useRouter();
@@ -222,7 +231,7 @@ export function QuickstartPanel({
     dismiss,
   } = useQuickstart(repositoryId);
 
-  const [showCreds, setShowCreds] = useState(true);
+  const [showCreds, setShowCreds] = useState(false);
   const [appEmail, setAppEmail] = useState("");
   const [appPassword, setAppPassword] = useState("");
   const [baseUrlInput, setBaseUrlInput] = useState("");
@@ -251,59 +260,62 @@ export function QuickstartPanel({
     }
   };
 
+  const host = hostOf(baseUrl);
+
   if (!enabled) {
     // Only render the disabled hint when the team IS early-adopter but baseUrl is missing —
     // otherwise hide entirely to keep the home page uncluttered.
     if (reason !== "no_base_url") return null;
     return (
-      <Card className="border-dashed">
-        <CardHeader className="pb-2">
-          <CardTitle className="flex items-center gap-2 text-base">
-            <Rocket className="size-4 text-pink-600 dark:text-pink-400" />
-            QuickStart
-          </CardTitle>
-          <CardDescription>
-            {canInlineBaseUrl
-              ? "Point QuickStart at your app to generate a live walkthrough + shareable report. localhost URLs are skipped."
-              : "Set a non-local base URL for this repo in the sidebar to enable the QuickStart agent. localhost URLs are skipped."}
-          </CardDescription>
-        </CardHeader>
+      <Card className="gap-0 overflow-hidden border-dashed py-0">
+        <div className="flex items-center gap-4 p-5">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-md bg-foreground">
+            <Rocket className="size-5 text-background" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-base font-semibold">QuickStart</div>
+            <p className="mt-0.5 text-sm text-muted-foreground">
+              {canInlineBaseUrl
+                ? "Point QuickStart at your app to generate a live walkthrough + shareable report. localhost URLs are skipped."
+                : "Set a non-local base URL for this repo in the sidebar to enable the QuickStart agent. localhost URLs are skipped."}
+            </p>
+          </div>
+        </div>
         {canInlineBaseUrl && (
-          <CardContent className="pt-0">
-            <div className="flex flex-col gap-2 sm:flex-row">
-              <Input
-                type="url"
-                inputMode="url"
-                placeholder="your-app.com"
-                aria-label="App base URL"
-                value={baseUrlInput}
-                onChange={(e) => setBaseUrlInput(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") saveBaseUrl();
-                }}
-                disabled={savingBaseUrl}
-                className="h-9"
-              />
-              <Button
-                size="sm"
-                onClick={saveBaseUrl}
-                disabled={savingBaseUrl || !baseUrlInput.trim()}
-                className="shrink-0"
-              >
-                {savingBaseUrl ? (
-                  <Loader2 className="size-3.5 mr-1.5 animate-spin" />
-                ) : (
-                  <Rocket className="size-3.5 mr-1.5" />
-                )}
-                Save &amp; enable
-              </Button>
-            </div>
-          </CardContent>
+          <div className="flex flex-col gap-2 border-t bg-muted/20 p-4 sm:flex-row">
+            <Input
+              type="url"
+              inputMode="url"
+              placeholder="your-app.com"
+              aria-label="App base URL"
+              value={baseUrlInput}
+              onChange={(e) => setBaseUrlInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") saveBaseUrl();
+              }}
+              disabled={savingBaseUrl}
+              className="h-9"
+            />
+            <Button
+              size="sm"
+              onClick={saveBaseUrl}
+              disabled={savingBaseUrl || !baseUrlInput.trim()}
+              className="h-9 shrink-0"
+            >
+              {savingBaseUrl ? (
+                <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+              ) : (
+                <Rocket className="mr-1.5 size-3.5" />
+              )}
+              Save &amp; enable
+            </Button>
+          </div>
         )}
       </Card>
     );
   }
 
+  const status = session?.status;
   const buildId = session?.metadata.buildId;
   const walkthroughTestId = session?.metadata.walkthroughTestId;
   const publicScout = session?.metadata.publicScout;
@@ -315,251 +327,477 @@ export function QuickstartPanel({
   const shareSlug = session?.metadata.shareSlug;
   const usedEmail = session?.metadata.quickstartEmail;
   const failedStep = session?.steps.find((s) => s.status === "failed");
+  const activeStep = session?.steps.find((s) => s.status === "active");
 
-  // The browser column is shown whenever a run is live or a stream is attached.
-  const showBrowserColumn = !!session && (isActive || !!streamUrl);
+  // Pipeline progress counters.
+  const totalSteps = session?.steps.length ?? 0;
+  const doneSteps =
+    session?.steps.filter(
+      (s) => s.status === "completed" || s.status === "skipped",
+    ).length ?? 0;
+  const activeIdx =
+    session?.steps.findIndex((s) => s.status === "active") ?? -1;
+  const stepNum = activeIdx >= 0 ? activeIdx + 1 : doneSteps;
 
-  // Credentials block — open by default and always rendered (even mid-run, where
-  // it degrades to a read-only summary of the account the agent is using).
-  const credsBlock = (
-    <div className="space-y-2">
-      <button
-        type="button"
-        onClick={() => setShowCreds((v) => !v)}
-        className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
-      >
-        <KeyRound className="size-3" />
-        {session ? "App login" : "Use my app login (optional)"}
-        <ChevronDown
-          className={`size-3 transition-transform ${showCreds ? "rotate-180" : ""}`}
-        />
-      </button>
-      {showCreds &&
-        (session ? (
-          <p className="text-[11px] text-muted-foreground pt-0.5">
-            {usedEmail ? (
-              <>
-                Account in use:{" "}
-                <span className="font-medium text-foreground">{usedEmail}</span>
-              </>
-            ) : (
-              "Using a throwaway demo account on your app."
-            )}
-          </p>
-        ) : (
-          <div className="space-y-2 pt-1">
-            <p className="text-[11px] text-muted-foreground">
-              QuickStart runs against your app&rsquo;s base URL. Provide a
-              working login to capture an authenticated walkthrough; leave blank
-              to register a throwaway demo account instead. Credentials stay on
-              your team and are never shown on the public share.
-            </p>
-            <Input
-              type="email"
-              autoComplete="off"
-              placeholder="you@yourapp.com"
-              aria-label="App login email"
-              value={appEmail}
-              onChange={(e) => setAppEmail(e.target.value)}
-              className="h-8 text-sm"
-            />
-            <Input
-              type="password"
-              autoComplete="off"
-              placeholder="App login password"
-              aria-label="App login password"
-              value={appPassword}
-              onChange={(e) => setAppPassword(e.target.value)}
-              className="h-8 text-sm"
-            />
-          </div>
-        ))}
-    </div>
+  // Right column shows the live browser whenever a run is live or a stream is
+  // attached; otherwise the report preview (terminal) or a failure card.
+  const showLive = !!session && (isActive || !!streamUrl);
+
+  const copyShare = async () => {
+    if (!shareUrl) return;
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      toast.success("Share link copied");
+    } catch {
+      toast.error("Couldn't copy — select and copy manually");
+    }
+  };
+
+  // ── Header bits ──────────────────────────────────────────────────────────
+  const tileClass =
+    status === "completed"
+      ? "bg-primary"
+      : status === "failed"
+        ? "bg-destructive"
+        : "bg-foreground";
+  const TileIcon =
+    status === "completed"
+      ? Check
+      : status === "failed"
+        ? AlertTriangle
+        : Rocket;
+
+  const statusPill = session && (
+    <>
+      {isActive && (
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-info/12 px-2.5 py-1 text-[11.5px] font-semibold text-info">
+          <LiveDot tone="info" />
+          Agent working · step {stepNum} of {totalSteps}
+        </span>
+      )}
+      {status === "completed" && (
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-primary/12 px-2.5 py-1 text-[11.5px] font-semibold text-success">
+          <CheckCircle2 className="size-3" />
+          Demo ready · {doneSteps} of {totalSteps}
+        </span>
+      )}
+      {status === "failed" && (
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-destructive/12 px-2.5 py-1 text-[11.5px] font-semibold text-destructive">
+          <AlertTriangle className="size-3" />
+          Stopped · step {Math.max(stepNum, 1)} of {totalSteps}
+        </span>
+      )}
+      {status === "cancelled" && (
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-muted px-2.5 py-1 text-[11.5px] font-semibold text-muted-foreground">
+          Cancelled
+        </span>
+      )}
+    </>
   );
 
-  const stepsList = session && (
-    <ol className="space-y-1.5">
-      {session.steps.map((step) => {
-        const label = STEP_LABELS[step.id] ?? step.label;
-        return (
-          <li key={step.id} className="flex items-start gap-2 text-sm">
-            <StepIcon status={step.status} />
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-2">
-                <span
-                  className={
-                    step.status === "pending" ? "text-muted-foreground/70" : ""
-                  }
-                >
-                  {label}
-                </span>
-                {step.id === "qs_scout_public" &&
-                  publicScout?.classification &&
-                  step.status === "completed" && (
-                    <Badge variant="secondary" className="text-[10px]">
-                      {publicScout.classification.replace(/_/g, " ")}
-                    </Badge>
-                  )}
-                {step.id === "qs_auth_setup" && step.status === "skipped" && (
-                  <span className="text-[11px] text-muted-foreground/70">
-                    not automatable
+  const subtitle = (() => {
+    const target = host ? (
+      <span className="font-mono text-xs text-foreground">{host}</span>
+    ) : (
+      "your app's base URL"
+    );
+    if (status === "completed")
+      return <>2-test demo built on {target} — pipeline complete.</>;
+    if (status === "failed")
+      return <>Run stopped — see the pipeline below for where it stalled.</>;
+    if (isActive)
+      return (
+        <>
+          Spinning up a 2-test demo on {target} — auth setup, walkthrough, video
+          &amp; notes.
+        </>
+      );
+    return (
+      <>
+        Spin up a 2-test demo on {target} — auth setup, walkthrough, video &amp;
+        notes.
+      </>
+    );
+  })();
+
+  // ── Pipeline column ──────────────────────────────────────────────────────
+  const pipelineColumn = session && (
+    <div className="min-w-0 border-b bg-muted/20 p-5 lg:border-b-0 lg:border-r">
+      <div className="mb-1.5 flex items-center justify-between">
+        <Eyebrow>Pipeline</Eyebrow>
+        <Eyebrow
+          className={
+            status === "completed" ? "text-success" : "text-foreground/40"
+          }
+        >
+          {doneSteps} / {totalSteps}
+        </Eyebrow>
+      </div>
+      <ol>
+        {session.steps.map((step) => {
+          const label = STEP_LABELS[step.id] ?? step.label;
+          const pending = step.status === "pending";
+          return (
+            <li key={step.id} className="flex items-start gap-3 py-[7px]">
+              <StepCircle status={step.status} />
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span
+                    className={
+                      pending
+                        ? "text-[13.5px] text-muted-foreground/70"
+                        : step.status === "active"
+                          ? "text-[13.5px] font-medium text-info"
+                          : "text-[13.5px] font-medium text-foreground"
+                    }
+                  >
+                    {label}
                   </span>
+                  {step.id === "qs_scout_public" &&
+                    publicScout?.classification &&
+                    step.status === "completed" && (
+                      <span className="inline-flex items-center rounded-full bg-muted px-1.5 py-px font-mono text-[10px] text-muted-foreground">
+                        {publicScout.classification.replace(/_/g, " ")}
+                      </span>
+                    )}
+                  {step.id === "qs_auth_setup" && step.status === "skipped" && (
+                    <span className="text-[11px] text-muted-foreground/70">
+                      not automatable
+                    </span>
+                  )}
+                  {step.id === "qs_auth_setup" &&
+                    authSetup?.captured === false &&
+                    step.status === "completed" && (
+                      <span className="text-[11px] text-warning">
+                        auth rejected
+                      </span>
+                    )}
+                </div>
+                {step.status === "active" && step.id === "qs_auth_setup" && (
+                  <div className="mt-0.5 text-xs leading-snug text-muted-foreground">
+                    Filling credentials &amp; submitting login form…
+                  </div>
+                )}
+                {step.status === "failed" && step.error && (
+                  <p className="mt-0.5 line-clamp-3 text-[11px] text-destructive">
+                    {step.error}
+                  </p>
                 )}
                 {step.id === "qs_auth_setup" &&
                   authSetup?.captured === false &&
-                  step.status === "completed" && (
-                    <span className="text-[11px] text-warning">
-                      auth rejected
-                    </span>
+                  authSetup?.failureReason && (
+                    <p className="mt-0.5 line-clamp-3 break-words text-[11px] text-warning/90">
+                      {authSetup.failureReason}
+                    </p>
                   )}
               </div>
-              {step.status === "failed" && step.error && (
-                <p className="text-[11px] text-destructive mt-0.5 line-clamp-3">
-                  {step.error}
-                </p>
-              )}
-              {step.id === "qs_auth_setup" &&
-                authSetup?.captured === false &&
-                authSetup?.failureReason && (
-                  <p className="text-[11px] text-warning/90 mt-0.5 line-clamp-3 break-words">
-                    {authSetup.failureReason}
-                  </p>
-                )}
-            </div>
-          </li>
-        );
-      })}
-    </ol>
-  );
-
-  const leftColumn = session && (
-    <div className="space-y-3 min-w-0">
-      {stepsList}
-
-      {shareUrl && <ShareBlock shareUrl={shareUrl} shareSlug={shareSlug} />}
-
-      {demoNotes && <NotesPanel notes={demoNotes} />}
-
-      {(buildId || walkthroughTestId) && (
-        <div className="flex flex-wrap items-center gap-2 pt-2 border-t">
-          {buildId && (
-            <Button size="sm" variant="outline" asChild>
-              <Link href={`/builds/${buildId}`}>Open build</Link>
-            </Button>
-          )}
-          {walkthroughTestId && (
-            <Button size="sm" variant="outline" asChild>
-              <Link href={`/tests/${walkthroughTestId}`}>Walkthrough test</Link>
-            </Button>
-          )}
+            </li>
+          );
+        })}
+      </ol>
+      {usedEmail && (
+        <div className="mt-3 truncate border-t pt-3 font-mono text-[10px] text-muted-foreground">
+          as {usedEmail}
         </div>
-      )}
-
-      {failedStep && session.status === "failed" && (
-        <p className="text-xs text-muted-foreground">
-          Stopped at{" "}
-          <span className="font-medium">
-            {STEP_LABELS[failedStep.id] ?? failedStep.label}
-          </span>
-          . Use <span className="font-medium">Retry</span> above to run again,
-          or dismiss.
-        </p>
       )}
     </div>
   );
 
-  return (
-    <Card>
-      <CardHeader className="pb-3">
-        <div className="flex items-start justify-between gap-3">
-          <div className="space-y-1">
-            <CardTitle className="flex items-center gap-2 text-base">
-              <Rocket className="size-4 text-pink-600 dark:text-pink-400" />
-              QuickStart
-            </CardTitle>
-            <CardDescription>
-              Spin up a 2-test demo (auth setup + app walkthrough) on this
-              repo&rsquo;s base URL, run with video, write demo notes.
-            </CardDescription>
+  // ── Content column (live browser / report preview / failure) ─────────────
+  const contentColumn = session && (
+    <div className="flex min-w-0 flex-col gap-3 bg-muted/40 p-5">
+      {showLive ? (
+        <>
+          <div className="flex items-center justify-between">
+            <Eyebrow>Live browser stream</Eyebrow>
+            <span className="inline-flex items-center gap-1.5 font-mono text-[10.5px] font-semibold uppercase tracking-[0.06em] text-destructive">
+              <LiveDot tone="destructive" />
+              Live
+            </span>
           </div>
-          <div className="flex items-center gap-2 shrink-0">
-            {!session && (
-              <Button
-                size="sm"
-                onClick={handleStart}
-                disabled={loading || !repositoryId}
-              >
-                {loading ? (
-                  <Loader2 className="size-3.5 mr-1.5 animate-spin" />
-                ) : (
-                  <Rocket className="size-3.5 mr-1.5" />
-                )}
-                Start QuickStart
-              </Button>
+          <Chrome url={host} trailing="reload">
+            {streamUrl ? (
+              // `fit` scales the 1280×720 canvas to the column width inside a
+              // fixed 16:9 box — no layout shift vs. the placeholder.
+              <BrowserViewer
+                streamUrl={streamUrl}
+                initialViewport={{ width: 1280, height: 720 }}
+                interactive={false}
+                fit
+                hideToolbar
+                hideStatusBar
+                className="aspect-video w-full"
+              />
+            ) : queuedForBrowser ? (
+              <div className="flex aspect-video items-center justify-center gap-2 text-[11px] text-muted-foreground">
+                <Loader2 className="size-3 animate-spin" />
+                Waiting for a browser from the pool…
+              </div>
+            ) : (
+              <div className="flex aspect-video items-center justify-center px-4 text-center text-[11px] text-muted-foreground/70">
+                The live browser appears here while the agent is driving it.
+              </div>
             )}
-            {session && isActive && (
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={cancel}
-                disabled={loading}
-              >
-                Cancel
-              </Button>
+          </Chrome>
+          {activeStep && (
+            <div className="flex items-center gap-2 font-mono text-[11px] text-muted-foreground">
+              <Terminal className="size-3 shrink-0" />↳{" "}
+              {STEP_LABELS[activeStep.id] ?? activeStep.label}…
+            </div>
+          )}
+        </>
+      ) : demoNotes ? (
+        <>
+          <Eyebrow>Report preview</Eyebrow>
+          <Chrome
+            url={shareSlug ? `${host ?? "lastest.cloud"}/r/${shareSlug}` : host}
+            trailing="external"
+          >
+            <div className="max-h-[360px] overflow-auto">
+              <NotesBody notes={demoNotes} />
+            </div>
+          </Chrome>
+          {(buildId || walkthroughTestId) && (
+            <div className="flex flex-wrap items-center gap-2">
+              {buildId && (
+                <Button size="sm" variant="outline" asChild>
+                  <Link href={`/builds/${buildId}`}>Open build</Link>
+                </Button>
+              )}
+              {walkthroughTestId && (
+                <Button size="sm" variant="outline" asChild>
+                  <Link href={`/tests/${walkthroughTestId}`}>
+                    Walkthrough test
+                  </Link>
+                </Button>
+              )}
+            </div>
+          )}
+        </>
+      ) : status === "failed" ? (
+        <>
+          <Eyebrow>What happened</Eyebrow>
+          <div className="rounded-md border border-destructive/30 bg-destructive/5 p-4">
+            <div className="flex items-center gap-2 text-sm font-medium text-destructive">
+              <AlertTriangle className="size-4" />
+              Stopped at{" "}
+              {failedStep
+                ? (STEP_LABELS[failedStep.id] ?? failedStep.label)
+                : "an early step"}
+            </div>
+            {failedStep?.error && (
+              <p className="mt-2 text-xs leading-relaxed text-foreground/80">
+                {failedStep.error}
+              </p>
             )}
-            {session && isTerminal && session.status !== "completed" && (
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={handleStart}
-                disabled={loading || !repositoryId}
-                title="Dismiss this run and start a fresh one"
-              >
-                {loading ? (
-                  <Loader2 className="size-3.5 mr-1.5 animate-spin" />
-                ) : (
-                  <Rocket className="size-3.5 mr-1.5" />
-                )}
-                Retry
-              </Button>
-            )}
-            {session && isTerminal && (
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={dismiss}
-                title="Dismiss"
-              >
-                <X className="size-3.5" />
-              </Button>
-            )}
+            <p className="mt-3 text-xs text-muted-foreground">
+              Use <span className="font-medium">Retry</span> above to run again,
+              or dismiss.
+            </p>
+          </div>
+          {(buildId || walkthroughTestId) && (
+            <div className="flex flex-wrap items-center gap-2">
+              {buildId && (
+                <Button size="sm" variant="outline" asChild>
+                  <Link href={`/builds/${buildId}`}>Open build</Link>
+                </Button>
+              )}
+              {walkthroughTestId && (
+                <Button size="sm" variant="outline" asChild>
+                  <Link href={`/tests/${walkthroughTestId}`}>
+                    Walkthrough test
+                  </Link>
+                </Button>
+              )}
+            </div>
+          )}
+        </>
+      ) : (
+        <>
+          <Eyebrow>Report preview</Eyebrow>
+          <div className="flex aspect-video items-center justify-center rounded-md border border-dashed text-center text-[11px] text-muted-foreground/70">
+            The run finished — open the build for full results.
+          </div>
+        </>
+      )}
+    </div>
+  );
+
+  // ── Footer ───────────────────────────────────────────────────────────────
+  const footer = session && (
+    <>
+      {shareUrl ? (
+        <div className="flex flex-wrap items-center gap-4 border-t bg-destructive/[0.03] p-4">
+          <div className="min-w-0 flex-1">
+            <Eyebrow className="flex items-center gap-1.5 text-destructive">
+              <Share2 className="size-3" />
+              Founder share ready
+            </Eyebrow>
+            <div className="mt-1.5 truncate font-mono text-xs text-foreground/80">
+              {shareSlug
+                ? `${host ?? "lastest.cloud"}/r/${shareSlug}`
+                : shareUrl}
+            </div>
+          </div>
+          <Button size="sm" variant="outline" onClick={copyShare}>
+            <Copy className="mr-1.5 size-3.5" />
+            Copy link
+          </Button>
+          <Button size="sm" asChild>
+            <a href={shareUrl} target="_blank" rel="noopener noreferrer">
+              <ExternalLink className="mr-1.5 size-3.5" />
+              Open report
+            </a>
+          </Button>
+        </div>
+      ) : isActive ? (
+        <div className="flex items-center gap-3 border-t bg-muted/20 p-4">
+          <Share2 className="size-4 shrink-0 text-muted-foreground/50" />
+          <span className="text-[12.5px] text-muted-foreground">
+            Your founder share link &amp; report preview will appear here when
+            the run finishes.
+          </span>
+          <div className="flex-1" />
+          <div className="h-1.5 w-40 animate-pulse rounded-full bg-muted-foreground/20" />
+        </div>
+      ) : null}
+    </>
+  );
+
+  return (
+    <Card className="gap-0 overflow-hidden py-0">
+      {/* Header */}
+      <div className="flex items-center gap-4 border-b p-5">
+        <div
+          className={`flex size-[42px] shrink-0 items-center justify-center rounded-md ${tileClass}`}
+        >
+          <TileIcon
+            className="size-5 text-background"
+            strokeWidth={status === "completed" ? 3 : 2}
+          />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2.5">
+            <span className="text-[17px] font-semibold text-foreground">
+              QuickStart
+            </span>
+            {statusPill}
+          </div>
+          <div className="mt-0.5 text-[13px] text-muted-foreground">
+            {subtitle}
           </div>
         </div>
-      </CardHeader>
+        <div className="flex shrink-0 items-center gap-2">
+          {!session && (
+            <Button
+              size="sm"
+              onClick={handleStart}
+              disabled={loading || !repositoryId}
+            >
+              {loading ? (
+                <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+              ) : (
+                <Rocket className="mr-1.5 size-3.5" />
+              )}
+              Start QuickStart
+            </Button>
+          )}
+          {session && isActive && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={cancel}
+              disabled={loading}
+            >
+              Cancel
+            </Button>
+          )}
+          {session && isTerminal && status !== "completed" && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleStart}
+              disabled={loading || !repositoryId}
+              title="Dismiss this run and start a fresh one"
+            >
+              {loading ? (
+                <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+              ) : (
+                <Rocket className="mr-1.5 size-3.5" />
+              )}
+              Retry
+            </Button>
+          )}
+          {session && isTerminal && (
+            <Button
+              size="icon"
+              variant="ghost"
+              onClick={dismiss}
+              title="Dismiss"
+              className="size-8"
+            >
+              <X className="size-4" />
+            </Button>
+          )}
+        </div>
+      </div>
 
-      <CardContent className="pt-0 space-y-3">
-        {showBrowserColumn ? (
-          // Unequal split: the live browser is the centerpiece while a run is
-          // active, so give it ~60% and the left side ~40%. The creds block
-          // moves into the left column so the browser shares the grid's first
-          // row and sits in-line with the TOP of the section, rather than being
-          // pushed down below a full-width creds block.
-          <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]">
-            <div className="space-y-3 min-w-0">
-              {credsBlock}
-              {leftColumn}
+      {/* Body */}
+      {session ? (
+        <div className="grid lg:grid-cols-[340px_minmax(0,1fr)]">
+          {pipelineColumn}
+          {contentColumn}
+        </div>
+      ) : (
+        // Pre-run: optional app-login config.
+        <div className="space-y-2 p-5">
+          <button
+            type="button"
+            onClick={() => setShowCreds((v) => !v)}
+            className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <KeyRound className="size-3" />
+            Use my app login (optional)
+            <ChevronDown
+              className={`size-3 transition-transform ${showCreds ? "rotate-180" : ""}`}
+            />
+          </button>
+          {showCreds && (
+            <div className="space-y-2 pt-1">
+              <p className="text-[11px] text-muted-foreground">
+                QuickStart runs against your app&rsquo;s base URL. Provide a
+                working login to capture an authenticated walkthrough; leave
+                blank to register a throwaway demo account instead. Credentials
+                stay on your team and are never shown on the public share.
+              </p>
+              <Input
+                type="email"
+                autoComplete="off"
+                placeholder="you@yourapp.com"
+                aria-label="App login email"
+                value={appEmail}
+                onChange={(e) => setAppEmail(e.target.value)}
+                className="h-8 text-sm"
+              />
+              <Input
+                type="password"
+                autoComplete="off"
+                placeholder="App login password"
+                aria-label="App login password"
+                value={appPassword}
+                onChange={(e) => setAppPassword(e.target.value)}
+                className="h-8 text-sm"
+              />
             </div>
-            <BrowserColumn streamUrl={streamUrl} queued={queuedForBrowser} />
-          </div>
-        ) : (
-          <>
-            {credsBlock}
-            {leftColumn}
-          </>
-        )}
+          )}
+        </div>
+      )}
 
-        {error && <p className="text-xs text-destructive">{error}</p>}
-      </CardContent>
+      {footer}
+
+      {error && (
+        <p className="border-t px-5 py-3 text-xs text-destructive">{error}</p>
+      )}
     </Card>
   );
 }

--- a/src/components/quickstart/quickstart-panel.tsx
+++ b/src/components/quickstart/quickstart-panel.tsx
@@ -212,6 +212,86 @@ function NotesBody({
   );
 }
 
+/** Brand marks (lucide dropped its brand icons, so inline the SVGs). */
+function XLogo({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden
+      fill="currentColor"
+      className={className}
+    >
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+function LinkedInLogo({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden
+      fill="currentColor"
+      className={className}
+    >
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z" />
+    </svg>
+  );
+}
+
+/** X/Twitter-style link unfurl — mirrors how the published /r/ share appears
+ *  when pasted into a social timeline: OG card image + domain + title + blurb. */
+function ShareEmbed({
+  shareUrl,
+  shareSlug,
+  title,
+  description,
+}: {
+  shareUrl: string;
+  shareSlug?: string;
+  title: string;
+  description?: string;
+}) {
+  const domain = hostOf(shareUrl) ?? "lastest.cloud";
+  return (
+    <a
+      href={shareUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex overflow-hidden rounded-md border bg-card shadow-sm transition-shadow hover:shadow-md"
+    >
+      {shareSlug && (
+        // Twitter "summary"-card layout: a ~1/2-width thumbnail on the left,
+        // text on the right (not the full-bleed banner).
+        <div className="w-1/2 shrink-0 self-stretch border-r bg-muted">
+          {/* The exact OG card the share serves — same image a social unfurl
+              renders. Plain <img>: the OG route is a public, already-optimized
+              1200×630 PNG, so next/image would just add an optimizer hop. */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={`/api/og/share/${shareSlug}`}
+            alt={`${title} preview`}
+            className="size-full object-cover"
+            loading="lazy"
+          />
+        </div>
+      )}
+      <div className="min-w-0 flex-1 space-y-0.5 p-3">
+        <div className="font-mono text-[10.5px] uppercase tracking-[0.06em] text-muted-foreground">
+          {domain}
+        </div>
+        <div className="truncate text-sm font-semibold text-foreground">
+          {title}
+        </div>
+        {description && (
+          <div className="line-clamp-3 text-xs text-muted-foreground">
+            {description}
+          </div>
+        )}
+      </div>
+    </a>
+  );
+}
+
 export function QuickstartPanel({
   repositoryId,
   enabled,
@@ -546,17 +626,28 @@ export function QuickstartPanel({
             </div>
           )}
         </>
-      ) : demoNotes ? (
+      ) : shareUrl || demoNotes ? (
         <>
           <Eyebrow>Report preview</Eyebrow>
-          <Chrome
-            url={shareSlug ? `${host ?? "lastest.cloud"}/r/${shareSlug}` : host}
-            trailing="external"
-          >
-            <div className="max-h-[360px] overflow-auto">
-              <NotesBody notes={demoNotes} />
-            </div>
-          </Chrome>
+          {shareUrl ? (
+            <ShareEmbed
+              shareUrl={shareUrl}
+              shareSlug={shareSlug}
+              title={host ? `${host} · Lastest` : "Lastest visual QA report"}
+              description={
+                demoNotes?.uxSummary ??
+                "Visual QA baseline — screenshots, layer checks, and demo notes."
+              }
+            />
+          ) : (
+            demoNotes && (
+              <div className="overflow-hidden rounded-md border bg-card shadow-sm">
+                <div className="max-h-[360px] overflow-auto">
+                  <NotesBody notes={demoNotes} />
+                </div>
+              </div>
+            )
+          )}
           {(buildId || walkthroughTestId) && (
             <div className="flex flex-wrap items-center gap-2">
               {buildId && (
@@ -639,16 +730,40 @@ export function QuickstartPanel({
                 : shareUrl}
             </div>
           </div>
-          <Button size="sm" variant="outline" onClick={copyShare}>
-            <Copy className="mr-1.5 size-3.5" />
-            Copy link
-          </Button>
-          <Button size="sm" asChild>
-            <a href={shareUrl} target="_blank" rel="noopener noreferrer">
-              <ExternalLink className="mr-1.5 size-3.5" />
-              Open report
-            </a>
-          </Button>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button size="sm" variant="outline" onClick={copyShare}>
+              <Copy className="mr-1.5 size-3.5" />
+              Copy link
+            </Button>
+            <Button size="sm" variant="outline" asChild>
+              <a
+                href={`https://x.com/intent/tweet?url=${encodeURIComponent(shareUrl)}&text=${encodeURIComponent(host ? `Visual QA report for ${host}` : "Visual QA report")}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                title="Share on X"
+              >
+                <XLogo className="mr-1.5 size-3" />
+                Share on X
+              </a>
+            </Button>
+            <Button size="sm" variant="outline" asChild>
+              <a
+                href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareUrl)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                title="Share on LinkedIn"
+              >
+                <LinkedInLogo className="mr-1.5 size-3" />
+                LinkedIn
+              </a>
+            </Button>
+            <Button size="sm" asChild>
+              <a href={shareUrl} target="_blank" rel="noopener noreferrer">
+                <ExternalLink className="mr-1.5 size-3.5" />
+                Open report
+              </a>
+            </Button>
+          </div>
         </div>
       ) : isActive ? (
         <div className="flex items-center gap-3 border-t bg-muted/20 p-4">

--- a/src/components/quickstart/use-quickstart.ts
+++ b/src/components/quickstart/use-quickstart.ts
@@ -50,6 +50,11 @@ export interface QuickstartSessionView {
     disabledReason?: string;
     streamUrl?: string;
     queuedForBrowser?: boolean;
+    demoNotes?: {
+      uxSummary: string;
+      highlights: { label: string; note: string }[];
+      frictionPoints: { label: string; note: string }[];
+    } | null;
   };
   createdAt?: string;
   completedAt?: string;

--- a/src/components/quickstart/use-quickstart.ts
+++ b/src/components/quickstart/use-quickstart.ts
@@ -105,36 +105,43 @@ export function useQuickstart(repositoryId?: string | null) {
     return stopPolling;
   }, [storageKey, poll, stopPolling]);
 
-  const start = useCallback(async () => {
-    if (!repositoryId || !storageKey) return;
-    setLoading(true);
-    setError(null);
-    try {
-      const res = await fetch(`/api/v1/repos/${repositoryId}/quickstart`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      });
-      if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as {
-          error?: string;
-          hint?: string;
-          reason?: string;
-        };
-        setError(body.hint ?? body.error ?? `HTTP ${res.status}`);
-        return;
+  const start = useCallback(
+    async (creds?: { appEmail?: string; appPassword?: string }) => {
+      if (!repositoryId || !storageKey) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const reqBody =
+          creds?.appEmail && creds?.appPassword
+            ? { appEmail: creds.appEmail, appPassword: creds.appPassword }
+            : {};
+        const res = await fetch(`/api/v1/repos/${repositoryId}/quickstart`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(reqBody),
+        });
+        if (!res.ok) {
+          const body = (await res.json().catch(() => ({}))) as {
+            error?: string;
+            hint?: string;
+            reason?: string;
+          };
+          setError(body.hint ?? body.error ?? `HTTP ${res.status}`);
+          return;
+        }
+        const { sessionId } = (await res.json()) as { sessionId: string };
+        localStorage.setItem(storageKey, sessionId);
+        stopPolling();
+        await poll(sessionId);
+        pollRef.current = setInterval(() => poll(sessionId), POLL_INTERVAL_MS);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setLoading(false);
       }
-      const { sessionId } = (await res.json()) as { sessionId: string };
-      localStorage.setItem(storageKey, sessionId);
-      stopPolling();
-      await poll(sessionId);
-      pollRef.current = setInterval(() => poll(sessionId), POLL_INTERVAL_MS);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setLoading(false);
-    }
-  }, [repositoryId, storageKey, poll, stopPolling]);
+    },
+    [repositoryId, storageKey, poll, stopPolling],
+  );
 
   const cancel = useCallback(async () => {
     if (!session?.id) return;

--- a/src/components/quickstart/use-quickstart.ts
+++ b/src/components/quickstart/use-quickstart.ts
@@ -46,7 +46,13 @@ export interface QuickstartSessionView {
     };
     walkthroughTestId?: string;
     buildId?: string;
+    rerunBuildId?: string;
     demoNotesId?: string;
+    /** Founder-facing /r/<slug> public share, published by the final
+     *  qs_publish_share step. Surfaced as the terminal CTA in the panel. */
+    shareId?: string;
+    shareSlug?: string;
+    shareUrl?: string;
     disabledReason?: string;
     streamUrl?: string;
     queuedForBrowser?: boolean;

--- a/src/components/quickstart/use-quickstart.ts
+++ b/src/components/quickstart/use-quickstart.ts
@@ -48,6 +48,8 @@ export interface QuickstartSessionView {
     buildId?: string;
     demoNotesId?: string;
     disabledReason?: string;
+    streamUrl?: string;
+    queuedForBrowser?: boolean;
   };
   createdAt?: string;
   completedAt?: string;

--- a/src/lib/crypto-fields.test.ts
+++ b/src/lib/crypto-fields.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeAll } from "vitest";
+
+// A valid 32-byte (64 hex char) key for the AES-256-GCM primitives. Set before
+// any helper runs — crypto.ts reads ENCRYPTION_KEY lazily inside getKey().
+const TEST_KEY =
+  "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+
+beforeAll(() => {
+  process.env.ENCRYPTION_KEY = TEST_KEY;
+});
+process.env.ENCRYPTION_KEY = TEST_KEY;
+
+import {
+  encrypt,
+  decrypt,
+  encryptField,
+  decryptField,
+  ENC_PREFIX,
+} from "./crypto";
+import {
+  encryptAuthConfig,
+  decryptAuthConfig,
+  encryptSessionMetadata,
+  decryptSessionMetadata,
+} from "./crypto-fields";
+import type { SetupAuthConfig, AgentSessionMetadata } from "./db/schema";
+
+describe("crypto primitives", () => {
+  it("round-trips arbitrary strings, including unicode and large blobs", () => {
+    const samples = [
+      "hunter2",
+      "пароль-日本語-🔐",
+      "",
+      JSON.stringify({ cookies: Array(2000).fill({ name: "s", value: "x" }) }),
+    ];
+    for (const s of samples) {
+      const enc = encrypt(s);
+      expect(enc.startsWith(ENC_PREFIX)).toBe(true);
+      expect(enc).not.toBe(s);
+      expect(decrypt(enc)).toBe(s);
+    }
+  });
+
+  it("uses a fresh IV so ciphertext differs but decrypts identically", () => {
+    const a = encrypt("same-input");
+    const b = encrypt("same-input");
+    expect(a).not.toBe(b);
+    expect(decrypt(a)).toBe("same-input");
+    expect(decrypt(b)).toBe("same-input");
+  });
+
+  it("passes plaintext through on decrypt (legacy rows)", () => {
+    expect(decrypt("plain-legacy-value")).toBe("plain-legacy-value");
+  });
+
+  it("rejects tampered ciphertext (GCM auth tag)", () => {
+    const enc = encrypt("secret");
+    const tampered = enc.slice(0, -2) + (enc.endsWith("A") ? "B" : "A");
+    expect(() => decrypt(tampered)).toThrow();
+  });
+
+  it("encryptField/decryptField pass null and undefined through", () => {
+    expect(encryptField(null)).toBeNull();
+    expect(encryptField(undefined)).toBeUndefined();
+    expect(decryptField(null)).toBeNull();
+    expect(decryptField(undefined)).toBeUndefined();
+  });
+});
+
+describe("encryptAuthConfig / decryptAuthConfig", () => {
+  it("round-trips token, password and header values; leaves username plaintext", () => {
+    const cfg: SetupAuthConfig = {
+      token: "bearer-tok",
+      username: "admin@example.com",
+      password: "s3cret",
+      headers: { "X-Api-Key": "abc123", "X-Trace": "keep" },
+    };
+    const enc = encryptAuthConfig(cfg)!;
+    expect(enc.token!.startsWith(ENC_PREFIX)).toBe(true);
+    expect(enc.password!.startsWith(ENC_PREFIX)).toBe(true);
+    expect(enc.headers!["X-Api-Key"].startsWith(ENC_PREFIX)).toBe(true);
+    // username is a low-sensitivity identifier — never encrypted
+    expect(enc.username).toBe("admin@example.com");
+
+    const dec = decryptAuthConfig(enc)!;
+    expect(dec).toEqual(cfg);
+  });
+
+  it("is idempotent — already-encrypted values are not double-encrypted", () => {
+    const cfg: SetupAuthConfig = { token: "t", password: "p" };
+    const once = encryptAuthConfig(cfg)!;
+    const twice = encryptAuthConfig(once)!;
+    expect(twice.token).toBe(once.token);
+    expect(twice.password).toBe(once.password);
+    expect(decryptAuthConfig(twice)).toEqual(cfg);
+  });
+
+  it("passes null/undefined through", () => {
+    expect(encryptAuthConfig(null)).toBeNull();
+    expect(encryptAuthConfig(undefined)).toBeNull();
+    expect(decryptAuthConfig(null)).toBeNull();
+  });
+
+  it("decrypts a legacy plaintext authConfig unchanged", () => {
+    const plain: SetupAuthConfig = { token: "plain", password: "plain2" };
+    expect(decryptAuthConfig(plain)).toEqual(plain);
+  });
+});
+
+describe("encryptSessionMetadata / decryptSessionMetadata", () => {
+  it("encrypts only quickstartPassword, leaving email and other fields intact", () => {
+    const meta: AgentSessionMetadata = {
+      quickstartEmail: "viktor@example.com",
+      quickstartPassword: "app-login-pw",
+      quickstartSlug: "acme",
+      credsProvided: true,
+    };
+    const enc = encryptSessionMetadata(meta)!;
+    expect(enc.quickstartPassword!.startsWith(ENC_PREFIX)).toBe(true);
+    expect(enc.quickstartEmail).toBe("viktor@example.com");
+    expect(enc.quickstartSlug).toBe("acme");
+    expect(enc.credsProvided).toBe(true);
+
+    const dec = decryptSessionMetadata(enc)!;
+    expect(dec).toEqual(meta);
+  });
+
+  it("is idempotent and order-independent (read-merge-rewrite cycle)", () => {
+    const meta: AgentSessionMetadata = { quickstartPassword: "pw" };
+    const once = encryptSessionMetadata(meta)!;
+    const twice = encryptSessionMetadata(once)!;
+    expect(twice.quickstartPassword).toBe(once.quickstartPassword);
+    expect(decryptSessionMetadata(twice)!.quickstartPassword).toBe("pw");
+  });
+
+  it("no-ops when there is no quickstartPassword", () => {
+    const meta: AgentSessionMetadata = { quickstartSlug: "x" };
+    expect(encryptSessionMetadata(meta)).toBe(meta);
+    expect(decryptSessionMetadata(meta)).toBe(meta);
+  });
+
+  it("passes null/undefined through", () => {
+    expect(encryptSessionMetadata(null)).toBeNull();
+    expect(encryptSessionMetadata(undefined)).toBeUndefined();
+    expect(decryptSessionMetadata(null)).toBeNull();
+  });
+});

--- a/src/lib/crypto-fields.ts
+++ b/src/lib/crypto-fields.ts
@@ -1,0 +1,76 @@
+/**
+ * Field-level encryption helpers for credentials nested inside JSONB columns.
+ *
+ * These wrap the AES-256-GCM primitives in `./crypto` with the shape-specific
+ * logic for the two JSONB stores that hold user-provided app credentials:
+ *   - setup_configs.authConfig  (bearer token / basic-auth password / headers)
+ *   - agent_sessions.metadata.quickstartPassword  (QuickStart app login)
+ *
+ * Kept DB-free (depends only on `./crypto` + schema *types*) so the encrypt/
+ * decrypt round-trip is unit-testable without a database. The query layers in
+ * queries/setup.ts and queries/integrations.ts apply these on write/read.
+ *
+ * Invariants (shared with the flat-column helpers in ./crypto):
+ *   - encrypt-on-write is guarded by ENC_PREFIX → idempotent, never double-encrypts
+ *   - decrypt-on-read passes plaintext through → backward-compatible with legacy rows
+ */
+
+import { encrypt, decryptField, ENC_PREFIX } from "./crypto";
+import type { SetupAuthConfig, AgentSessionMetadata } from "./db/schema";
+
+function encField(value: string): string {
+  return value.startsWith(ENC_PREFIX) ? value : encrypt(value);
+}
+
+// ── setup_configs.authConfig ────────────────────────────────────────────────
+// Encrypts token / password / each header value; `username` stays plaintext (a
+// low-sensitivity identifier, like an email).
+
+export function encryptAuthConfig(
+  cfg: SetupAuthConfig | null | undefined,
+): SetupAuthConfig | null {
+  if (!cfg) return cfg ?? null;
+  const out: SetupAuthConfig = { ...cfg };
+  if (out.token != null) out.token = encField(out.token);
+  if (out.password != null) out.password = encField(out.password);
+  if (out.headers) {
+    out.headers = Object.fromEntries(
+      Object.entries(out.headers).map(([k, v]) => [k, encField(v)]),
+    );
+  }
+  return out;
+}
+
+export function decryptAuthConfig(
+  cfg: SetupAuthConfig | null | undefined,
+): SetupAuthConfig | null {
+  if (!cfg) return cfg ?? null;
+  const out: SetupAuthConfig = { ...cfg };
+  if (out.token != null) out.token = decryptField(out.token);
+  if (out.password != null) out.password = decryptField(out.password);
+  if (out.headers) {
+    out.headers = Object.fromEntries(
+      Object.entries(out.headers).map(([k, v]) => [k, decryptField(v)]),
+    );
+  }
+  return out;
+}
+
+// ── agent_sessions.metadata.quickstartPassword ──────────────────────────────
+// Encrypts only the password sub-field; every other metadata field (including
+// the email) passes through untouched.
+
+export function encryptSessionMetadata<
+  T extends AgentSessionMetadata | null | undefined,
+>(meta: T): T {
+  if (!meta || meta.quickstartPassword == null) return meta;
+  if (meta.quickstartPassword.startsWith(ENC_PREFIX)) return meta;
+  return { ...meta, quickstartPassword: encrypt(meta.quickstartPassword) };
+}
+
+export function decryptSessionMetadata<
+  T extends AgentSessionMetadata | null | undefined,
+>(meta: T): T {
+  if (!meta || meta.quickstartPassword == null) return meta;
+  return { ...meta, quickstartPassword: decryptField(meta.quickstartPassword) };
+}

--- a/src/lib/db/queries/integrations.ts
+++ b/src/lib/db/queries/integrations.ts
@@ -1,6 +1,10 @@
 import { db } from "../index";
 import { encryptField, decryptField } from "@/lib/crypto";
 import {
+  encryptSessionMetadata,
+  decryptSessionMetadata,
+} from "@/lib/crypto-fields";
+import {
   specImports,
   googleSheetsAccounts,
   googleSheetsDataSources,
@@ -337,11 +341,24 @@ export async function upsertComposeConfig(
 // Agent Sessions
 // ============================================
 
+// QuickStart can run against the user's OWN app with their real login. When
+// supplied, the password lands in agent_sessions.metadata.quickstartPassword,
+// so it is encrypted at rest via the shared helpers in @/lib/crypto-fields —
+// encrypt on write, decrypt on read at this query layer so every consumer (and
+// mergeMetadata's read-merge-rewrite cycle) works with plaintext. The email is
+// left plaintext (low-sensitivity identifier shown in the QuickStart UI).
+function decryptAgentSessionRow<T extends { metadata: AgentSessionMetadata }>(
+  row: T,
+): T {
+  return { ...row, metadata: decryptSessionMetadata(row.metadata) };
+}
+
 export async function createAgentSession(data: Omit<NewAgentSession, "id">) {
   const id = uuid();
   const now = new Date();
   await db.insert(agentSessions).values({
     ...data,
+    metadata: encryptSessionMetadata(data.metadata),
     id,
     createdAt: now,
     updatedAt: now,
@@ -350,7 +367,7 @@ export async function createAgentSession(data: Omit<NewAgentSession, "id">) {
     .select()
     .from(agentSessions)
     .where(eq(agentSessions.id, id));
-  return row!;
+  return decryptAgentSessionRow(row!);
 }
 
 export async function getAgentSession(id: string) {
@@ -358,7 +375,7 @@ export async function getAgentSession(id: string) {
     .select()
     .from(agentSessions)
     .where(eq(agentSessions.id, id));
-  return row;
+  return row ? decryptAgentSessionRow(row) : row;
 }
 
 export async function getActiveAgentSession(
@@ -385,7 +402,7 @@ export async function getActiveAgentSession(
       ),
     )
     .orderBy(desc(agentSessions.createdAt));
-  return row;
+  return row ? decryptAgentSessionRow(row) : row;
 }
 
 export async function updateAgentSession(
@@ -398,9 +415,13 @@ export async function updateAgentSession(
     completedAt?: Date;
   },
 ) {
+  const patch =
+    data.metadata !== undefined
+      ? { ...data, metadata: encryptSessionMetadata(data.metadata) }
+      : data;
   await db
     .update(agentSessions)
-    .set({ ...data, updatedAt: new Date() })
+    .set({ ...patch, updatedAt: new Date() })
     .where(eq(agentSessions.id, id));
 }
 

--- a/src/lib/db/queries/public-shares.ts
+++ b/src/lib/db/queries/public-shares.ts
@@ -17,6 +17,7 @@ import type {
   DomDiffResult,
   StepComparisonEvidence,
   StepVerdict,
+  WebVitalsSample,
 } from "../schema";
 import { eq, and, desc, sql, isNotNull } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
@@ -334,6 +335,7 @@ export type ShareTestResult = {
   videoPath: string | null;
   durationMs: number | null;
   screenshots: CapturedScreenshot[] | null;
+  webVitals: WebVitalsSample[] | null;
 };
 
 // Slim step-comparison projection for share rendering. Drops issue/reviewer
@@ -407,6 +409,7 @@ export async function getShareDataBySlug(
           videoPath: testResults.videoPath,
           durationMs: testResults.durationMs,
           screenshots: testResults.screenshots,
+          webVitals: testResults.webVitals,
         })
         .from(testResults)
         .where(

--- a/src/lib/db/queries/setup.ts
+++ b/src/lib/db/queries/setup.ts
@@ -14,6 +14,7 @@ import type {
   NewDefaultSetupStep,
   NewDefaultTeardownStep,
   SetupScriptType,
+  SetupAuthConfig,
   TestSetupOverrides,
   TestTeardownOverrides,
   StabilizationSettings,
@@ -23,8 +24,18 @@ import type {
 import { getTest } from "./tests";
 import { getRepository } from "./repositories";
 import { getStorageState } from "./storage-states";
+import { encryptAuthConfig, decryptAuthConfig } from "@/lib/crypto-fields";
 import { eq, desc, and, isNull } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
+
+// Setup-config auth (bearer token / basic-auth password / custom header values)
+// is encrypted at rest via the shared helpers in @/lib/crypto-fields — encrypt
+// on write, decrypt on read, so every consumer sees plaintext.
+function decryptSetupConfigRow<
+  T extends { authConfig: SetupAuthConfig | null },
+>(row: T): T {
+  return { ...row, authConfig: decryptAuthConfig(row.authConfig) };
+}
 
 // ============================================
 // Setup Scripts
@@ -92,11 +103,12 @@ export async function duplicateSetupScript(id: string) {
 // ============================================
 
 export async function getSetupConfigs(repositoryId: string) {
-  return db
+  const rows = await db
     .select()
     .from(setupConfigs)
     .where(eq(setupConfigs.repositoryId, repositoryId))
     .orderBy(desc(setupConfigs.createdAt));
+  return rows.map(decryptSetupConfigRow);
 }
 
 export async function getSetupConfig(id: string) {
@@ -104,7 +116,7 @@ export async function getSetupConfig(id: string) {
     .select()
     .from(setupConfigs)
     .where(eq(setupConfigs.id, id));
-  return row;
+  return row ? decryptSetupConfigRow(row) : row;
 }
 
 export async function createSetupConfig(
@@ -114,10 +126,12 @@ export async function createSetupConfig(
   const now = new Date();
   await db.insert(setupConfigs).values({
     ...data,
+    authConfig: encryptAuthConfig(data.authConfig),
     id,
     createdAt: now,
     updatedAt: now,
   });
+  // Return the plaintext shape callers passed in (DB holds the encrypted copy).
   return { id, ...data, createdAt: now, updatedAt: now };
 }
 
@@ -125,9 +139,15 @@ export async function updateSetupConfig(
   id: string,
   data: Partial<NewSetupConfig>,
 ) {
+  // Only re-encrypt authConfig when the caller actually supplied it, so a patch
+  // that omits it doesn't wipe the stored credentials.
+  const patch: Partial<NewSetupConfig> = { ...data };
+  if (data.authConfig !== undefined) {
+    patch.authConfig = encryptAuthConfig(data.authConfig);
+  }
   await db
     .update(setupConfigs)
-    .set({ ...data, updatedAt: new Date() })
+    .set({ ...patch, updatedAt: new Date() })
     .where(eq(setupConfigs.id, id));
 }
 

--- a/src/lib/db/queries/storage-states.ts
+++ b/src/lib/db/queries/storage-states.ts
@@ -1,13 +1,25 @@
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { storageStates } from "@/lib/db/schema";
+import { encryptField, decryptField } from "@/lib/crypto";
+
+type StorageStateRow = typeof storageStates.$inferSelect;
+
+// storageStateJson holds a live Playwright storageState() blob (cookies +
+// localStorage = live auth tokens), so it is encrypted at rest. Decrypt on the
+// way out so every consumer sees the plaintext blob; legacy plaintext rows pass
+// through unchanged (decrypt() is a no-op without the enc:v1: prefix).
+function decryptStorageStateRow<T extends StorageStateRow>(row: T): T {
+  return { ...row, storageStateJson: decryptField(row.storageStateJson) };
+}
 
 export async function getStorageStates(repositoryId: string | null) {
   if (!repositoryId) return [];
-  return db
+  const rows = await db
     .select()
     .from(storageStates)
     .where(eq(storageStates.repositoryId, repositoryId));
+  return rows.map(decryptStorageStateRow);
 }
 
 export async function getStorageState(id: string) {
@@ -15,7 +27,7 @@ export async function getStorageState(id: string) {
     .select()
     .from(storageStates)
     .where(eq(storageStates.id, id));
-  return rows[0] ?? null;
+  return rows[0] ? decryptStorageStateRow(rows[0]) : null;
 }
 
 export async function createStorageState(data: {
@@ -52,7 +64,9 @@ export async function createStorageState(data: {
     .values({
       repositoryId: data.repositoryId,
       name: data.name,
-      storageStateJson: data.storageStateJson,
+      // Counts above are derived from the plaintext blob; encrypt only the
+      // stored value. Returned row is decrypted below so callers get plaintext.
+      storageStateJson: encryptField(data.storageStateJson),
       cookieCount,
       originCount,
       includesIndexedDB,
@@ -62,7 +76,7 @@ export async function createStorageState(data: {
       expiresAt: data.expiresAt ?? null,
     })
     .returning();
-  return rows[0];
+  return rows[0] ? decryptStorageStateRow(rows[0]) : rows[0];
 }
 
 export async function deleteStorageState(id: string) {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -2775,6 +2775,12 @@ export interface AgentSessionMetadata {
   publicScout?: QuickstartPublicScout;
   authedScout?: QuickstartAuthedScout;
   authSetup?: QuickstartAuthSetupMeta;
+  /** Live CDP screencast URL of the EB the scout is currently driving. Set while
+   *  a scout step holds an EB, cleared when it releases. Powers the panel's live
+   *  browser view. */
+  streamUrl?: string;
+  /** True while an agent step is blocked waiting for an EB from the pool. */
+  queuedForBrowser?: boolean;
   walkthroughTestId?: string;
   buildId?: string;
   /** Build id of the second walkthrough run (after baselines are approved). Replaces

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -2677,6 +2677,7 @@ export interface QuickstartAuthClassification {
    */
   classification:
     | "email_password"
+    | "login_email_password"
     | "magic_link_only"
     | "oauth_only"
     | "captcha_gated"
@@ -2702,6 +2703,27 @@ export interface QuickstartPublicScout extends QuickstartAuthClassification {
   concept?: string;
   navLinks: Array<{ path: string; label: string }>;
   registerPath?: string | null;
+  /** Login page URL observed in the DOM (distinct from registerPath). Relative
+   *  path (starting with /) or full https URL for cross-subdomain auth. Used by
+   *  the user-credential login path when no automatable signup exists. */
+  loginPath?: string | null;
+  /** Auth library's REST sign-in endpoint when detectable (e.g.
+   *  "/api/auth/sign-in/email" for better-auth). Drives the api-login bypass in
+   *  the login template when the React form doesn't persist a session cookie. */
+  apiLoginEndpoint?: string | null;
+  /** Best-effort auth library guess (better-auth | nextauth | supabase | firebase
+   *  | clerk | lucia | unknown). Informational — surfaced in demo notes + used as
+   *  authFlavor provenance on the captured storage state. */
+  authLibrary?: string;
+  /** Where the session token persists, best-effort. Informs storage-capture and
+   *  re-auth strategy; replay accepts any of these so a precise value isn't
+   *  required for correctness. */
+  tokenLocation?:
+    | "cookie"
+    | "localstorage"
+    | "indexeddb"
+    | "sessionstorage"
+    | "unknown";
   cookieBannerSelectorHint?: string;
   friction?: Array<{ kind: string; note: string }>;
   businessInteraction?: QuickstartBusinessInteraction;
@@ -2719,6 +2741,9 @@ export interface QuickstartAuthSetupMeta {
   storageStateId?: string;
   captured: boolean;
   failureReason?: string;
+  /** Which handshake produced the session: "login" (user-supplied creds) or
+   *  "signup" (fresh demo account). Surfaced in demo notes. */
+  mode?: "login" | "signup";
 }
 
 export interface AgentSessionMetadata {
@@ -2740,6 +2765,13 @@ export interface AgentSessionMetadata {
   quickstartPassword?: string;
   quickstartSlug?: string;
   quickstartStamp?: string;
+  /** True when the user supplied real app login credentials for their own
+   *  baseURL (QuickStart runs against the user's own app). When set,
+   *  quickstartEmail/quickstartPassword hold those creds and the auth-setup runs
+   *  a LOGIN handshake instead of registering a fresh demo account. */
+  credsProvided?: boolean;
+  /** Resolved auth handshake for this run, decided at auth-setup time. */
+  authMode?: "login" | "signup" | "public_only";
   publicScout?: QuickstartPublicScout;
   authedScout?: QuickstartAuthedScout;
   authSetup?: QuickstartAuthSetupMeta;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -2762,6 +2762,9 @@ export interface AgentSessionMetadata {
   skipAI?: boolean;
   // QuickStart-only fields
   quickstartEmail?: string;
+  /** User's real app-login password (QuickStart against their own baseURL).
+   *  Encrypted at rest (AES-256-GCM) via the agent-session query layer in
+   *  queries/integrations.ts — callers always see the decrypted plaintext. */
   quickstartPassword?: string;
   quickstartSlug?: string;
   quickstartStamp?: string;

--- a/src/lib/playwright/quickstart-scout.test.ts
+++ b/src/lib/playwright/quickstart-scout.test.ts
@@ -64,6 +64,50 @@ describe("runQuickstartScoutPublic — happy path", () => {
   });
 });
 
+describe("runQuickstartScoutPublic — tolerant JSON extraction", () => {
+  it("parses JSON followed by a trailing summary sentence (no retry)", async () => {
+    mockGen.mockResolvedValueOnce(
+      `${HAPPY_JSON}\n\nI have completed the reconnaissance and classified the sign-up flow as email_password.`,
+    );
+
+    const { data } = await runQuickstartScoutPublic(
+      "repo-1",
+      "https://www.featurely.no",
+    );
+
+    expect(data.classification).toBe("email_password");
+    expect(data.registerPath).toBe("/sign-up");
+    // The whole point: a trailing sentence must NOT cost a retry.
+    expect(mockGen).toHaveBeenCalledTimes(1);
+  });
+
+  it("parses JSON wrapped in leading prose + a markdown fence", async () => {
+    mockGen.mockResolvedValueOnce(
+      `Here is what I found:\n\n\`\`\`json\n${HAPPY_JSON}\n\`\`\`\n\nDone.`,
+    );
+
+    const { data } = await runQuickstartScoutPublic(
+      "repo-1",
+      "https://www.featurely.no",
+    );
+
+    expect(data.classification).toBe("email_password");
+    expect(mockGen).toHaveBeenCalledTimes(1);
+  });
+
+  it("parses JSON preceded by prose when there is no fence", async () => {
+    mockGen.mockResolvedValueOnce(`Sure — the result is ${HAPPY_JSON}`);
+
+    const { data } = await runQuickstartScoutPublic(
+      "repo-1",
+      "https://www.featurely.no",
+    );
+
+    expect(data.classification).toBe("email_password");
+    expect(mockGen).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("runQuickstartScoutPublic — retry on non-JSON", () => {
   it("retries once when the first response is prose, then succeeds", async () => {
     mockGen

--- a/src/lib/playwright/quickstart-scout.ts
+++ b/src/lib/playwright/quickstart-scout.ts
@@ -88,6 +88,9 @@ Use Playwright MCP browser tools (browser_navigate, browser_snapshot, browser_cl
    - demoInputValue: a SAFE additive demo string to type into primaryInputLabel that exercises the product's core function. Examples: "AI-powered birthday-card generator for parents of 3-7 year olds" for an idea-validator, "https://example.com/article" for a URL summariser, "best coffee shops in Berlin" for a search tool. NEVER pick a value that triggers destructive actions, real payments, outbound messaging on the founder's behalf, or scans of real third-party accounts.
 5. Find the registration page by examining the landing page DOM ONLY. Look for any visible \`<a>\` or \`<button>\` whose visible text matches /sign ?up|register|create.+account|get started|join (free|now|us)/i. Accept both same-origin links (href starts with /) AND cross-subdomain links (e.g. https://auth.example.com/register, https://app.example.com/signup). Click the first match and snapshot the destination. NEVER guess paths like /signup, /register, /join — if no CTA exists in the DOM, return registerPath: null and classification: "no_public_register". Record registerPath as either a relative path starting with / (same-origin) or the FULL absolute URL (cross-subdomain, e.g. "https://auth.example.com/register"). NEVER mix the two formats (do not prefix a path with a partial URL).
 6. Snapshot the register page and classify the sign-up flow.
+7. Find the LOGIN page the same DOM-only way (link/button whose visible text matches /sign ?in|log ?in/i). Record loginPath as either a relative path starting with / OR the FULL absolute URL — same format rules as registerPath; null if none found. Note whether the login form exposes email + password fields.
+8. Detect the auth library + its REST sign-in endpoint when actually visible: footer text like "SECURED BY BETTER AUTH", a login form whose action is under /api/auth/, or SDK hints in the page source (Firebase, Supabase, Clerk, NextAuth, Lucia). Report authLibrary (one of better-auth | nextauth | supabase | firebase | clerk | lucia | unknown) and apiLoginEndpoint (the sign-in REST path you SAW, e.g. "/api/auth/sign-in/email" for better-auth; null if you didn't see one — never guess).
+9. Report tokenLocation best-effort from the detected library: better-auth/nextauth/lucia → cookie; firebase/clerk → indexeddb; supabase → localstorage; otherwise unknown.
 
 CLASSIFICATION TABLE (pick ONE, in priority order — if multiple apply, pick the first match):
 
@@ -100,6 +103,9 @@ CLASSIFICATION TABLE (pick ONE, in priority order — if multiple apply, pick th
 | Only OAuth buttons (Google / GitHub / Apple / SSO) | oauth_only | false |
 | textbox "Email" only + button "Send magic link" / "Continue" | magic_link_only | false |
 | textbox "Email" + textbox "Password" + submit button | email_password | true |
+| Register is oauth-only / magic-link / gated / unreachable, BUT a conventional email + password LOGIN form exists | login_email_password | false |
+
+OVERRIDE: if you would otherwise classify the REGISTER flow as oauth_only / magic_link_only / captcha_gated / otp / no_public_register, but the site ALSO has a standard email + password LOGIN form, classify as "login_email_password" instead. Signup is not automatable there, but login IS — when the user supplies their own credentials.
 
 You MUST have actually loaded a register page (or confirmed no such page exists by following step 4) before classifying as anything other than "no_public_register" or "unknown". If the browser failed, you could not snapshot the landing page, or you have no concrete observations, return "classification": "unknown".
 
@@ -109,7 +115,11 @@ Return STRICT JSON (no markdown, no prose), shape:
   "concept": "1-2 sentence description, no marketing fluff",
   "navLinks": [{ "path": "/features", "label": "Features" }, ...],
   "registerPath": "/sign-up | https://auth.example.com/register | null",
-  "classification": "email_password | magic_link_only | oauth_only | captcha_gated | otp | no_public_register | unknown",
+  "loginPath": "/login | https://auth.example.com/sign-in | null",
+  "apiLoginEndpoint": "/api/auth/sign-in/email | null",
+  "authLibrary": "better-auth | nextauth | supabase | firebase | clerk | lucia | unknown",
+  "tokenLocation": "cookie | localstorage | indexeddb | sessionstorage | unknown",
+  "classification": "email_password | login_email_password | magic_link_only | oauth_only | captcha_gated | otp | no_public_register | unknown",
   "authAutomatable": true | false,
   "cookieBannerSelectorHint": "optional — if you saw a cookie banner, the button label that dismisses it",
   "businessInteraction": {
@@ -210,6 +220,7 @@ function asBusinessInteraction(
 function classify(value: unknown): QuickstartPublicScout["classification"] {
   const allowed = [
     "email_password",
+    "login_email_password",
     "magic_link_only",
     "oauth_only",
     "captcha_gated",
@@ -220,6 +231,30 @@ function classify(value: unknown): QuickstartPublicScout["classification"] {
   return (allowed as readonly string[]).includes(value as string)
     ? (value as QuickstartPublicScout["classification"])
     : "unknown";
+}
+
+function asTokenLocation(
+  value: unknown,
+): QuickstartPublicScout["tokenLocation"] {
+  const allowed = [
+    "cookie",
+    "localstorage",
+    "indexeddb",
+    "sessionstorage",
+    "unknown",
+  ] as const;
+  return (allowed as readonly string[]).includes(value as string)
+    ? (value as QuickstartPublicScout["tokenLocation"])
+    : undefined;
+}
+
+/** Normalise a scout-reported path/URL: a relative path (starts with /) or a full
+ *  https URL passes through; anything else (guessed bare word, partial URL) → null. */
+function asPathOrUrl(value: unknown): string | null {
+  if (typeof value !== "string" || value.length === 0) return null;
+  if (value.startsWith("/")) return value;
+  if (/^https?:\/\//i.test(value)) return value;
+  return null;
 }
 
 export interface QuickstartScoutPublicResult {
@@ -336,8 +371,14 @@ export async function runQuickstartScoutPublic(
     tagline,
     concept,
     navLinks,
-    registerPath:
-      typeof parsed.registerPath === "string" ? parsed.registerPath : null,
+    registerPath: asPathOrUrl(parsed.registerPath),
+    loginPath: asPathOrUrl(parsed.loginPath),
+    apiLoginEndpoint: asPathOrUrl(parsed.apiLoginEndpoint),
+    authLibrary:
+      typeof parsed.authLibrary === "string" && parsed.authLibrary.length > 0
+        ? parsed.authLibrary
+        : undefined,
+    tokenLocation: asTokenLocation(parsed.tokenLocation),
     cookieBannerSelectorHint:
       typeof parsed.cookieBannerSelectorHint === "string"
         ? parsed.cookieBannerSelectorHint

--- a/src/lib/playwright/quickstart-scout.ts
+++ b/src/lib/playwright/quickstart-scout.ts
@@ -437,13 +437,25 @@ export async function runQuickstartScoutAuthed(
   repositoryId: string,
   baseUrl: string,
   authSetupCode: string,
-  options?: { onLogCreated?: (logId: string) => void; cdpEndpoint?: string },
+  options?: {
+    onLogCreated?: (logId: string) => void;
+    cdpEndpoint?: string;
+    /** When true, the EB already has the captured session cookies/localStorage
+     *  injected — skip the seed replay entirely and start scouting authed. */
+    preAuthenticated?: boolean;
+  },
 ): Promise<QuickstartScoutAuthedResult> {
   const settings = await queries.getAISettings(repositoryId);
   const config = getAIConfig(settings);
   const mcpOpts = applyScoutMcpWiring(config, options?.cdpEndpoint);
 
-  const prompt = `Walk the authenticated app at ${baseUrl}.
+  // Pre-authenticated: the session was injected into this browser out-of-band,
+  // so skip step 1 (the seed sign-in) — re-driving the login form through the
+  // model is what made this step take minutes. Otherwise fall back to handing
+  // the seed to the agent to replay.
+  const prompt = options?.preAuthenticated
+    ? `Walk the authenticated app at ${baseUrl}. You are ALREADY signed in — the session has been injected into this browser. Do NOT sign in again and SKIP step 1 (the seed) of the workflow. Navigate directly to ${baseUrl} and proceed from step 2 of the workflow in the system prompt. Return strict JSON.`
+    : `Walk the authenticated app at ${baseUrl}.
 
 ## Seed (run this FIRST using MCP browser tools to authenticate)
 \`\`\`javascript

--- a/src/lib/playwright/quickstart-scout.ts
+++ b/src/lib/playwright/quickstart-scout.ts
@@ -147,10 +147,53 @@ Return STRICT JSON (no markdown), shape:
   "friction": [{ "kind": "string", "note": "string" }]
 }`;
 
+/** Return the first balanced {...} or [...] substring, honoring string literals
+ *  and escapes so braces inside strings don't throw off the depth count. Returns
+ *  null when no balanced object/array is present. */
+function firstBalancedJson(text: string): string | null {
+  const start = text.search(/[{[]/);
+  if (start === -1) return null;
+  const open = text[start];
+  const close = open === "{" ? "}" : "]";
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === open) depth++;
+    else if (ch === close && --depth === 0) return text.slice(start, i + 1);
+  }
+  return null;
+}
+
+/**
+ * Extract a JSON value from a model response. The response may wrap the JSON in
+ * a markdown fence and/or append a trailing summary sentence after the closing
+ * brace — the claude-agent-sdk final message routinely does the latter, which a
+ * strict `JSON.parse` rejects with "Unexpected non-whitespace character after
+ * JSON". Strategy:
+ *   1. Prefer fenced ```json … ``` content when present.
+ *   2. Try a strict parse of the trimmed candidate (clean case).
+ *   3. Fall back to the first balanced {...}/[...] slice — tolerates leading
+ *      AND trailing prose around an otherwise-valid object.
+ */
 function extractJson(response: string): unknown {
   const fence = response.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
-  const raw = (fence?.[1] ?? response).trim();
-  return JSON.parse(raw);
+  const candidate = (fence?.[1] ?? response).trim();
+  try {
+    return JSON.parse(candidate);
+  } catch (err) {
+    const sliced = firstBalancedJson(candidate);
+    if (sliced === null) throw err;
+    return JSON.parse(sliced);
+  }
 }
 
 function safeArray<T>(

--- a/src/lib/playwright/quickstart-templates.test.ts
+++ b/src/lib/playwright/quickstart-templates.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   renderAuthSetupCode,
+  renderAuthLoginCode,
   renderWalkthroughCode,
   renderQuickstartEmail,
   renderQuickstartPassword,
@@ -171,6 +172,59 @@ describe("renderWalkthroughCode — public-only mode", () => {
   it("still walks the public phase", () => {
     expect(code).toMatch(/Scenario 1: Homepage/);
     expect(code).toMatch(/page\.\$\$eval\('a\[href\]'/);
+  });
+});
+
+describe("renderAuthLoginCode (user-credential login)", () => {
+  const withApi = renderAuthLoginCode({
+    email: "owner@myapp.com",
+    password: "s3cret-pass",
+    loginUrl: "/login",
+    apiLoginEndpoint: "/api/auth/sign-in/email",
+  });
+  const noApi = renderAuthLoginCode({
+    email: "owner@myapp.com",
+    password: "s3cret-pass",
+    loginUrl: "https://auth.example.com/sign-in",
+  });
+
+  it("exports the canonical 4-arg test function", () => {
+    expect(withApi).toMatch(
+      /export async function test\(page, baseUrl, screenshotPath, stepLogger\)/,
+    );
+  });
+
+  it("inlines the supplied credentials", () => {
+    expect(withApi).toContain("owner@myapp.com");
+    expect(withApi).toContain("s3cret-pass");
+  });
+
+  it("navigates relative loginUrl via baseUrl and absolute loginUrl directly", () => {
+    expect(withApi).toMatch(/await page\.goto\(`\$\{baseUrl\}\/login`/);
+    expect(noApi).toMatch(
+      /await page\.goto\('https:\/\/auth\.example\.com\/sign-in'/,
+    );
+  });
+
+  it("does the api-login POST bypass when an endpoint is provided", () => {
+    expect(withApi).toContain("/api/auth/sign-in/email");
+    expect(withApi).toMatch(/fetch\(args\.url/);
+  });
+
+  it("bakes an empty API_LOGIN when no endpoint is provided", () => {
+    expect(noApi).toMatch(/const API_LOGIN = '';/);
+  });
+
+  it("ships the EB bootstrap + hoisted settle", () => {
+    expect(withApi).toMatch(/setExtraHTTPHeaders\(\{ 'User-Agent':/);
+    expect(withApi).toContain("email-decode.min.js");
+    expect(withApi).toMatch(/async function settle\(\)/);
+  });
+
+  it("screenshots fullPage everywhere", () => {
+    const matches = withApi.match(/page\.screenshot\([\s\S]*?\)\s*;/g) ?? [];
+    expect(matches.length).toBeGreaterThan(0);
+    for (const m of matches) expect(m).toMatch(/fullPage:\s*true/);
   });
 });
 

--- a/src/lib/playwright/quickstart-templates.test.ts
+++ b/src/lib/playwright/quickstart-templates.test.ts
@@ -9,6 +9,7 @@ import {
   SAFE_CTA_PATTERN,
   DESTRUCTIVE_CTA_PATTERN,
   CAPTCHA_LOCATOR,
+  AUTH_CHAIN_FAILED_MARKER,
 } from "./quickstart-templates";
 
 const sampleEmail = "viktor+postbox202604030915@lastest.cloud";
@@ -105,8 +106,18 @@ describe("renderWalkthroughCode — authed (chained storage state) mode", () => 
     expect(code).not.toMatch(/CHAINED_AUTH/);
   });
 
-  it("verifies storage-state auth via Sign-in CTA absence after navigation", () => {
-    expect(code).toMatch(/Storage state did not authenticate the browser/);
+  it("reds the build via the auth-fail marker when the chain doesn't authenticate", () => {
+    expect(code).toContain(AUTH_CHAIN_FAILED_MARKER);
+    // The marker throw must sit OUTSIDE the best-effort try/catch so it surfaces
+    // as a failed test rather than a swallowed warning. It captures an
+    // 'auth-failed' frame just before throwing.
+    expect(code).toMatch(/shot\(publicScenario, 'auth-failed'\)/);
+    const markerIdx = code.indexOf(AUTH_CHAIN_FAILED_MARKER);
+    const firstTryIdx = code.indexOf("try {");
+    expect(markerIdx).toBeGreaterThan(-1);
+    expect(firstTryIdx).toBeGreaterThan(-1);
+    // throw appears before the first try block opens (gate runs before the walk).
+    expect(markerIdx).toBeLessThan(firstTryIdx);
   });
 
   it("takes every screenshot at fullPage: true", () => {
@@ -161,6 +172,39 @@ describe("renderWalkthroughCode — public-only mode", () => {
     expect(code).toMatch(/Scenario 1: Homepage/);
     expect(code).toMatch(/page\.\$\$eval\('a\[href\]'/);
   });
+});
+
+describe("EB Chromium bootstrap (both renderers)", () => {
+  const authCode = renderAuthSetupCode({
+    email: sampleEmail,
+    password: samplePassword,
+    registerUrl: "/sign-up",
+  });
+  const walkCode = renderWalkthroughCode({
+    authAutomatable: true,
+    chainedAuth: true,
+  });
+
+  for (const [label, code] of [
+    ["auth-setup", authCode],
+    ["walkthrough", walkCode],
+  ] as const) {
+    it(`${label}: overrides the HeadlessChrome User-Agent before navigation`, () => {
+      expect(code).toMatch(/setExtraHTTPHeaders\(\{ 'User-Agent':/);
+      expect(code).toMatch(/Chrome\/\d/);
+    });
+
+    it(`${label}: route-blocks known third-party console-noise scripts`, () => {
+      expect(code).toContain("email-decode.min.js");
+      expect(code).toMatch(/page\.route\(pattern, function \(r\)/);
+    });
+
+    it(`${label}: settle is a hoisted function (not a scoped-out const arrow), with a hydration wait`, () => {
+      expect(code).toMatch(/async function settle\(\)/);
+      expect(code).not.toMatch(/const settle = \(\) =>/);
+      expect(code).toMatch(/\[role="main"\]/);
+    });
+  }
 });
 
 describe("SAFE_CTA_PATTERN / DESTRUCTIVE_CTA_PATTERN", () => {

--- a/src/lib/playwright/quickstart-templates.test.ts
+++ b/src/lib/playwright/quickstart-templates.test.ts
@@ -114,11 +114,15 @@ describe("renderWalkthroughCode — authed (chained storage state) mode", () => 
     // 'auth-failed' frame just before throwing.
     expect(code).toMatch(/shot\(publicScenario, 'auth-failed'\)/);
     const markerIdx = code.indexOf(AUTH_CHAIN_FAILED_MARKER);
-    const firstTryIdx = code.indexOf("try {");
+    // The authed-phase best-effort walk is wrapped in a try/catch that opens
+    // right after the `authed = true;` gate. The marker throw must sit BEFORE
+    // that try so a failed chain reds the build instead of being swallowed.
+    // (A separate public-phase canvas-draw try exists earlier in the body — the
+    // gate is not inside it.)
+    const authedTryIdx = code.indexOf("try {", code.indexOf("authed = true;"));
     expect(markerIdx).toBeGreaterThan(-1);
-    expect(firstTryIdx).toBeGreaterThan(-1);
-    // throw appears before the first try block opens (gate runs before the walk).
-    expect(markerIdx).toBeLessThan(firstTryIdx);
+    expect(authedTryIdx).toBeGreaterThan(-1);
+    expect(markerIdx).toBeLessThan(authedTryIdx);
   });
 
   it("takes every screenshot at fullPage: true", () => {
@@ -172,6 +176,24 @@ describe("renderWalkthroughCode — public-only mode", () => {
   it("still walks the public phase", () => {
     expect(code).toMatch(/Scenario 1: Homepage/);
     expect(code).toMatch(/page\.\$\$eval\('a\[href\]'/);
+  });
+
+  it("performs a coordinate-based canvas draw when a canvas is present", () => {
+    // Drawing/canvas apps (e.g. Excalidraw) expose no form input — the walk must
+    // demonstrate the product by selecting the rectangle tool and dragging a
+    // square with real mouse coordinates, then screenshot the result.
+    expect(code).toMatch(/page\.locator\('canvas'\)/);
+    expect(code).toMatch(/page\.keyboard\.press\('r'\)/);
+    expect(code).toMatch(/page\.mouse\.down\(\)/);
+    expect(code).toMatch(/page\.mouse\.move\(/);
+    expect(code).toMatch(/page\.mouse\.up\(\)/);
+    expect(code).toMatch(/Drew a square on the canvas/);
+    expect(code).toMatch(/shot\(publicScenario, 'draw-square'\)/);
+    // Runs in the public phase (before the AUTH_AUTOMATABLE branch) so public
+    // canvas apps like Excalidraw get the interaction without auth.
+    expect(code.indexOf("Drew a square")).toBeLessThan(
+      code.indexOf("if (AUTH_AUTOMATABLE)"),
+    );
   });
 });
 

--- a/src/lib/playwright/quickstart-templates.ts
+++ b/src/lib/playwright/quickstart-templates.ts
@@ -20,6 +20,56 @@ export const DESTRUCTIVE_CTA_PATTERN =
 export const CAPTCHA_LOCATOR =
   'iframe[src*="recaptcha"], iframe[src*="hcaptcha"], iframe[src*="cloudflare"][src*="challenge"]';
 
+/**
+ * Stable marker thrown by the walkthrough when chained `storage_state` failed to
+ * replay an authenticated session. The orchestrator (`runQsRunAndNotes`) detects
+ * this in the failed test's error message and downgrades to a public-only rerun
+ * rather than shipping login-page screenshots as if they were authed.
+ */
+export const AUTH_CHAIN_FAILED_MARKER =
+  "QuickStart authed walkthrough: storage_state did not authenticate";
+
+/** Current stable Chrome UA. EB's default `HeadlessChrome` string is rejected by
+ *  Cloudflare Turnstile, Clerk, Supabase Auth, and several SaaS edge routers. */
+const EB_USER_AGENT =
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36";
+
+/** Known third-party console-noise scripts to abort before the first navigation.
+ *  The EB executor reds a test on ANY console error; Cloudflare's auto-injected
+ *  email-decoder is the #1 false positive across customer sites. */
+const EB_NOISE_PATTERNS = [
+  "**/cdn-cgi/scripts/**/email-decode.min.js",
+  "**/cdn-cgi/scripts/**/cloudflare-static/**",
+  "**/sentry-cdn.com/**",
+  "**/browser.sentry-cdn.com/**",
+  "**/cdn.segment.com/**",
+  "**/connect.facebook.net/**",
+];
+
+/**
+ * EB Chromium bootstrap, emitted at the top of every rendered test body (mirrors
+ * the mandatory header in the skill's `test-template.md`). Two mitigations that
+ * otherwise falsely-fail 50%+ of runs on the EB pod:
+ *   1. Override the HeadlessChrome User-Agent with a current stable Chrome string.
+ *   2. Abort known third-party console-noise scripts before the first navigation.
+ * The route loop is INLINED (run once) rather than wrapped in a `const fn = () =>`
+ * arrow — the runner's per-statement instrumentation can scope cross-statement
+ * arrow helpers out, throwing "fn is not defined" mid-walk.
+ */
+export function renderEbBootstrap(): string {
+  const patterns = EB_NOISE_PATTERNS.map((p) => `    ${jsString(p)},`).join(
+    "\n",
+  );
+  return [
+    `  await page.context().setExtraHTTPHeaders({ 'User-Agent': ${jsString(EB_USER_AGENT)} }).catch(function () {});`,
+    `  for (const pattern of [`,
+    patterns,
+    `  ]) {`,
+    `    await page.route(pattern, function (r) { return r.abort(); }).catch(function () {});`,
+    `  }`,
+  ].join("\n");
+}
+
 export interface RenderAuthSetupOptions {
   email: string;
   password: string;
@@ -76,7 +126,13 @@ export function renderAuthSetupCode(opts: RenderAuthSetupOptions): string {
   const DEMO_NAME = ${jsString(name)};
 
   const shot = (n, slug) => screenshotPath.replace('.png', \`-\${n}-\${slug}.png\`);
-  const settle = () => page.waitForLoadState('networkidle').catch(() => {});
+  async function settle() {
+    await page.waitForLoadState('networkidle').catch(function () {});
+    await page.locator('h1, h2, main, [role="main"]').first().waitFor({ state: 'visible', timeout: 5000 }).catch(function () {});
+    await page.waitForTimeout(300);
+  }
+
+${renderEbBootstrap()}
 
   await page.goto(baseUrl, { waitUntil: 'domcontentloaded' });
   const accept = page.getByRole('button', { name: /accept|allow|got it|ok$/i });
@@ -247,7 +303,13 @@ export function renderWalkthroughCode(opts: RenderWalkthroughOptions): string {
   const HAS_BIZ_INTERACTION = ${hasBizInteraction};
 
   const shot = (n, slug) => screenshotPath.replace('.png', \`-\${n}-\${slug}.png\`);
-  const settle = () => page.waitForLoadState('networkidle').catch(() => {});
+  async function settle() {
+    await page.waitForLoadState('networkidle').catch(function () {});
+    await page.locator('h1, h2, main, [role="main"]').first().waitFor({ state: 'visible', timeout: 5000 }).catch(function () {});
+    await page.waitForTimeout(300);
+  }
+
+${renderEbBootstrap()}
 
   stepLogger.log('Scenario 1: Homepage');
   await page.goto(baseUrl, { waitUntil: 'domcontentloaded' });
@@ -284,18 +346,23 @@ export function renderWalkthroughCode(opts: RenderWalkthroughOptions): string {
 
   let authed = false;
   if (AUTH_AUTOMATABLE) {
-    try {
-      // Storage state (cookies + localStorage) was attached by the runner via
-      // setupOverrides.extraSteps. Just verify the chain actually authenticated.
-      await page.goto(baseUrl, { waitUntil: 'domcontentloaded' });
-      await settle();
-      const signInCta = page.getByRole('link', { name: /sign ?in|log ?in/i }).first()
-        .or(page.getByRole('button', { name: /sign ?in|log ?in/i }).first());
-      if (await signInCta.isVisible().catch(() => false)) {
-        throw new Error('Storage state did not authenticate the browser (sign-in CTA still visible)');
-      }
-      authed = true;
+    // Hard gate (OUTSIDE the best-effort try/catch below): the runner attached
+    // the captured storage_state (cookies + localStorage) via
+    // setupOverrides.extraSteps. If it did NOT replay an authenticated session
+    // (expired, dropped, or never injected), RED the build instead of silently
+    // shipping login-page screenshots as "authed". The orchestrator detects this
+    // marker on the failed result and downgrades to a public-only rerun.
+    await page.goto(baseUrl, { waitUntil: 'domcontentloaded' });
+    await settle();
+    const signInCta = page.getByRole('link', { name: /sign ?in|log ?in/i }).first()
+      .or(page.getByRole('button', { name: /sign ?in|log ?in/i }).first());
+    if (await signInCta.isVisible().catch(() => false)) {
+      await page.screenshot({ path: shot(publicScenario, 'auth-failed'), fullPage: true });
+      throw new Error(${jsString(AUTH_CHAIN_FAILED_MARKER + " (sign-in CTA still visible)")});
+    }
+    authed = true;
 
+    try {
       stepLogger.log(\`Scenario \${publicScenario}: Post-auth landing\`);
       await page.screenshot({ path: shot(publicScenario, 'post-auth'), fullPage: true });
       publicScenario++;
@@ -424,10 +491,6 @@ export function renderWalkthroughCode(opts: RenderWalkthroughOptions): string {
   await page.goto(baseUrl, { waitUntil: 'domcontentloaded' }).catch(() => {});
   await settle();
   await page.screenshot({ path: screenshotPath, fullPage: true });
-
-  if (AUTH_AUTOMATABLE && !authed) {
-    stepLogger.warn('Authed phase did not run — see warnings above');
-  }
 }
 `;
 }

--- a/src/lib/playwright/quickstart-templates.ts
+++ b/src/lib/playwright/quickstart-templates.ts
@@ -141,7 +141,7 @@ export function renderAuthSetupCode(opts: RenderAuthSetupOptions): string {
 
   const shot = (n, slug) => screenshotPath.replace('.png', \`-\${n}-\${slug}.png\`);
   async function settle() {
-    await page.waitForLoadState('networkidle').catch(function () {});
+    await page.waitForLoadState('networkidle', { timeout: 3000 }).catch(function () {});
     await page.locator('h1, h2, main, [role="main"]').first().waitFor({ state: 'visible', timeout: 5000 }).catch(function () {});
     await page.waitForTimeout(300);
   }
@@ -344,7 +344,7 @@ export function renderAuthLoginCode(opts: RenderAuthLoginOptions): string {
 
   const shot = (n, slug) => screenshotPath.replace('.png', \`-\${n}-\${slug}.png\`);
   async function settle() {
-    await page.waitForLoadState('networkidle').catch(function () {});
+    await page.waitForLoadState('networkidle', { timeout: 3000 }).catch(function () {});
     await page.locator('h1, h2, main, [role="main"]').first().waitFor({ state: 'visible', timeout: 5000 }).catch(function () {});
     await page.waitForTimeout(300);
   }
@@ -449,7 +449,7 @@ export function renderWalkthroughCode(opts: RenderWalkthroughOptions): string {
 
   const shot = (n, slug) => screenshotPath.replace('.png', \`-\${n}-\${slug}.png\`);
   async function settle() {
-    await page.waitForLoadState('networkidle').catch(function () {});
+    await page.waitForLoadState('networkidle', { timeout: 3000 }).catch(function () {});
     await page.locator('h1, h2, main, [role="main"]').first().waitFor({ state: 'visible', timeout: 5000 }).catch(function () {});
     await page.waitForTimeout(300);
   }

--- a/src/lib/playwright/quickstart-templates.ts
+++ b/src/lib/playwright/quickstart-templates.ts
@@ -200,10 +200,26 @@ ${renderEbBootstrap()}
   const submit = page.getByRole('button', { name: /sign ?up|register|create account|get started/i }).first();
   await submit.click();
 
-  await Promise.race([
-    page.waitForURL(/dashboard|onboarding|welcome|home|app|projects/i, { timeout: 15000 }),
-    page.waitForSelector('[role="alert"]:visible, .error:visible, [data-error]:visible', { timeout: 15000 }),
-  ]).catch(() => {});
+  // Success = left the auth page OR a session/auth cookie was set. The Lastest-
+  // style register form awaits sign-up, THEN a consent server-action, THEN
+  // redirects — so on a cold EB the navigation can lag many seconds. Poll up to
+  // 30s for EITHER signal instead of sampling the URL once (a single 15s sample
+  // false-failed slow-but-successful signups and discarded the captured session).
+  const AUTH_URL_RE = /register|signup|signin|log[\\-]?in|sign-in|sign-up/i;
+  async function hasSessionCookie() {
+    const cookies = await page.context().cookies().catch(function () { return []; });
+    return cookies.some(function (c) {
+      return c && c.value && /session|auth|token|sid|jwt/i.test(c.name || '');
+    });
+  }
+  let authed = false;
+  const authDeadline = Date.now() + 30000;
+  while (Date.now() < authDeadline) {
+    if (!AUTH_URL_RE.test(page.url()) || (await hasSessionCookie())) { authed = true; break; }
+    const rejected = await page.locator('[role="alert"]:visible, .error:visible, [data-error]:visible').first().isVisible().catch(function () { return false; });
+    if (rejected) break;
+    await page.waitForTimeout(500);
+  }
   await settle();
 
   stepLogger.log('Scenario 3: Post-signup landing');
@@ -215,8 +231,10 @@ ${renderEbBootstrap()}
     throw new Error('verify-email gate detected after submit');
   }
 
+  // A captured session means auth succeeded even if the post-signup redirect
+  // lagged — the session, not the landing URL, is what auth-setup needs.
   const url = page.url();
-  if (/register|signup|signin|log[\\-]?in|sign-in|sign-up/i.test(url)) {
+  if (!authed && AUTH_URL_RE.test(url)) {
     await page.screenshot({ path: screenshotPath, fullPage: true });
     // Scrape visible error text verbatim from the site so the user sees the
     // actual rejection (e.g. "Sign-ups from disposable email addresses are not
@@ -240,6 +258,10 @@ ${renderEbBootstrap()}
     ];
     const ERROR_HINTS = /(not allowed|not supported|invalid|required|must|cannot|disposable|business|already|exists|taken|incorrect|wrong|weak|too (short|long|weak|common)|please|try again|failed|error|denied|blocked|use a different|use another|forbidden|temporarily)/i;
     const NOISE_HINTS = /(privacy policy|terms (and|of)|cookie|all rights reserved|copyright|^\\s*\\d{1,4}\\s*$|^\\W*$)/i;
+    // Strong error verbs override the noise filter — "Please accept the Terms of
+    // Service and Privacy Policy to continue" is a real validation error, not
+    // footer boilerplate, even though it mentions "terms"/"privacy policy".
+    const STRONG_ERROR = /(please|must|required|accept|agree to|enter|provide|invalid|already|exists|disposable|not allowed|too (short|long|weak))/i;
     async function collectErrorTexts(scope) {
       const seen = new Set();
       const out = [];
@@ -252,7 +274,7 @@ ${renderEbBootstrap()}
           const t = ((await loc.textContent().catch(() => '')) || '')
             .replace(/\\s+/g, ' ').trim();
           if (t.length < 4 || t.length > 240) continue;
-          if (NOISE_HINTS.test(t)) continue;
+          if (NOISE_HINTS.test(t) && !STRONG_ERROR.test(t)) continue;
           if (!ERROR_HINTS.test(t)) continue;
           const key = t.toLowerCase();
           if (seen.has(key)) continue;
@@ -280,7 +302,7 @@ ${renderEbBootstrap()}
         for (const raw of lines) {
           const t = raw.replace(/\\s+/g, ' ').trim();
           if (t.length < 6 || t.length > 240) continue;
-          if (NOISE_HINTS.test(t)) continue;
+          if (NOISE_HINTS.test(t) && !STRONG_ERROR.test(t)) continue;
           if (!ERROR_HINTS.test(t)) continue;
           const key = t.toLowerCase();
           if (seen.has(key)) continue;

--- a/src/lib/playwright/quickstart-templates.ts
+++ b/src/lib/playwright/quickstart-templates.ts
@@ -80,6 +80,20 @@ export interface RenderAuthSetupOptions {
   registerUrl: string;
 }
 
+export interface RenderAuthLoginOptions {
+  /** User-supplied app credentials (QuickStart runs against the user's own app). */
+  email: string;
+  password: string;
+  /** Login URL observed by the scout in the page DOM. Relative path (starting with /)
+   *  or full https:// URL. REQUIRED — no path-guessing fallback. */
+  loginUrl: string;
+  /** Auth library REST sign-in endpoint observed by the scout (e.g.
+   *  "/api/auth/sign-in/email"). When present, the test lands the session cookie
+   *  via a direct POST (bypasses React forms that don't persist on .fill()), and
+   *  falls back to the visible form submit if the POST is rejected. */
+  apiLoginEndpoint?: string | null;
+}
+
 export interface RenderWalkthroughOptions {
   authAutomatable: boolean;
   /** When true, walkthrough trusts setupTestId/storageState injection and skips inline login. */
@@ -281,6 +295,115 @@ ${renderEbBootstrap()}
     throw new Error(joined
       ? joined
       : \`auth did not complete — still on \${url}\`);
+  }
+
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+}
+`;
+}
+
+/**
+ * Test 1 (login variant) — signs into the user's OWN app with user-supplied
+ * credentials, captures sign-in screenshots, asserts auth completed. Used when
+ * the user provided creds (QuickStart runs against their own baseURL). When the
+ * scout found an `apiLoginEndpoint`, the test lands the session cookie via a
+ * direct POST (bypasses React forms whose .fill() doesn't persist the session),
+ * then falls back to the visible form submit if the POST is rejected.
+ *
+ * SECURITY: the credentials are baked as literals into the test body, which is
+ * stored team-gated (never exposed on the public /r/ share — that renders
+ * screenshots + notes only). These are the user's own app credentials.
+ */
+export function renderAuthLoginCode(opts: RenderAuthLoginOptions): string {
+  return `export async function test(page, baseUrl, screenshotPath, stepLogger) {
+  const DEMO_EMAIL = ${jsString(opts.email)};
+  const DEMO_PASSWORD = ${jsString(opts.password)};
+  const API_LOGIN = ${jsString(opts.apiLoginEndpoint ?? "")};
+
+  const shot = (n, slug) => screenshotPath.replace('.png', \`-\${n}-\${slug}.png\`);
+  async function settle() {
+    await page.waitForLoadState('networkidle').catch(function () {});
+    await page.locator('h1, h2, main, [role="main"]').first().waitFor({ state: 'visible', timeout: 5000 }).catch(function () {});
+    await page.waitForTimeout(300);
+  }
+
+${renderEbBootstrap()}
+
+  await page.goto(baseUrl, { waitUntil: 'domcontentloaded' });
+  const accept = page.getByRole('button', { name: /accept|allow|got it|ok$/i });
+  if (await accept.isVisible().catch(() => false)) {
+    await accept.click();
+  }
+  await settle();
+
+  stepLogger.log('Scenario 1: Sign-in page');
+  ${gotoExpr(opts.loginUrl)}
+  await settle();
+  await page.screenshot({ path: shot(1, 'sign-in'), fullPage: true });
+
+  const captcha = page.locator(${jsString(CAPTCHA_LOCATOR)});
+  if (await captcha.first().isVisible().catch(() => false)) {
+    throw new Error('captcha-blocked on sign-in page');
+  }
+
+  stepLogger.log('Scenario 2: Submit sign-in');
+  const emailField = page.getByLabel(/email/i).first()
+    .or(page.getByPlaceholder(/email/i).first())
+    .or(page.locator('input[type="email"]').first());
+  const passField = page.getByLabel(/^password$/i).first()
+    .or(page.getByPlaceholder(/^password$/i).first())
+    .or(page.locator('input[type="password"]').first());
+
+  await emailField.click();
+  await emailField.pressSequentially(DEMO_EMAIL, { delay: 20 });
+  await passField.click();
+  await passField.pressSequentially(DEMO_PASSWORD, { delay: 20 });
+  await page.screenshot({ path: shot(2, 'sign-in-filled'), fullPage: true });
+
+  // API-login bypass: POST the credentials directly so the session cookie sticks
+  // even when the React form's submit handler swallows programmatic input.
+  let apiOk = false;
+  if (API_LOGIN) {
+    apiOk = await page.evaluate(async function (args) {
+      try {
+        const r = await fetch(args.url, {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ email: args.email, password: args.password }),
+        });
+        return r.ok;
+      } catch (e) {
+        return false;
+      }
+    }, { url: API_LOGIN, email: DEMO_EMAIL, password: DEMO_PASSWORD });
+    if (apiOk) {
+      await page.goto(baseUrl, { waitUntil: 'domcontentloaded' });
+    }
+  }
+  if (!apiOk) {
+    const submit = page.getByRole('button', { name: /sign ?in|log ?in|continue|submit|next/i }).first();
+    await submit.click().catch(function () {});
+    await Promise.race([
+      page.waitForURL(/dashboard|onboarding|welcome|home|app|projects|account/i, { timeout: 15000 }),
+      page.waitForSelector('[role="alert"]:visible, .error:visible, [data-error]:visible', { timeout: 15000 }),
+    ]).catch(function () {});
+  }
+  await settle();
+
+  stepLogger.log('Scenario 3: Post-sign-in landing');
+  const url = page.url();
+  const stillSignInCta = page.getByRole('link', { name: /sign ?in|log ?in/i }).first()
+    .or(page.getByRole('button', { name: /sign ?in|log ?in/i }).first());
+  const onAuthUrl = /login|signin|sign-in|log-in/i.test(url);
+  if (onAuthUrl && (await stillSignInCta.isVisible().catch(() => false))) {
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+    let errText = '';
+    const errLoc = page.locator('[role="alert"], [aria-live="polite"], [aria-live="assertive"], .error, .field-error, [class*="text-red"], [class*="text-destructive"]').first();
+    if (await errLoc.isVisible().catch(() => false)) {
+      errText = ((await errLoc.textContent().catch(() => '')) || '').replace(/\\s+/g, ' ').trim().slice(0, 200);
+    }
+    throw new Error(errText ? ('sign-in failed: ' + errText) : ('sign-in did not complete — still on ' + url));
   }
 
   await page.screenshot({ path: screenshotPath, fullPage: true });

--- a/src/lib/playwright/quickstart-templates.ts
+++ b/src/lib/playwright/quickstart-templates.ts
@@ -444,6 +444,41 @@ ${renderEbBootstrap()}
   await page.screenshot({ path: shot(1, 'home'), fullPage: true });
 
   let publicScenario = 2;
+
+  // Primary interaction for canvas / drawing apps (Excalidraw, tldraw, whiteboards,
+  // map tools): when the homepage exposes a large drawing <canvas>, perform a REAL
+  // coordinate-based action — select the rectangle tool ('r', the de-facto shortcut
+  // across drawing apps) and drag a square — so the walkthrough demonstrates the
+  // product's core function instead of only screenshotting nav pages. Best-effort:
+  // gated on a visibly large canvas and fully wrapped, so non-drawing canvases
+  // (charts, games) never break the run.
+  try {
+    const canvas = page.locator('canvas').first();
+    if (await canvas.isVisible().catch(() => false)) {
+      const box = await canvas.boundingBox().catch(() => null);
+      if (box && box.width > 300 && box.height > 200) {
+        await canvas.click({ position: { x: 30, y: 30 } }).catch(() => {});
+        await page.keyboard.press('r').catch(() => {});
+        await page.waitForTimeout(150);
+        const side = Math.min(box.width, box.height) * 0.25;
+        const x1 = box.x + box.width * 0.4;
+        const y1 = box.y + box.height * 0.35;
+        await page.mouse.move(x1, y1);
+        await page.mouse.down();
+        await page.mouse.move(x1 + side * 0.5, y1 + side * 0.5, { steps: 8 });
+        await page.mouse.move(x1 + side, y1 + side, { steps: 8 });
+        await page.mouse.up();
+        await page.keyboard.press('Escape').catch(() => {});
+        await page.waitForTimeout(300);
+        stepLogger.log(\`Scenario \${publicScenario}: Drew a square on the canvas\`);
+        await page.screenshot({ path: shot(publicScenario, 'draw-square'), fullPage: true });
+        publicScenario++;
+      }
+    }
+  } catch (canvasErr) {
+    stepLogger.warn(\`Canvas draw step skipped: \${canvasErr && canvasErr.message}\`);
+  }
+
   const navLinks = await page.$$eval('a[href]', as => as
     .map(a => a.getAttribute('href') || '')
     .filter(h => h.startsWith('/') && h.length > 1 && !h.startsWith('/_') && !h.startsWith('/#'))

--- a/src/lib/quickstart/gating.test.ts
+++ b/src/lib/quickstart/gating.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import type { Repository } from "@/lib/db/schema";
+import { pickRepoBaseUrl } from "./gating";
+
+function repo(partial: Partial<Repository>): Repository {
+  return partial as unknown as Repository;
+}
+
+describe("pickRepoBaseUrl", () => {
+  it("prefers the real default branch over the legacy 'default' key", () => {
+    // The reported bug: an excalidraw repo whose `default` key was a stale
+    // sandbox-seed URL (playwright.dev) while the actual `master` branch points
+    // at the product. The scout must reconnoiter excalidraw.com, not playwright.dev.
+    const url = pickRepoBaseUrl(
+      repo({
+        defaultBranch: "master",
+        comparisonBaselineBranch: null,
+        branchBaseUrls: {
+          master: "https://excalidraw.com",
+          default: "https://playwright.dev",
+        },
+      }),
+    );
+    expect(url).toBe("https://excalidraw.com");
+  });
+
+  it("falls back to the comparison baseline branch when there is no default branch URL", () => {
+    const url = pickRepoBaseUrl(
+      repo({
+        defaultBranch: "missing-branch",
+        comparisonBaselineBranch: "staging",
+        branchBaseUrls: {
+          staging: "https://staging.example.com",
+          default: "https://playwright.dev",
+        },
+      }),
+    );
+    expect(url).toBe("https://staging.example.com");
+  });
+
+  it("uses any named branch before the 'default' key", () => {
+    const url = pickRepoBaseUrl(
+      repo({
+        defaultBranch: null,
+        comparisonBaselineBranch: null,
+        branchBaseUrls: {
+          feature: "https://feature.example.com",
+          default: "https://playwright.dev",
+        },
+      }),
+    );
+    expect(url).toBe("https://feature.example.com");
+  });
+
+  it("still returns the 'default' key when it is the only entry", () => {
+    const url = pickRepoBaseUrl(
+      repo({
+        defaultBranch: null,
+        comparisonBaselineBranch: null,
+        branchBaseUrls: { default: "https://playwright.dev" },
+      }),
+    );
+    expect(url).toBe("https://playwright.dev");
+  });
+
+  it("skips a local default-branch URL and uses the next non-local candidate", () => {
+    const url = pickRepoBaseUrl(
+      repo({
+        defaultBranch: "main",
+        comparisonBaselineBranch: null,
+        branchBaseUrls: {
+          main: "http://localhost:3000",
+          prod: "https://app.example.com",
+          default: "https://playwright.dev",
+        },
+      }),
+    );
+    expect(url).toBe("https://app.example.com");
+  });
+
+  it("returns undefined when every candidate is local", () => {
+    const url = pickRepoBaseUrl(
+      repo({
+        defaultBranch: "main",
+        comparisonBaselineBranch: null,
+        branchBaseUrls: {
+          main: "http://localhost:3000",
+          default: "http://127.0.0.1:8080",
+        },
+      }),
+    );
+    expect(url).toBeUndefined();
+  });
+
+  it("returns undefined when there are no branch base URLs", () => {
+    const url = pickRepoBaseUrl(
+      repo({ defaultBranch: "main", branchBaseUrls: null }),
+    );
+    expect(url).toBeUndefined();
+  });
+});

--- a/src/lib/quickstart/gating.test.ts
+++ b/src/lib/quickstart/gating.test.ts
@@ -52,7 +52,9 @@ describe("pickRepoBaseUrl", () => {
     expect(url).toBe("https://feature.example.com");
   });
 
-  it("still returns the 'default' key when it is the only entry", () => {
+  it("ignores the legacy 'default' key entirely (no real branch ⇒ undefined)", () => {
+    // The repo-wide "default" key is removed from the design: a stale value
+    // there must never be picked, even when it's the only entry.
     const url = pickRepoBaseUrl(
       repo({
         defaultBranch: null,
@@ -60,7 +62,21 @@ describe("pickRepoBaseUrl", () => {
         branchBaseUrls: { default: "https://playwright.dev" },
       }),
     );
-    expect(url).toBe("https://playwright.dev");
+    expect(url).toBeUndefined();
+  });
+
+  it("ignores 'default' even alongside a real branch", () => {
+    const url = pickRepoBaseUrl(
+      repo({
+        defaultBranch: "main",
+        comparisonBaselineBranch: null,
+        branchBaseUrls: {
+          main: "https://app.example.com",
+          default: "https://playwright.dev",
+        },
+      }),
+    );
+    expect(url).toBe("https://app.example.com");
   });
 
   it("skips a local default-branch URL and uses the next non-local candidate", () => {

--- a/src/lib/quickstart/gating.ts
+++ b/src/lib/quickstart/gating.ts
@@ -38,14 +38,14 @@ export function pickRepoBaseUrl(repo: Repository): string | undefined {
   const map = repo.branchBaseUrls ?? {};
   const candidates: string[] = [];
 
-  // Prefer the repo's real default branch (e.g. main/master), then its
-  // comparison baseline branch, then any other named branch. The literal
-  // "default" key is a LEGACY fallback that sandbox seeds + repo creation
-  // populate with throwaway URLs (e.g. https://playwright.dev), so it must come
-  // LAST — otherwise it shadows a real, user-configured branch URL and the
-  // QuickStart scout reconnoiters the wrong site. (The reported bug: an
-  // excalidraw repo with {master: excalidraw.com, default: playwright.dev}
-  // resolved to playwright.dev because "default" was tried first.)
+  // Resolve from real, named branches only: the repo's default branch (e.g.
+  // main/master), then its comparison baseline branch, then any other branch.
+  // The legacy repo-wide "default" key is intentionally IGNORED — it was a
+  // write-once fallback (set at repo creation/onboarding, never updated by the
+  // per-branch UI) that went stale and shadowed real branch URLs, sending the
+  // QuickStart scout to the wrong site (e.g. an excalidraw repo whose stale
+  // default was https://playwright.dev). Data is migrated off it; see
+  // scripts/migrate-drop-default-baseurl.sql.
   const seen = new Set<string>();
   const pushBranch = (branch: string | null | undefined) => {
     if (!branch || branch === "default" || seen.has(branch)) return;
@@ -55,7 +55,6 @@ export function pickRepoBaseUrl(repo: Repository): string | undefined {
   pushBranch(repo.defaultBranch);
   pushBranch(repo.comparisonBaselineBranch);
   for (const branch of Object.keys(map)) pushBranch(branch);
-  if (typeof map.default === "string") candidates.push(map.default);
 
   for (const url of candidates) {
     if (url.length > 0 && !isLocalUrl(url)) return url;

--- a/src/lib/quickstart/gating.ts
+++ b/src/lib/quickstart/gating.ts
@@ -37,11 +37,26 @@ function isLocalUrl(url: string): boolean {
 export function pickRepoBaseUrl(repo: Repository): string | undefined {
   const map = repo.branchBaseUrls ?? {};
   const candidates: string[] = [];
+
+  // Prefer the repo's real default branch (e.g. main/master), then its
+  // comparison baseline branch, then any other named branch. The literal
+  // "default" key is a LEGACY fallback that sandbox seeds + repo creation
+  // populate with throwaway URLs (e.g. https://playwright.dev), so it must come
+  // LAST — otherwise it shadows a real, user-configured branch URL and the
+  // QuickStart scout reconnoiters the wrong site. (The reported bug: an
+  // excalidraw repo with {master: excalidraw.com, default: playwright.dev}
+  // resolved to playwright.dev because "default" was tried first.)
+  const seen = new Set<string>();
+  const pushBranch = (branch: string | null | undefined) => {
+    if (!branch || branch === "default" || seen.has(branch)) return;
+    seen.add(branch);
+    if (typeof map[branch] === "string") candidates.push(map[branch]);
+  };
+  pushBranch(repo.defaultBranch);
+  pushBranch(repo.comparisonBaselineBranch);
+  for (const branch of Object.keys(map)) pushBranch(branch);
   if (typeof map.default === "string") candidates.push(map.default);
-  for (const [branch, value] of Object.entries(map)) {
-    if (branch !== "default" && typeof value === "string")
-      candidates.push(value);
-  }
+
   for (const url of candidates) {
     if (url.length > 0 && !isLocalUrl(url)) return url;
   }

--- a/src/lib/quickstart/gating.ts
+++ b/src/lib/quickstart/gating.ts
@@ -72,10 +72,8 @@ export async function isQuickstartEnabled(
   const team = await queries.getTeam(repo.teamId);
   if (!team) return { enabled: false, reason: "no_team", repo };
 
-  if (!team.earlyAdopterMode) {
-    return { enabled: false, reason: "not_early_adopter", repo, team };
-  }
-
+  // QuickStart is generally available (promoted out of Early Adopter). The only
+  // remaining requirement is a non-local base URL to point the agent at.
   const baseUrl = pickRepoBaseUrl(repo);
   if (!baseUrl) return { enabled: false, reason: "no_base_url", repo, team };
 

--- a/src/lib/quickstart/quickstart-notes.ts
+++ b/src/lib/quickstart/quickstart-notes.ts
@@ -39,15 +39,21 @@ export interface GenerateDemoNotesInput {
   authVerificationFailed?: boolean;
 }
 
-const SYSTEM_PROMPT = `You are summarising a Lastest visual-regression baseline run for a SaaS product. Generate the demo notes.
+const SYSTEM_PROMPT = `You are writing the demo notes for a Lastest visual-regression baseline run of a SaaS product. These notes are the qualitative counterpart to the screenshots — the part that says "we actually looked, here's what we noticed." The founder reads them on a public share, so they must be specific, accurate, and genuinely useful.
+
+QUALITY BAR (this is what separates good notes from generic ones):
+- Specific over generic. "Three pricing tiers, each with one differentiator headline, no 'contact sales' tier" beats "clear pricing". Name the actual route, element, label, or count whenever the facts contain it (publicNavRoutes, businessInteraction, safeCtas, friction notes).
+- Quantify when the facts allow it (screenshot count, route count, a timing a friction note mentions). NEVER invent a number, route, or feature.
+- Where a friction point has an obvious one-line fix, say it (e.g. "/signup 404s but /sign-up works — add a redirect").
+- Conversational and concrete. No marketing fluff, no hedging, no filler.
 
 RULES:
-- Pass facts only. Do NOT invent features the input did not mention.
-- uxSummary: 2-3 sentences, conversational, in your own words. Lead with the product's concept (from publicScout.concept). Mention one strong UX signal if present.
-- highlights: 2-4 items the founder would be proud of (clear pricing, polished empty state, fast load, etc.). Safe-for-outreach quality.
-- frictionPoints: 1-3 UX issues observed during the walk. Cookie banner overlap, slow blog index, console-noisy analytics, that kind of thing.
-- testingStruggles: 0-3 items. Captcha, verify-email gates, OAuth-only flows, OTP, hung networkidle. Empty array if none.
-- skippedRoutes: 0-N items. Routes the agent intended to visit but didn't (auth blocked, 404, hang).
+- Pass facts ONLY. Do NOT invent features, routes, timings, or issues the input did not contain. If a section has little real signal, return fewer items (or an empty array) — do not pad.
+- uxSummary: 2-3 sentences. Lead with what the product actually does (from concept / businessInteraction — the primary input + CTA tell you the core job). Then point to the single strongest UX signal in the facts.
+- highlights: 1-4 things the founder should be proud of, each tied to a concrete observation and safe to quote in outreach.
+- frictionPoints: 0-3 real UX issues observed (cookie-banner overlap, slow route, console-noisy analytics, confusing empty state, guessable-URL 404). Product-facing — never shown in outreach.
+- testingStruggles: 0-3 things that made automated testing hard (captcha, verify-email gate, OAuth-only, OTP, hung networkidle, an auth session that wouldn't replay). Empty array if the run was clean.
+- skippedRoutes: 0-N routes the agent meant to visit but couldn't, each with the reason.
 
 OUTPUT STRICT JSON, no markdown, exactly this shape:
 {
@@ -56,6 +62,24 @@ OUTPUT STRICT JSON, no markdown, exactly this shape:
   "frictionPoints": [{ "label": "string", "note": "string" }],
   "testingStruggles": [{ "label": "string", "note": "string" }],
   "skippedRoutes": [{ "path": "string", "reason": "string" }]
+}
+
+EXAMPLE — match this specificity and voice, do NOT copy its content:
+{
+  "uxSummary": "Postbox is a transactional-email API for indie developers; the hero leads with a strong 'send your first email in 4 lines' tagline. The pricing table is unusually clean for an indie product, and the register page is a single minimal column.",
+  "highlights": [
+    { "label": "Pricing clarity", "note": "Three tiers, each with one differentiator headline and no 'contact sales' tier — a strong signal for an indie audience." },
+    { "label": "Empty-state copy", "note": "The /dashboard zero-state ships with working sample data, so a new user skips the 'now what?' moment." }
+  ],
+  "frictionPoints": [
+    { "label": "Cookie banner overlap", "note": "The consent banner covers the hero CTA on first paint; dismissed before the screenshot." }
+  ],
+  "testingStruggles": [
+    { "label": "Captcha on register", "note": "An hCaptcha iframe rendered after submit, so the auth phase fell back to public-only." }
+  ],
+  "skippedRoutes": [
+    { "path": "/dashboard", "reason": "Couldn't authenticate past the captcha." }
+  ]
 }`;
 
 function dedupeItems(items: DemoNoteItem[]): DemoNoteItem[] {
@@ -100,6 +124,9 @@ function buildFactsBlock(input: GenerateDemoNotesInput): string {
     productName: input.productName,
     concept: input.publicScout.concept ?? null,
     tagline: input.publicScout.tagline ?? null,
+    // The primary input + CTA the product is built around — the single best
+    // "what does this actually do" signal for the uxSummary lead sentence.
+    businessInteraction: input.publicScout.businessInteraction ?? null,
     authClassification: input.publicScout.classification,
     authAutomatable: input.publicScout.authAutomatable,
     publicNavRoutes: input.publicScout.navLinks.map((n) => n.path),

--- a/src/lib/quickstart/quickstart-notes.ts
+++ b/src/lib/quickstart/quickstart-notes.ts
@@ -32,6 +32,11 @@ export interface GenerateDemoNotesInput {
   authedScout?: QuickstartAuthedScout;
   authSetup?: QuickstartAuthSetupMeta;
   runFacts: QuickstartRunFacts;
+  /** True when the captured login session was successfully captured but did NOT
+   *  replay as authenticated on the test runner, so the walkthrough was
+   *  downgraded to public-only. Distinct from authSetup.captured=false (capture
+   *  itself failed). Surfaced as a testingStruggles item. */
+  authVerificationFailed?: boolean;
 }
 
 const SYSTEM_PROMPT = `You are summarising a Lastest visual-regression baseline run for a SaaS product. Generate the demo notes.
@@ -106,6 +111,7 @@ function buildFactsBlock(input: GenerateDemoNotesInput): string {
     authedFriction: input.authedScout?.friction ?? [],
     authSetupCaptured: input.authSetup?.captured ?? false,
     authSetupFailureReason: input.authSetup?.failureReason ?? null,
+    authVerificationFailed: input.authVerificationFailed ?? false,
     runResults: {
       passed: input.runFacts.passedCount,
       failed: input.runFacts.failedCount,
@@ -164,6 +170,12 @@ Produce the demo notes JSON.`;
     fallbackTesting.push({
       label: "Auth setup blocked",
       note: input.authSetup.failureReason,
+    });
+  }
+  if (input.authVerificationFailed) {
+    fallbackTesting.push({
+      label: "Login session could not be verified",
+      note: "The captured login session did not replay as authenticated on the test runner, so the walkthrough ran in public-only mode. This usually means the session expired or is stored where replay can't reach it (e.g. IndexedDB). Re-run, or supply working login credentials for the app.",
     });
   }
   if (

--- a/src/lib/quickstart/quickstart-notes.ts
+++ b/src/lib/quickstart/quickstart-notes.ts
@@ -110,6 +110,7 @@ function buildFactsBlock(input: GenerateDemoNotesInput): string {
     safeCtas: input.authedScout?.safeCtaCandidates.map((c) => c.label) ?? [],
     authedFriction: input.authedScout?.friction ?? [],
     authSetupCaptured: input.authSetup?.captured ?? false,
+    authSetupMode: input.authSetup?.mode ?? null,
     authSetupFailureReason: input.authSetup?.failureReason ?? null,
     authVerificationFailed: input.authVerificationFailed ?? false,
     runResults: {

--- a/src/lib/quickstart/storage-capture.ts
+++ b/src/lib/quickstart/storage-capture.ts
@@ -1,29 +1,44 @@
 /**
- * Run an auth-setup test in a sandboxed Embedded Browser pod, then capture the
- * resulting storageState and persist it via createStorageState so the QuickStart
- * walkthrough test can re-use it via setupOverrides.extraSteps.
+ * Run a freshly-rendered auth-setup test, then capture the resulting
+ * `context.storageState()` and persist it via createStorageState so the
+ * QuickStart walkthrough test can re-use it via setupOverrides.extraSteps.
  *
  * SECURITY: the auth-setup code is AI/user-derived arbitrary Playwright code.
- * It is executed in a disposable runner/EB pod via executeSetupViaRunner — never
- * eval'd in the host process (which holds DATABASE_URL / STRIPE_* / SYSTEM_EB_TOKEN).
+ * On a provisioned (Kubernetes) deployment it is executed in a disposable
+ * runner/EB pod via executeSetupViaRunner — never `eval`'d in the host process
+ * (which holds DATABASE_URL / STRIPE_* / SYSTEM_EB_TOKEN). Only a self-hosted
+ * single-tenant install with no runner pool falls back to in-process execution.
  */
 
+import { chromium } from "playwright";
 import * as queries from "@/lib/db/queries";
 import { executeSetupViaRunner } from "@/lib/execution/executor";
 import {
   claimOrProvisionPoolEB,
   releasePoolEB,
 } from "@/server/actions/embedded-sessions";
+import { isKubernetesMode } from "@/lib/eb/provisioner";
 
 export interface CaptureStorageStateInput {
   repositoryId: string;
   baseUrl: string;
-  /** Rendered auth-setup test code (output of renderAuthSetupCode). */
+  /** Rendered auth-setup test code (output of renderAuthSetupCode/renderAuthLoginCode). */
   testCode: string;
   /** Display name for the persisted storage state. */
   name: string;
   /** Hard cap so a stuck signup can't burn the agent. Default 90s. */
   timeoutMs?: number;
+  /** Best-effort token location from the scout — only used as a provenance
+   *  fallback when the captured state's actual locations can't be derived. */
+  tokenLocation?:
+    | "cookie"
+    | "localstorage"
+    | "indexeddb"
+    | "sessionstorage"
+    | "unknown";
+  /** Best-effort auth library guess (better-auth, firebase, ...). Stored as
+   *  authFlavor provenance so re-runs can pick a re-auth strategy. */
+  authFlavor?: string;
 }
 
 export interface CaptureStorageStateResult {
@@ -33,11 +48,105 @@ export interface CaptureStorageStateResult {
   durationMs: number;
 }
 
-export async function captureStorageState(
-  input: CaptureStorageStateInput,
-): Promise<CaptureStorageStateResult> {
-  const start = Date.now();
+function extractTestBody(code: string): string | null {
+  const match = code.match(
+    /export\s+async\s+function\s+test\s*\(\s*page[^)]*\)\s*\{([\s\S]*)\}\s*$/,
+  );
+  return match ? match[1] : null;
+}
 
+function buildExpectStub() {
+  // The auth-setup template doesn't use expect, but the AsyncFunction signature
+  // includes it so the body's `expect` references (none today, but future-proof)
+  // resolve. Returning a no-op proxy is safe.
+  const noop = () => Promise.resolve();
+  return new Proxy(() => noop, {
+    get: () => noop,
+  });
+}
+
+// Transient infrastructure failures that warrant an automatic retry.
+// Content failures (form validation, disposable email, captcha) are NOT
+// retried — the user needs to see those verbatim and adjust the email template.
+const TRANSIENT_ERROR_RE =
+  /ECONNRESET|ECONNREFUSED|ENOTFOUND|ETIMEDOUT|net::ERR_(?:CONNECTION|NETWORK|TIMED_OUT|SOCKET|EMPTY|TUNNEL)|Target page, context or browser has been closed|Protocol error/i;
+
+async function attemptCapture(
+  input: CaptureStorageStateInput,
+  body: string,
+): Promise<
+  { ok: true; storageStateJson: string } | { ok: false; reason: string }
+> {
+  const timeoutMs = input.timeoutMs ?? 90_000;
+  let browser: Awaited<ReturnType<typeof chromium.launch>> | null = null;
+  try {
+    browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({ ignoreHTTPSErrors: true });
+    const page = await context.newPage();
+    page.setDefaultTimeout(15_000);
+    page.setDefaultNavigationTimeout(20_000);
+
+    const stepLogger = {
+      log: (msg: string) => console.log(`[QuickStart auth-setup] ${msg}`),
+      warn: (msg: string) => console.warn(`[QuickStart auth-setup] ${msg}`),
+    };
+
+    const AsyncFunction = Object.getPrototypeOf(
+      async function () {},
+    ).constructor;
+    const fn = new AsyncFunction(
+      "page",
+      "baseUrl",
+      "screenshotPath",
+      "stepLogger",
+      "expect",
+      body,
+    );
+    const exec = fn(
+      page,
+      input.baseUrl,
+      "/tmp/quickstart-auth.png",
+      stepLogger,
+      buildExpectStub(),
+    );
+
+    await Promise.race([
+      exec,
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error(`auth-setup timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        ),
+      ),
+    ]);
+
+    // { indexedDB: true } (PW 1.51+) captures Firebase Auth / Clerk / Supabase-v2
+    // sessions that the bare call drops. The runner/EB paths already do this; the
+    // host fallback must match or those apps replay unauthenticated.
+    const storageStateJson = JSON.stringify(
+      await context.storageState({ indexedDB: true }),
+    );
+    return { ok: true, storageStateJson };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    if (browser) await browser.close().catch(() => {});
+  }
+}
+
+/**
+ * Run the auth-setup code in a disposable runner/EB pod and return its captured
+ * storage state. Returns null when no pooled browser could be claimed (so the
+ * caller can decide whether a host fallback is permitted).
+ */
+async function tryCaptureViaRunner(
+  input: CaptureStorageStateInput,
+): Promise<
+  { ok: true; storageStateJson: string } | { ok: false; reason: string } | null
+> {
   let runnerId: string | null = null;
   try {
     const poolEB = await claimOrProvisionPoolEB({ purpose: "interactive" });
@@ -45,14 +154,7 @@ export async function captureStorageState(
   } catch {
     runnerId = null;
   }
-
-  if (!runnerId) {
-    return {
-      captured: false,
-      failureReason: "All browsers are busy. Please try again later.",
-      durationMs: Date.now() - start,
-    };
-  }
+  if (!runnerId) return null;
 
   try {
     const result = await executeSetupViaRunner(
@@ -64,52 +166,124 @@ export async function captureStorageState(
       input.timeoutMs ?? 90_000,
       null,
     );
-
-    const storageStateJson = result.storageStateJson;
-    if (!storageStateJson) {
-      return {
-        captured: false,
-        failureReason:
-          "Auth-setup completed but no storage state was returned from the browser.",
-        durationMs: Date.now() - start,
-      };
+    const json = result.storageStateJson;
+    if (!json) {
+      return { ok: false, reason: "runner returned no storage state" };
     }
-
-    let cookieCount = 0;
-    try {
-      const parsed = JSON.parse(storageStateJson);
-      cookieCount = Array.isArray(parsed.cookies) ? parsed.cookies.length : 0;
-    } catch {
-      /* ignore parse failures — persisted as-is */
-    }
-
-    if (cookieCount === 0) {
-      return {
-        captured: false,
-        failureReason:
-          "Auth-setup completed but captured 0 cookies — storage state would not authenticate the walkthrough. Likely the script navigated off the auth URL without actually signing in.",
-        durationMs: Date.now() - start,
-      };
-    }
-
-    const persisted = await queries.createStorageState({
-      repositoryId: input.repositoryId,
-      name: input.name,
-      storageStateJson,
-    });
-
-    return {
-      captured: true,
-      storageStateId: persisted.id,
-      durationMs: Date.now() - start,
-    };
+    return { ok: true, storageStateJson: json };
   } catch (err) {
     return {
-      captured: false,
-      failureReason: err instanceof Error ? err.message : String(err),
-      durationMs: Date.now() - start,
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
     };
   } finally {
     await releasePoolEB(runnerId).catch(() => {});
   }
+}
+
+export async function captureStorageState(
+  input: CaptureStorageStateInput,
+): Promise<CaptureStorageStateResult> {
+  const start = Date.now();
+  const body = extractTestBody(input.testCode);
+  if (!body) {
+    return {
+      captured: false,
+      failureReason: "could not extract test() body from rendered code",
+      durationMs: Date.now() - start,
+    };
+  }
+
+  // Preferred path: execute off-host in a disposable runner/EB pod.
+  let attempt = await tryCaptureViaRunner(input);
+
+  if (!attempt) {
+    // No pooled browser available. On a provisioned deployment we must NOT fall
+    // back to in-process eval of arbitrary auth code.
+    if (isKubernetesMode()) {
+      return {
+        captured: false,
+        failureReason: "All browsers are busy. Please try again later.",
+        durationMs: Date.now() - start,
+      };
+    }
+
+    // Self-hosted / local-dev fallback: no runner pool configured. Such
+    // deployments are single-tenant, so in-process execution is acceptable.
+    // First attempt; one retry on transient network/browser errors.
+    attempt = await attemptCapture(input, body);
+    if (!attempt.ok && TRANSIENT_ERROR_RE.test(attempt.reason)) {
+      console.warn(
+        `[QuickStart auth-setup] transient error, retrying once: ${attempt.reason}`,
+      );
+      attempt = await attemptCapture(input, body);
+    }
+  }
+
+  if (!attempt.ok) {
+    return {
+      captured: false,
+      failureReason: attempt.reason,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  // Validate the captured state carries SOME session material. HttpOnly-cookie
+  // shops (better-auth, NextAuth) put it in cookies; Firebase/Clerk/Supabase-v2
+  // keep it in localStorage or IndexedDB (captured via { indexedDB: true }).
+  // Accept any of them — a truly empty jar means the script navigated off the
+  // auth URL without actually signing in. Also derive the real token locations
+  // for provenance (more accurate than the scout's guess).
+  let cookieCount = 0;
+  let hasStorage = false;
+  const tokenLocations: string[] = [];
+  try {
+    const parsed = JSON.parse(attempt.storageStateJson) as {
+      cookies?: unknown[];
+      origins?: Array<{ localStorage?: unknown[]; indexedDB?: unknown[] }>;
+    };
+    cookieCount = Array.isArray(parsed.cookies) ? parsed.cookies.length : 0;
+    const origins = Array.isArray(parsed.origins) ? parsed.origins : [];
+    const hasLocal = origins.some(
+      (o) => Array.isArray(o.localStorage) && o.localStorage.length > 0,
+    );
+    const hasIdb = origins.some(
+      (o) => Array.isArray(o.indexedDB) && o.indexedDB.length > 0,
+    );
+    hasStorage = hasLocal || hasIdb;
+    if (cookieCount > 0) tokenLocations.push("cookie");
+    if (hasLocal) tokenLocations.push("localStorage");
+    if (hasIdb) tokenLocations.push("indexedDB");
+  } catch {
+    /* parse failure handled below */
+  }
+  if (cookieCount === 0 && !hasStorage) {
+    return {
+      captured: false,
+      failureReason:
+        "auth-setup completed but captured no cookies, localStorage, or IndexedDB session material — storage state would not authenticate the walkthrough. Likely the script navigated off the auth URL without actually signing in.",
+      durationMs: Date.now() - start,
+    };
+  }
+
+  const provenanceLocations =
+    tokenLocations.length > 0
+      ? tokenLocations
+      : input.tokenLocation
+        ? [input.tokenLocation]
+        : null;
+
+  const persisted = await queries.createStorageState({
+    repositoryId: input.repositoryId,
+    name: input.name,
+    storageStateJson: attempt.storageStateJson,
+    tokenLocations: provenanceLocations,
+    authFlavor: input.authFlavor ?? null,
+  });
+
+  return {
+    captured: true,
+    storageStateId: persisted.id,
+    durationMs: Date.now() - start,
+  };
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -39,6 +39,7 @@ const PUBLIC_PATHS = [
   "/planned/",
   "/bug-reports/",
   "/_umami/",
+  "/api/umami/", // resilient umami ingest forwarder (rewrite target of /_umami/api/*)
 ];
 
 const isDev = process.env.NODE_ENV !== "production";

--- a/src/server/actions/ai.ts
+++ b/src/server/actions/ai.ts
@@ -31,6 +31,38 @@ import { embeddedSessions } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 
 /**
+ * Probe an EB's CDP endpoint once. cdpUrl is `http://<host>:<cdpPort>` (a TCP
+ * proxy in the pod forwards 0.0.0.0 → 127.0.0.1 where Chromium binds); Chromium
+ * serves `/json/version` over it. Returns false on any error / non-2xx / timeout.
+ */
+async function probeCdp(cdpUrl: string, timeoutMs = 2500): Promise<boolean> {
+  const base = cdpUrl.replace(/^ws/i, "http").replace(/\/+$/, "");
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${base}/json/version`, { signal: ctrl.signal });
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Confirm a claimed EB's CDP endpoint is actually reachable before handing it to
+ * an agent. After a `pnpm dev` restart (dead port-forward) or a dead pod, the DB
+ * still holds a cdpUrl whose proxy is gone — pointing Playwright MCP at it makes
+ * the agent fail with an opaque connect error (and no live screencast). Two quick
+ * attempts so a transient blip doesn't evict a healthy EB.
+ */
+async function isCdpReachable(cdpUrl: string): Promise<boolean> {
+  if (await probeCdp(cdpUrl)) return true;
+  await new Promise((r) => setTimeout(r, 250));
+  return probeCdp(cdpUrl);
+}
+
+/**
  * Claim an embedded browser from the pool for AI agent use.
  * Waits (polls) until an EB becomes available, up to maxWaitMs.
  * Returns CDP + stream URLs and the runnerId for release.
@@ -70,15 +102,25 @@ export async function claimEmbeddedBrowserForAgent(
         .where(eq(embeddedSessions.runnerId, poolEB.runnerId));
 
       if (session?.cdpUrl && session?.streamUrl) {
-        return {
-          cdpUrl: session.cdpUrl,
-          streamUrl: session.streamUrl,
-          runnerId: poolEB.runnerId,
-        };
+        if (await isCdpReachable(session.cdpUrl)) {
+          return {
+            cdpUrl: session.cdpUrl,
+            streamUrl: session.streamUrl,
+            runnerId: poolEB.runnerId,
+          };
+        }
+        // Registered but its CDP endpoint is unreachable — a stale port-forward
+        // (post `pnpm dev` restart) or a dead pod. Handing this to an agent makes
+        // Playwright MCP fail opaquely. Release it (k8s mode tears the Job down
+        // and ensureWarmPool provisions a fresh one) and keep waiting.
+        console.warn(
+          `[AgentPool] Claimed EB ${poolEB.runnerId.slice(0, 8)} has an unreachable CDP endpoint (${session.cdpUrl}) — evicting and retrying`,
+        );
+        await releasePoolEB(poolEB.runnerId);
+      } else {
+        // Session not found or missing URLs — release and retry
+        await releasePoolEB(poolEB.runnerId);
       }
-
-      // Session not found or missing URLs — release and retry
-      await releasePoolEB(poolEB.runnerId);
     }
 
     // Notify caller on first queue (so UI can update status)

--- a/src/server/actions/embedded-sessions.ts
+++ b/src/server/actions/embedded-sessions.ts
@@ -464,6 +464,33 @@ export async function isPoolBusy(): Promise<boolean> {
 }
 
 /**
+ * Snapshot of EB pool health for diagnostics. `online` is the number of idle,
+ * claimable system EBs; `size` is the total provisioned (online + busy + any
+ * in-flight provisions); `max` is the cluster cap. When a claim times out, a
+ * caller can render this to explain WHY (e.g. "0 online, 4 provisioned but not
+ * ready" → pods stuck pulling the image / pending) instead of a generic
+ * "all browsers busy". Internal/read-only — no auth, no sensitive data.
+ */
+export async function getEbPoolHealth(): Promise<{
+  online: number;
+  size: number;
+  max: number;
+}> {
+  const onlineRows = await db
+    .select({ id: runners.id })
+    .from(runners)
+    .where(
+      and(
+        eq(runners.isSystem, true),
+        eq(runners.status, "online"),
+        eq(runners.type, "embedded"),
+      ),
+    );
+  const [size, max] = await Promise.all([currentPoolSize(), poolMax()]);
+  return { online: onlineRows.length, size, max };
+}
+
+/**
  * Atomically claim an idle system EB from the pool.
  * Uses optimistic locking: SELECT one online EB, then UPDATE with WHERE status='online'
  * to prevent races. Retries up to 3 times if another caller grabs it first.

--- a/src/server/actions/onboarding.ts
+++ b/src/server/actions/onboarding.ts
@@ -28,8 +28,10 @@ export async function setBaseUrl(repositoryId: string, url: string) {
   if (schemeErr) throw new Error(`baseUrl rejected: ${schemeErr}`);
   const branch = repo.defaultBranch || "main";
   const existing = (repo.branchBaseUrls ?? {}) as Record<string, string>;
+  // Write only the branch key. (We used to also write a repo-wide "default"
+  // key, but the per-branch UI never updated it, so it went stale — removed.)
   await queries.updateRepository(repositoryId, {
-    branchBaseUrls: { ...existing, default: url, [branch]: url },
+    branchBaseUrls: { ...existing, [branch]: url },
   });
   // If the only test is an untouched auto-seeded sample (e.g. the herokuapp
   // demo), re-point it at the URL the user just entered so their first test

--- a/src/server/actions/quickstart-agent.ts
+++ b/src/server/actions/quickstart-agent.ts
@@ -16,6 +16,7 @@ import type {
 import { isQuickstartEnabled, gateReasonHint } from "@/lib/quickstart/gating";
 import {
   renderAuthSetupCode,
+  renderAuthLoginCode,
   renderWalkthroughCode,
   renderQuickstartEmail,
   renderQuickstartPassword,
@@ -351,16 +352,35 @@ async function runQsPreflight(
 
   const stamp = utcStamp();
   const slug = slugify(gate.repo.name);
-  const template =
-    gate.team.quickstartEmailTemplate ?? "viktor+{slug}{stamp}@lastest.cloud";
-  const email = renderQuickstartEmail(template, slug, stamp);
-  const password = renderQuickstartPassword(stamp);
+
+  // QuickStart runs against the user's OWN app. If they supplied real login
+  // credentials (set on the session at start), use those for a LOGIN handshake
+  // and skip generating a throwaway demo account. Otherwise fall back to a fresh
+  // demo signup via the team email template.
+  const preMeta = (await queries.getAgentSession(sessionId))?.metadata;
+  const credsProvided =
+    preMeta?.credsProvided === true &&
+    !!preMeta?.quickstartEmail &&
+    !!preMeta?.quickstartPassword;
+
+  let email: string;
+  let password: string;
+  if (credsProvided) {
+    email = preMeta!.quickstartEmail!;
+    password = preMeta!.quickstartPassword!;
+  } else {
+    const template =
+      gate.team.quickstartEmailTemplate ?? "viktor+{slug}{stamp}@lastest.cloud";
+    email = renderQuickstartEmail(template, slug, stamp);
+    password = renderQuickstartPassword(stamp);
+  }
 
   await mergeMetadata(sessionId, {
     quickstartEmail: email,
     quickstartPassword: password,
     quickstartSlug: slug,
     quickstartStamp: stamp,
+    credsProvided,
   });
 
   // Force the repo's EB error gates to "warn" before the first run. Founder
@@ -499,8 +519,8 @@ async function runQsAuthSetup(
 
   const meta = session.metadata;
   const publicScout = meta.publicScout;
-  if (!publicScout || !publicScout.authAutomatable) {
-    await setSkipped(sessionId, "qs_auth_setup", "auth flow not automatable");
+  if (!publicScout) {
+    await setSkipped(sessionId, "qs_auth_setup", "no public scout output");
     return true;
   }
 
@@ -508,49 +528,84 @@ async function runQsAuthSetup(
   const password = meta.quickstartPassword!;
   const stamp = meta.quickstartStamp!;
   const slug = meta.quickstartSlug!;
+  const credsProvided = meta.credsProvided === true;
 
-  if (!publicScout.registerPath) {
-    await setFailed(
-      sessionId,
-      "qs_auth_setup",
-      "Scout did not observe a register URL in the page DOM. Auth setup cannot proceed without one — no path guessing.",
-    );
-    return false;
+  // Decide the handshake. QuickStart runs against the user's OWN app:
+  //  - creds provided + a login surface exists  -> LOGIN (real creds, most reliable)
+  //  - else automatable email+password register -> SIGNUP (fresh demo account)
+  //  - else                                      -> skip (public-only walkthrough)
+  const canLogin =
+    credsProvided &&
+    !!publicScout.loginPath &&
+    (publicScout.classification === "email_password" ||
+      publicScout.classification === "login_email_password");
+  const canSignup = publicScout.authAutomatable && !!publicScout.registerPath;
+
+  let authMode: "login" | "signup";
+  let code: string;
+  let testName: string;
+  if (canLogin) {
+    authMode = "login";
+    code = renderAuthLoginCode({
+      email,
+      password,
+      loginUrl: publicScout.loginPath!,
+      apiLoginEndpoint: publicScout.apiLoginEndpoint ?? undefined,
+    });
+    testName = `${slug} — auth login`;
+  } else if (canSignup) {
+    authMode = "signup";
+    code = renderAuthSetupCode({
+      email,
+      password,
+      registerUrl: publicScout.registerPath!,
+    });
+    testName = `${slug} — auth setup`;
+  } else {
+    const reason = credsProvided
+      ? "Credentials were provided but the scout found no usable login form on the site — running public-only."
+      : publicScout.authAutomatable
+        ? "Scout did not observe a register URL in the page DOM — running public-only (no path guessing)."
+        : "auth flow not automatable — running public-only";
+    await mergeMetadata(sessionId, { authMode: "public_only" });
+    await setSkipped(sessionId, "qs_auth_setup", reason);
+    return true;
   }
 
-  const code = renderAuthSetupCode({
-    email,
-    password,
-    registerUrl: publicScout.registerPath,
-  });
-
-  // Persist the auth setup test so the founder-facing share carries it too.
+  // Persist the auth test so the authed scout can replay it and (in non-chained
+  // mode) the build includes it. Test code is team-gated; the public /r/ share
+  // renders screenshots + notes only, never code.
   const created = await queries.createTest({
     repositoryId,
-    name: `${slug} — auth setup`,
+    name: testName,
     code,
   });
   const testId = created.id;
 
-  // Capture storage state in a transient browser context.
+  // Capture storage state in a disposable runner/EB (or transient host browser).
   const captured = await captureStorageState({
     repositoryId,
     baseUrl: gate.baseUrl,
     testCode: code,
     name: `QuickStart auth ${slug} ${stamp}`,
+    tokenLocation: publicScout.tokenLocation,
+    authFlavor: publicScout.authLibrary,
   });
 
   await mergeMetadata(sessionId, {
+    authMode,
     authSetup: {
       testId,
       storageStateId: captured.storageStateId,
       captured: captured.captured,
       failureReason: captured.failureReason,
+      mode: authMode,
     },
   });
 
   await setCompleted(sessionId, "qs_auth_setup", {
     testId,
+    mode: authMode,
     captured: captured.captured,
     storageStateId: captured.storageStateId,
     failureReason: captured.failureReason,
@@ -671,13 +726,13 @@ async function runQsGenerate(
   }
 
   const slug = meta.quickstartSlug!;
-  // Authed walkthrough requires both: scout said automatable AND storage state
-  // was actually captured AND we have a storageStateId to chain. No fallback to
-  // inline-login (we don't guess login URLs).
+  // Authed walkthrough is driven purely by whether the auth-setup actually
+  // captured a chainable storage_state — true for BOTH the signup path
+  // (classification email_password) and the user-creds login path
+  // (login_email_password, where publicScout.authAutomatable is false). No
+  // fallback to inline-login (we don't guess login URLs).
   const authAutomatable =
-    publicScout.authAutomatable &&
-    (meta.authSetup?.captured ?? false) &&
-    !!meta.authSetup?.storageStateId;
+    (meta.authSetup?.captured ?? false) && !!meta.authSetup?.storageStateId;
 
   const biz = publicScout.businessInteraction;
   const code = renderWalkthroughCode({
@@ -1292,7 +1347,7 @@ async function executeQuickstart(
 
 export async function startQuickstart(
   repositoryId: string,
-  opts?: { emailTemplate?: string },
+  opts?: { emailTemplate?: string; appEmail?: string; appPassword?: string },
 ): Promise<{ sessionId: string }> {
   const { team } = await requireRepoAccess(repositoryId);
 
@@ -1304,6 +1359,16 @@ export async function startQuickstart(
       "quickstart_disabled";
     (err as Error & { code?: string; reason?: string }).reason = reason;
     throw err;
+  }
+
+  // Optional user-supplied login credentials for their own app. Both or neither.
+  const appEmail = opts?.appEmail?.trim();
+  const appPassword = opts?.appPassword;
+  const credsProvided = !!appEmail && !!appPassword;
+  if ((appEmail && !appPassword) || (!appEmail && appPassword)) {
+    throw new Error(
+      "Provide both an email and a password to use your app login, or neither.",
+    );
   }
 
   if (opts?.emailTemplate) {
@@ -1341,7 +1406,15 @@ export async function startQuickstart(
     status: "active",
     currentStepId: "qs_preflight",
     steps: buildInitialQsSteps(),
-    metadata: {},
+    // Seed user creds into metadata so preflight uses them for a LOGIN handshake.
+    // quickstartPassword is never returned by the GET /quickstart API (curated).
+    metadata: credsProvided
+      ? {
+          credsProvided: true,
+          quickstartEmail: appEmail,
+          quickstartPassword: appPassword,
+        }
+      : {},
   });
 
   emitActivity(

--- a/src/server/actions/quickstart-agent.ts
+++ b/src/server/actions/quickstart-agent.ts
@@ -21,6 +21,7 @@ import {
   renderQuickstartPassword,
   utcStamp,
   slugify,
+  AUTH_CHAIN_FAILED_MARKER,
 } from "@/lib/playwright/quickstart-templates";
 import {
   runQuickstartScoutPublic,
@@ -258,6 +259,64 @@ async function isCancelled(
 }
 
 // ---------------------------------------------------------------------------
+// Build helper — create a build and poll to completion. Used for the public-only
+// downgrade rerun inside runQsRunAndNotes. The primary run + the pairing rerun
+// keep their inline loops (they emit progress-specific activity between create
+// and poll); this helper is for the conditional auth-downgrade path only.
+// ---------------------------------------------------------------------------
+
+type QsBuildSummary = NonNullable<Awaited<ReturnType<typeof getBuildSummary>>>;
+
+async function runBuildAndWait(
+  repositoryId: string,
+  testIds: string[],
+  sessionId: string,
+  signal: AbortSignal,
+): Promise<
+  | { ok: true; buildId: string; summary: QsBuildSummary }
+  | { ok: false; error: string }
+> {
+  let buildId: string;
+  try {
+    const result = await createAndRunBuildCore(
+      "manual",
+      testIds,
+      repositoryId,
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+    if (!result.buildId) {
+      return {
+        ok: false,
+        error: `Build was queued (EB pool busy). Job ID: ${(result as { jobId?: string }).jobId ?? "unknown"}.`,
+      };
+    }
+    buildId = result.buildId;
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  const started = Date.now();
+  let summary = await getBuildSummary(buildId);
+  while (!summary || !summary.completedAt) {
+    if (Date.now() - started > BUILD_POLL_TIMEOUT_MS) {
+      return { ok: false, error: "Build timed out (>8 min)." };
+    }
+    if (await isCancelled(sessionId, signal)) {
+      return { ok: false, error: "cancelled" };
+    }
+    await new Promise((r) => setTimeout(r, BUILD_POLL_INTERVAL_MS));
+    summary = await getBuildSummary(buildId);
+  }
+  return { ok: true, buildId, summary };
+}
+
+// ---------------------------------------------------------------------------
 // Step runners
 // ---------------------------------------------------------------------------
 
@@ -304,10 +363,30 @@ async function runQsPreflight(
     quickstartStamp: stamp,
   });
 
+  // Force the repo's EB error gates to "warn" before the first run. Founder
+  // sites almost always emit benign console/network noise (analytics 401s,
+  // third-party scripts); with the default "fail" mode every clean screenshot
+  // reds the walk. The walkthrough template also route-blocks known noise, but
+  // this is the belt to that suspenders. Best-effort — never fail preflight on it.
+  let errorModesSet = false;
+  try {
+    await queries.upsertPlaywrightSettings(repositoryId, {
+      consoleErrorMode: "warn",
+      networkErrorMode: "warn",
+    });
+    errorModesSet = true;
+  } catch (err) {
+    console.warn(
+      "[QuickStart] could not set console/network error modes:",
+      err,
+    );
+  }
+
   await setCompleted(sessionId, "qs_preflight", {
     baseUrl: gate.baseUrl,
     slug,
     stamp,
+    errorModesSet,
   });
   emitActivity(
     teamId,
@@ -750,10 +829,74 @@ async function runQsRunAndNotes(
   }
 
   // Build run facts from the summary + test results
-  const build = await queries.getBuild(buildId);
-  const testResults = build?.testRunId
+  let build = await queries.getBuild(buildId);
+  let testResults = build?.testRunId
     ? await queries.getTestResultsWithTestInfo(build.testRunId).catch(() => [])
     : [];
+
+  // ── Post-run auth verification (the skill's "is the authed frame real?" gate) ──
+  // The walkthrough throws AUTH_CHAIN_FAILED_MARKER when the chained storage_state
+  // didn't replay an authenticated session. Rather than publish a red build (or
+  // login-page screenshots dressed up as authed), downgrade the walkthrough to
+  // public-only and rerun ONCE so the user still gets a clean public share, with
+  // the reason recorded in the demo notes.
+  const chainedAuth0 = !!meta.authSetup?.storageStateId;
+  let authDowngraded = false;
+  if (chainedAuth0) {
+    const wt = testResults.find((r) => r.testId === walkthroughTestId);
+    const wtFailed =
+      !!wt && (wt.status === "failed" || wt.status === "setup_failed");
+    const authChainFailed =
+      wtFailed && (wt?.errorMessage ?? "").includes(AUTH_CHAIN_FAILED_MARKER);
+    if (authChainFailed) {
+      emitActivity(
+        teamId,
+        repositoryId,
+        sessionId,
+        "step:start",
+        "Login session did not verify — downgrading walkthrough to public-only and re-running",
+        { stepId: "qs_run_and_notes" },
+      );
+      const biz = meta.publicScout?.businessInteraction;
+      const publicOnlyCode = renderWalkthroughCode({
+        authAutomatable: false,
+        chainedAuth: false,
+        primaryInputLabel: biz?.primaryInputLabel,
+        primaryCtaLabel: biz?.primaryCtaLabel,
+        demoInputValue: biz?.demoInputValue,
+      });
+      await queries.updateTest(walkthroughTestId, {
+        code: publicOnlyCode,
+        setupOverrides: null,
+      });
+      const rerun = await runBuildAndWait(
+        repositoryId,
+        [walkthroughTestId],
+        sessionId,
+        signal,
+      );
+      if (rerun.ok) {
+        buildId = rerun.buildId;
+        summary = rerun.summary;
+        build = await queries.getBuild(buildId);
+        testResults = build?.testRunId
+          ? await queries
+              .getTestResultsWithTestInfo(build.testRunId)
+              .catch(() => [])
+          : [];
+        authDowngraded = true;
+        await mergeMetadata(sessionId, { buildId });
+      } else {
+        // Downgrade rerun failed to start/complete; keep the original (red)
+        // build so the failure stays visible rather than vanishing.
+        console.warn(
+          "[QuickStart] public-only downgrade rerun failed:",
+          rerun.error,
+        );
+      }
+    }
+  }
+
   const runFacts: QuickstartRunFacts = {
     passedCount: summary.passedCount,
     failedCount: summary.failedCount,
@@ -781,6 +924,7 @@ async function runQsRunAndNotes(
       authedScout: meta.authedScout,
       authSetup: meta.authSetup,
       runFacts,
+      authVerificationFailed: authDowngraded,
     });
     await queries.upsertBuildDemoNotes(buildId, notes);
     demoNotesPersisted = true;
@@ -797,6 +941,7 @@ async function runQsRunAndNotes(
     failed: summary.failedCount,
     changes: summary.changesDetected,
     demoNotesPersisted,
+    authDowngraded,
   });
 
   emitActivity(

--- a/src/server/actions/quickstart-agent.ts
+++ b/src/server/actions/quickstart-agent.ts
@@ -37,7 +37,7 @@ import { createAndRunBuildCore, getBuildSummary } from "./builds";
 import { approveAllDiffs } from "./diffs";
 import { publishBuildShare } from "./public-shares";
 import { claimEmbeddedBrowserForAgent } from "./ai";
-import { releasePoolEB } from "./embedded-sessions";
+import { releasePoolEB, getEbPoolHealth } from "./embedded-sessions";
 import { emitAndPersistActivityEvent } from "@/lib/db/queries/activity-events";
 import { db } from "@/lib/db";
 import { embeddedSessions } from "@/lib/db/schema";
@@ -350,6 +350,37 @@ async function runBuildAndWait(
 }
 
 // ---------------------------------------------------------------------------
+// EB claim failure diagnostics
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an actionable failure message for a scout step that couldn't get an
+ * Embedded Browser. `claimErr` is the error the claim path threw (usually
+ * swallowed by `.catch(() => undefined)`); when the claim merely timed out it's
+ * undefined, so we probe pool health to explain WHY. The most common dev cause
+ * is the EB image not being imported into the k3d cluster (pods stuck in
+ * ImagePullBackOff / Pending) — surfaced here instead of a bare "all browsers
+ * are busy", which sent operators chasing the wrong thing.
+ */
+async function describeEbClaimFailure(claimErr: unknown): Promise<string> {
+  if (claimErr instanceof Error && claimErr.message) {
+    return `Couldn't get a browser for the scout: ${claimErr.message}`;
+  }
+  const health = await getEbPoolHealth().catch(() => null);
+  if (!health) {
+    return "Couldn't get a browser for the scout: no Embedded Browser became available, and pool health could not be read.";
+  }
+  if (health.size > health.online) {
+    const unready = health.size - health.online;
+    return `Couldn't get a browser for the scout: ${health.online} ready, ${unready} provisioned but not ready (cap ${health.max}). EB pods are likely unhealthy — stuck pulling the image (ImagePullBackOff) or pending on resources. An operator may need to restart the EB pool (pnpm stack:refresh:eb).`;
+  }
+  if (health.size >= health.max) {
+    return `Couldn't get a browser for the scout: all ${health.max} browsers are busy and the pool is at capacity. Try again once a run finishes.`;
+  }
+  return `Couldn't get a browser for the scout: no Embedded Browser became ready (${health.online} ready, pool ${health.size}/${health.max}). The EB pool may be unhealthy — an operator may need to restart it (pnpm stack:refresh:eb).`;
+}
+
+// ---------------------------------------------------------------------------
 // Step runners
 // ---------------------------------------------------------------------------
 
@@ -474,15 +505,19 @@ async function runQsScoutPublic(
   // Chromium (applyScoutMcpWiring would launch @playwright/mcp without a
   // --cdp-endpoint, the exact in-host execution this codebase forbids). While
   // waiting, surface "queued" so the panel reflects the pool back-pressure.
+  let claimErr: unknown;
   const eb = await claimEmbeddedBrowserForAgent(5 * 60 * 1000, () => {
     mergeMetadata(sessionId, { queuedForBrowser: true }).catch(() => {});
-  }).catch(() => undefined);
+  }).catch((e) => {
+    claimErr = e;
+    return undefined;
+  });
   if (!eb) {
     await mergeMetadata(sessionId, { queuedForBrowser: false }).catch(() => {});
     await setFailed(
       sessionId,
       "qs_scout_public",
-      "All browsers are busy. Please try again later.",
+      await describeEbClaimFailure(claimErr),
     );
     return false;
   }
@@ -698,15 +733,19 @@ async function runQsScoutAuthed(
 
   // Hard-fail when no EB is available — never fall through to a host-process
   // Chromium (see runQsScoutPublic for the rationale).
+  let claimErr: unknown;
   const eb = await claimEmbeddedBrowserForAgent(5 * 60 * 1000, () => {
     mergeMetadata(sessionId, { queuedForBrowser: true }).catch(() => {});
-  }).catch(() => undefined);
+  }).catch((e) => {
+    claimErr = e;
+    return undefined;
+  });
   if (!eb) {
     await mergeMetadata(sessionId, { queuedForBrowser: false }).catch(() => {});
     await setFailed(
       sessionId,
       "qs_scout_authed",
-      "All browsers are busy. Please try again later.",
+      await describeEbClaimFailure(claimErr),
     );
     return false;
   }

--- a/src/server/actions/quickstart-agent.ts
+++ b/src/server/actions/quickstart-agent.ts
@@ -39,6 +39,38 @@ import { publishBuildShare } from "./public-shares";
 import { claimEmbeddedBrowserForAgent } from "./ai";
 import { releasePoolEB } from "./embedded-sessions";
 import { emitAndPersistActivityEvent } from "@/lib/db/queries/activity-events";
+import { db } from "@/lib/db";
+import { embeddedSessions } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import { toProxyStreamUrl } from "@/lib/eb/stream-url";
+import { appendStreamToken } from "@/lib/eb/stream-token";
+
+/**
+ * Normalise a raw EB `ws://host:port` stream URL into a browser-routable form for
+ * the QuickStart panel's live view: a same-origin proxy path (works on HTTPS +
+ * k3s dev where pod IPs aren't routable) plus the stream auth token. Mirrors the
+ * build page's stream wiring.
+ */
+function proxiedStream(raw: string | null | undefined): string | undefined {
+  if (!raw) return undefined;
+  const proxied = toProxyStreamUrl(raw) ?? raw;
+  return appendStreamToken(proxied, process.env.STREAM_AUTH_TOKEN) || undefined;
+}
+
+/** Resolve the live stream URL of the EB currently running a build's test run. */
+async function resolveBuildStreamUrl(
+  buildId: string,
+): Promise<string | undefined> {
+  const build = await queries.getBuild(buildId);
+  if (!build?.testRunId) return undefined;
+  const testRun = await queries.getTestRun(build.testRunId);
+  if (!testRun?.runnerId) return undefined;
+  const [sess] = await db
+    .select({ streamUrl: embeddedSessions.streamUrl })
+    .from(embeddedSessions)
+    .where(eq(embeddedSessions.runnerId, testRun.runnerId));
+  return proxiedStream(sess?.streamUrl);
+}
 
 // ---------------------------------------------------------------------------
 // Step definitions
@@ -456,7 +488,7 @@ async function runQsScoutPublic(
   }
   // Surface the EB's live screencast so the panel can show the scout browsing.
   await mergeMetadata(sessionId, {
-    streamUrl: eb?.streamUrl,
+    streamUrl: proxiedStream(eb?.streamUrl),
     queuedForBrowser: false,
   });
   try {
@@ -679,7 +711,7 @@ async function runQsScoutAuthed(
     return false;
   }
   await mergeMetadata(sessionId, {
-    streamUrl: eb?.streamUrl,
+    streamUrl: proxiedStream(eb?.streamUrl),
     queuedForBrowser: false,
   });
   try {
@@ -872,8 +904,11 @@ async function runQsRunAndNotes(
     { stepId: "qs_run_and_notes", artifactType: "build", artifactId: buildId },
   );
 
-  // Poll for completion
+  // Poll for completion. Surface the run's live EB stream into the panel as soon
+  // as the EB picks up the test (set once), so the two-column view shows the
+  // walkthrough run — including the canvas-draw step — not just the scout phases.
   const started = Date.now();
+  let streamSurfaced = false;
   let summary = await getBuildSummary(buildId);
   while (!summary || !summary.completedAt) {
     if (Date.now() - started > BUILD_POLL_TIMEOUT_MS) {
@@ -885,9 +920,18 @@ async function runQsRunAndNotes(
       return false;
     }
     if (await isCancelled(sessionId, signal)) return false;
+    if (!streamSurfaced) {
+      const live = await resolveBuildStreamUrl(buildId).catch(() => undefined);
+      if (live) {
+        await mergeMetadata(sessionId, { streamUrl: live });
+        streamSurfaced = true;
+      }
+    }
     await new Promise((r) => setTimeout(r, BUILD_POLL_INTERVAL_MS));
     summary = await getBuildSummary(buildId);
   }
+  // Build done — stop the panel pointing at the (about-to-be-released) build EB.
+  await mergeMetadata(sessionId, { streamUrl: undefined });
   // After the loop, summary is non-null and has a completedAt; help TS narrow.
   if (!summary) {
     await setFailed(
@@ -1149,6 +1193,7 @@ async function runQsRerunAfterApproval(
   );
 
   const started = Date.now();
+  let rerunStreamSurfaced = false;
   let summary = await getBuildSummary(rerunBuildId);
   while (!summary || !summary.completedAt) {
     if (Date.now() - started > BUILD_POLL_TIMEOUT_MS) {
@@ -1160,9 +1205,19 @@ async function runQsRerunAfterApproval(
       return false;
     }
     if (await isCancelled(sessionId, signal)) return false;
+    if (!rerunStreamSurfaced) {
+      const live = await resolveBuildStreamUrl(rerunBuildId).catch(
+        () => undefined,
+      );
+      if (live) {
+        await mergeMetadata(sessionId, { streamUrl: live });
+        rerunStreamSurfaced = true;
+      }
+    }
     await new Promise((r) => setTimeout(r, BUILD_POLL_INTERVAL_MS));
     summary = await getBuildSummary(rerunBuildId);
   }
+  await mergeMetadata(sessionId, { streamUrl: undefined });
 
   await setCompleted(sessionId, "qs_rerun_after_approval", {
     rerunBuildId,

--- a/src/server/actions/quickstart-agent.ts
+++ b/src/server/actions/quickstart-agent.ts
@@ -44,6 +44,7 @@ import { embeddedSessions } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { toProxyStreamUrl } from "@/lib/eb/stream-url";
 import { appendStreamToken } from "@/lib/eb/stream-token";
+import { chromium, type Browser } from "playwright";
 
 /**
  * Normalise a raw EB `ws://host:port` stream URL into a browser-routable form for
@@ -700,6 +701,90 @@ async function runQsAuthSetup(
   return true;
 }
 
+/**
+ * Inject a captured storage_state (cookies + localStorage) into the EB's default
+ * browser context over CDP, so the authed scout starts already-signed-in. This
+ * removes the LLM-driven login replay that made `qs_scout_authed` the slowest
+ * step (~3.5min): the session was already captured 16s earlier in `qs_auth_setup`,
+ * so re-driving the form through the model is pure waste.
+ *
+ * Targets `browser.contexts()[0]` — the persistent default context that
+ * `@playwright/mcp --cdp-endpoint` reuses — NOT a fresh `newContext` (which MCP
+ * would never see). `browser.close()` over connectOverCDP only disconnects the
+ * CDP session; it does not terminate the EB's Chromium (mirrors play-agent.ts).
+ *
+ * Returns whether enough session material (cookies and/or localStorage) was
+ * injected to consider the browser pre-authenticated. IndexedDB-only captures
+ * (e.g. Firebase) inject nothing here → caller falls back to seed replay.
+ */
+async function injectStorageStateIntoEb(
+  cdpUrl: string,
+  storageStateJson: string,
+): Promise<boolean> {
+  let browser: Browser | null = null;
+  try {
+    const parsed = JSON.parse(storageStateJson) as {
+      cookies?: Array<Record<string, unknown>>;
+      origins?: Array<{
+        origin?: string;
+        localStorage?: Array<{ name: string; value: string }>;
+      }>;
+    };
+    const cookies = Array.isArray(parsed.cookies) ? parsed.cookies : [];
+    const origins = Array.isArray(parsed.origins) ? parsed.origins : [];
+    const hasLocalStorage = origins.some(
+      (o) => Array.isArray(o.localStorage) && o.localStorage.length > 0,
+    );
+    // Nothing cookie/localStorage-shaped to inject (e.g. IndexedDB-only Firebase
+    // capture) — let the caller fall back to LLM seed replay.
+    if (cookies.length === 0 && !hasLocalStorage) return false;
+
+    browser = await chromium.connectOverCDP(cdpUrl);
+    const ctx = browser.contexts()[0];
+    if (!ctx) return false;
+
+    if (cookies.length > 0) {
+      // Cookies come straight from Playwright's own storageState() capture, so
+      // they already match addCookies' param shape — route through `unknown` to
+      // satisfy the structural check on the loosely-parsed JSON.
+      await ctx.addCookies(
+        cookies as unknown as Parameters<typeof ctx.addCookies>[0],
+      );
+    }
+    for (const o of origins) {
+      const ls = Array.isArray(o.localStorage) ? o.localStorage : [];
+      if (!o.origin || ls.length === 0) continue;
+      const page = await ctx.newPage();
+      try {
+        await page
+          .goto(o.origin, { waitUntil: "domcontentloaded", timeout: 10000 })
+          .catch(() => {});
+        await page.evaluate((items) => {
+          for (const it of items) {
+            try {
+              window.localStorage.setItem(it.name, it.value);
+            } catch {
+              /* quota / opaque origin — best effort */
+            }
+          }
+        }, ls);
+      } finally {
+        await page.close().catch(() => {});
+      }
+    }
+    return true;
+  } catch (err) {
+    console.warn(
+      `[QuickStart authed-scout] storage_state injection failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return false;
+  } finally {
+    if (browser) await browser.close().catch(() => {});
+  }
+}
+
 async function runQsScoutAuthed(
   sessionId: string,
   repositoryId: string,
@@ -754,11 +839,25 @@ async function runQsScoutAuthed(
     queuedForBrowser: false,
   });
   try {
+    // Pre-authenticate the EB by injecting the storage_state captured in
+    // qs_auth_setup, so the scout never re-drives the sign-in form through the
+    // model. Falls back to seed replay when nothing injectable was captured.
+    let preAuthenticated = false;
+    if (authSetup.storageStateId) {
+      const ss = await queries.getStorageState(authSetup.storageStateId);
+      if (ss?.storageStateJson) {
+        preAuthenticated = await injectStorageStateIntoEb(
+          eb.cdpUrl,
+          ss.storageStateJson,
+        );
+      }
+    }
+
     const { data, promptLogId } = await runQuickstartScoutAuthed(
       repositoryId,
       gate.baseUrl,
       authTest.code,
-      { cdpEndpoint: eb.cdpUrl },
+      { cdpEndpoint: eb.cdpUrl, preAuthenticated },
     );
     await mergeMetadata(sessionId, { authedScout: data });
     await setCompleted(sessionId, "qs_scout_authed", {

--- a/src/server/actions/quickstart-agent.ts
+++ b/src/server/actions/quickstart-agent.ts
@@ -440,11 +440,13 @@ async function runQsScoutPublic(
   // any ambient @playwright/mcp process. Mirrors healer/generator pattern.
   // Hard-fail when no EB is available — never fall through to a host-process
   // Chromium (applyScoutMcpWiring would launch @playwright/mcp without a
-  // --cdp-endpoint, the exact in-host execution this codebase forbids).
-  const eb = await claimEmbeddedBrowserForAgent(5 * 60 * 1000).catch(
-    () => undefined,
-  );
+  // --cdp-endpoint, the exact in-host execution this codebase forbids). While
+  // waiting, surface "queued" so the panel reflects the pool back-pressure.
+  const eb = await claimEmbeddedBrowserForAgent(5 * 60 * 1000, () => {
+    mergeMetadata(sessionId, { queuedForBrowser: true }).catch(() => {});
+  }).catch(() => undefined);
   if (!eb) {
+    await mergeMetadata(sessionId, { queuedForBrowser: false }).catch(() => {});
     await setFailed(
       sessionId,
       "qs_scout_public",
@@ -452,6 +454,11 @@ async function runQsScoutPublic(
     );
     return false;
   }
+  // Surface the EB's live screencast so the panel can show the scout browsing.
+  await mergeMetadata(sessionId, {
+    streamUrl: eb?.streamUrl,
+    queuedForBrowser: false,
+  });
   try {
     const { data, promptLogId } = await runQuickstartScoutPublic(
       repositoryId,
@@ -500,6 +507,8 @@ async function runQsScoutPublic(
     return false;
   } finally {
     if (eb) await releasePoolEB(eb.runnerId).catch(() => {});
+    // Stop the panel pointing at a released EB.
+    await mergeMetadata(sessionId, { streamUrl: undefined }).catch(() => {});
   }
 }
 
@@ -657,10 +666,11 @@ async function runQsScoutAuthed(
 
   // Hard-fail when no EB is available — never fall through to a host-process
   // Chromium (see runQsScoutPublic for the rationale).
-  const eb = await claimEmbeddedBrowserForAgent(5 * 60 * 1000).catch(
-    () => undefined,
-  );
+  const eb = await claimEmbeddedBrowserForAgent(5 * 60 * 1000, () => {
+    mergeMetadata(sessionId, { queuedForBrowser: true }).catch(() => {});
+  }).catch(() => undefined);
   if (!eb) {
+    await mergeMetadata(sessionId, { queuedForBrowser: false }).catch(() => {});
     await setFailed(
       sessionId,
       "qs_scout_authed",
@@ -668,6 +678,10 @@ async function runQsScoutAuthed(
     );
     return false;
   }
+  await mergeMetadata(sessionId, {
+    streamUrl: eb?.streamUrl,
+    queuedForBrowser: false,
+  });
   try {
     const { data, promptLogId } = await runQuickstartScoutAuthed(
       repositoryId,
@@ -702,6 +716,7 @@ async function runQsScoutAuthed(
     return true;
   } finally {
     if (eb) await releasePoolEB(eb.runnerId).catch(() => {});
+    await mergeMetadata(sessionId, { streamUrl: undefined }).catch(() => {});
   }
 }
 

--- a/src/server/actions/repos.ts
+++ b/src/server/actions/repos.ts
@@ -257,7 +257,10 @@ export async function createLocalRepo(
     owner: "local",
     name,
     fullName: name,
-    ...(baseUrl ? { branchBaseUrls: { default: baseUrl } } : {}),
+    // Seed the base URL under the conventional default branch. (We used to
+    // write a repo-wide "default" key here, but it was never updated by the
+    // per-branch base-URL UI and went stale — see pickRepoBaseUrl.)
+    ...(baseUrl ? { branchBaseUrls: { main: baseUrl } } : {}),
   });
   // Auto-select the new repo on user
   await queries.updateUser(session.user.id, { selectedRepositoryId: repo.id });


### PR DESCRIPTION
## QuickStart — make it a first-class, self-serve feature

QuickStart runs a 9-step agent pipeline against a repo's base URL and publishes a public `/r/<slug>` founder report. This PR makes that value visible, lowers the barrier to running it, gives the report a presentable graded framing, and promotes the feature out of Early Adopter.

### Done in this branch

**1. Surface the published share** — the client dropped the serialized `shareUrl`/`shareSlug` on the floor. Now a prominent **"Founder share ready"** block appears on completion with `/r/<slug>` + **Open report** + **Copy link**. Completed the step-label map.

**2. Inline base-URL entry** — the `no_base_url` empty state no longer punts you to the sidebar. It takes the repo's `defaultBranch` and writes straight to the gate's key (`saveBranchBaseUrl`), then `router.refresh()`es so the gate re-evaluates in place.

**3. Presentable graded report card on the share** — the share showed raw a11y/perf *numbers*; now graded letter-grade tiles via `scoreGrade()` + `GradeCard` (reuses `StatCard`):
- **Accessible** — `build.a11yScore` (WCAG 2.2)
- **Design** — `build.designSystemScore` (when present)
- **Fast** — absolute Core Web Vitals from `test_results.webVitals`, scored against Google's standard good/NI/poor thresholds (LCP 2500/4000ms, INP 200/500ms, CLS 0.1/0.25). Chosen over the perf *diff* layer, which is regression-only and empty on baseline-less first runs. Renders "—" when no vitals were captured.
- Grids size themselves to the tiles present (`gridColsClass`). Both build-wide and test-scoped layouts.
- Only new data plumbing: projecting `webVitals` into `ShareTestResult`. No schema/DB change.

**4. Dashboard: hide the Play Agent** (Auto Setup Agent) timeline.

**5. Promote QuickStart out of Early Adopter** — dropped the `earlyAdopterMode` gate in `isQuickstartEnabled` and the dashboard mount condition; removed the "early adopter" badges. QuickStart now only requires a non-local base URL (and not `banAiMode`).

All changes typecheck (`tsc --noEmit`, Node 20) + lint clean. `gating.test.ts` (covers `pickRepoBaseUrl`) still passes.

### Heads-up
Promoting out of EA exposes QuickStart to every team — each run consumes an EB pod + AI. Worth a glance at provisioning/quota before this lands.

### Why (competitive context)
Closest competitor `prufa.dev` productized our manual `/gtm-lastest-saas-demo` motion into a self-serve, no-login audit returning a shareable **graded** report card (Works/Fast/Accessible/Compliant…). This PR gives QuickStart the same one-tap-share + graded framing, built on our existing a11y/design/perf verify layers.

### Possible follow-ups
- [ ] Build-level `perf_score` column (today computed on-read from per-result vitals).
- [ ] SSE instead of 2.5s polling for the live timeline.
- [ ] AEO check (robots.txt AI-crawler block) in the scout.
- [ ] Remove now-dead `not_early_adopter` reason from the gate union/hint (left as a harmless superset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)