### PR TITLE
feat(share): video subtitles for public recording shares

### DIFF
--- a/src/app/(public)/r/[slug]/page.tsx
+++ b/src/app/(public)/r/[slug]/page.tsx
@@ -334,6 +334,23 @@ export default async function PublicSharePage({ params }: PageProps) {
       (await getBuildDemoNotes(build.id)))
     : await getBuildDemoNotes(build.id);
 
+  // Subtitle track for the recording. Captions are time-coded to THIS build's
+  // recording, so they're read from the build's OWN notes — not the repo-latest
+  // `demoNotes` (which feeds the prose panel and may belong to a sibling build
+  // whose video has different step timing). Only emit a <track> when captions
+  // exist; absent captions → no track → the player renders exactly as before.
+  const buildCaptions = (await getBuildDemoNotes(build.id))?.captions ?? [];
+  const captionTracks =
+    buildCaptions.length > 0
+      ? [
+          {
+            src: `/share/${slug}/captions.vtt`,
+            srclang: "en",
+            label: "English",
+          },
+        ]
+      : undefined;
+
   // Lastest awards: render the earned-badges + embed block when the repo has
   // a tier. Resolved by repositoryId — works for both build and test shares.
   const award: RepoAward | null = repoIdForNotes
@@ -364,7 +381,7 @@ export default async function PublicSharePage({ params }: PageProps) {
                 the page reads as a video watch page (Google's "video is the
                 main content" signal) and the player has an accessible label. */}
             <figure className="m-0 space-y-2">
-              <ShareVideoPlayer clips={clips} />
+              <ShareVideoPlayer clips={clips} tracks={captionTracks} />
               <figcaption className="text-sm text-muted-foreground">
                 Recording of the visual regression run on {displayDomain}
                 {test?.name ? ` · ${test.name}` : ""}.

--- a/src/app/(public)/share/[slug]/captions.vtt/route.ts
+++ b/src/app/(public)/share/[slug]/captions.vtt/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest } from "next/server";
+import { getPublicShareContext } from "@/lib/db/queries/public-shares";
+import { getBuildDemoNotes } from "@/lib/db/queries/demo-notes";
+import { isValidShareSlug } from "@/lib/share/slug";
+import { captionsToVtt } from "@/lib/share/vtt";
+
+// Serve the share recording's subtitle track as a real WebVTT file so the
+// <video> on /r/<slug> can attach it via <track src=".../captions.vtt">.
+//
+// A literal `captions.vtt` segment out-ranks the sibling `[...path]` catch-all
+// in Next's route matching, so this never collides with the media route — and
+// because captions are generated text (not a storage file), they don't need a
+// place in that route's path allow-list.
+//
+// Captions are time-coded to the share's PINNED build recording, so they're
+// resolved from that build's own notes — NOT the repo-latest used for the prose
+// panel. Otherwise a sibling share in the same repo would inherit cues whose
+// timing matches a different video.
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  if (!isValidShareSlug(slug)) {
+    return new Response("Bad Request", { status: 400 });
+  }
+
+  const ctx = await getPublicShareContext(slug);
+  if (!ctx) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  const notes = await getBuildDemoNotes(ctx.build.id);
+  const captions = notes?.captions ?? [];
+  if (captions.length === 0) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  return new Response(captionsToVtt(captions), {
+    status: 200,
+    headers: {
+      "Content-Type": "text/vtt; charset=utf-8",
+      // Captions can change when a run regenerates them, so keep the TTL short
+      // and revalidate rather than the immutable year-long cache the media
+      // route uses for content-addressed assets.
+      "Cache-Control": "public, max-age=60, must-revalidate",
+    },
+  });
+}

--- a/src/app/api/v1/[...slug]/route.ts
+++ b/src/app/api/v1/[...slug]/route.ts
@@ -81,12 +81,68 @@ import {
   extractSourceIp,
 } from "@/lib/url-diff/ssrf";
 import { checkRateLimit } from "@/lib/url-diff/rate-limit";
+import {
+  generateAndStoreCaptionsForBuild,
+  storeCaptionsForBuild,
+} from "@/lib/share/generate-captions";
+import type { VideoCaption } from "@/lib/db/schema";
 
 // Helper to verify API auth. `getCurrentSession` already handles both cookie
 // sessions and `Authorization: Bearer <token>` headers, so v1 and any
 // downstream server actions share the same resolution path.
 async function verifyAuth(_request: NextRequest) {
   return getCurrentSession();
+}
+
+// Coerce an untrusted request body into a clean VideoCaption[] (used by the
+// manual, no-AI authoring path). Drops anything malformed rather than failing
+// the whole write so a partially-bad payload still stores its good cues.
+function sanitizeCaptions(raw: unknown): VideoCaption[] {
+  const arr = Array.isArray(raw)
+    ? raw
+    : Array.isArray((raw as { captions?: unknown })?.captions)
+      ? (raw as { captions: unknown[] }).captions
+      : [];
+  const num = (v: unknown): number | null =>
+    typeof v === "number" && Number.isFinite(v) ? v : null;
+  const out: VideoCaption[] = [];
+  for (const c of arr) {
+    if (!c || typeof c !== "object") continue;
+    const o = c as Record<string, unknown>;
+    const stepIndex = num(o.stepIndex);
+    const startMs = num(o.startMs);
+    const endMs = num(o.endMs);
+    if (
+      stepIndex == null ||
+      startMs == null ||
+      endMs == null ||
+      typeof o.text !== "string" ||
+      o.text.trim().length === 0
+    )
+      continue;
+    const ann = o.annotation;
+    const annotation =
+      ann === "arrow" || ann === "underline" || ann === "box" ? ann : undefined;
+    let focus: VideoCaption["focus"];
+    const f = o.focus as Record<string, unknown> | undefined;
+    if (f && typeof f === "object") {
+      const x = num(f.x);
+      const y = num(f.y);
+      const w = num(f.w);
+      const h = num(f.h);
+      if (x != null && y != null && w != null && h != null)
+        focus = { x, y, w, h };
+    }
+    out.push({
+      stepIndex,
+      startMs,
+      endMs,
+      text: o.text.trim(),
+      focus,
+      annotation,
+    });
+  }
+  return out;
 }
 
 // Map thrown auth errors from server actions to proper HTTP status codes
@@ -2093,6 +2149,51 @@ export async function POST(
       }
       await queries.upsertBuildDemoNotes(id, payload);
       return NextResponse.json({ ok: true }, { status: 201 });
+    }
+
+    // Write/generate share recording captions: POST /api/v1/builds/:id/captions
+    //   ?generate=true  → run the AI vision pass over the build's primary
+    //                     recording and store the cues (needs a vision-capable
+    //                     provider in the repo's AI settings).
+    //   otherwise       → store a caller-supplied VideoCaption[] verbatim
+    //                     (body = array or { captions: [...] }). Lets an agent
+    //                     author captions the same way it authors demo-notes.
+    // Cues are merged into the build's demo-notes payload, so the /r/<slug>
+    // share page picks them up via the captions.vtt route with no extra wiring.
+    if (resource === "builds" && id && subResource === "captions") {
+      if (!(await verifyBuildOwnership(id, session))) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+      }
+      const generate = request.nextUrl.searchParams.get("generate") === "true";
+      if (generate) {
+        const result = await generateAndStoreCaptionsForBuild(id);
+        if (result.count === 0) {
+          return NextResponse.json(
+            { error: "No captions generated", reason: result.reason },
+            { status: 422 },
+          );
+        }
+        return NextResponse.json(
+          { ok: true, count: result.count },
+          { status: 201 },
+        );
+      }
+      const body = await request.json().catch(() => null);
+      const captions = sanitizeCaptions(body);
+      if (captions.length === 0) {
+        return NextResponse.json(
+          {
+            error:
+              "Body must contain a non-empty VideoCaption[] (or { captions: [...] })",
+          },
+          { status: 400 },
+        );
+      }
+      await storeCaptionsForBuild(id, captions);
+      return NextResponse.json(
+        { ok: true, count: captions.length },
+        { status: 201 },
+      );
     }
 
     // Verify phase: POST /api/v1/verify/layer-feedback

--- a/src/components/replay-player.tsx
+++ b/src/components/replay-player.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { VideoPlayer, type VideoPlayerHandle } from "@/components/video-player";
+import {
+  VideoPlayer,
+  type VideoPlayerHandle,
+  type VideoTextTrack,
+} from "@/components/video-player";
 
 export interface ReplayClip {
   src: string;
@@ -30,6 +34,12 @@ export interface ReplayPlayerProps {
    */
   clips: ReplayClip[];
   className?: string;
+  /**
+   * Subtitle tracks for the recording. Attached to the FIRST clip only (the
+   * hero/primary player) — the share page's caption track describes the
+   * primary test result's run.
+   */
+  tracks?: VideoTextTrack[];
 }
 
 /**
@@ -40,7 +50,7 @@ export interface ReplayPlayerProps {
  * single component means scrubber, hover-preview, and step-seek behavior
  * stay aligned across surfaces.
  */
-export function ReplayPlayer({ clips, className }: ReplayPlayerProps) {
+export function ReplayPlayer({ clips, className, tracks }: ReplayPlayerProps) {
   const handlesRef = useRef<(VideoPlayerHandle | null)[]>([]);
 
   useEffect(() => {
@@ -64,6 +74,7 @@ export function ReplayPlayer({ clips, className }: ReplayPlayerProps) {
           src={clip.src}
           poster={clip.poster ?? undefined}
           durationMsFallback={clip.durationMs ?? null}
+          tracks={i === 0 ? tracks : undefined}
           autoPlay
           loop
           playsInline

--- a/src/components/replay-player.tsx
+++ b/src/components/replay-player.tsx
@@ -75,6 +75,7 @@ export function ReplayPlayer({ clips, className, tracks }: ReplayPlayerProps) {
           poster={clip.poster ?? undefined}
           durationMsFallback={clip.durationMs ?? null}
           tracks={i === 0 ? tracks : undefined}
+          captionsDefaultOn={i === 0 && !!tracks && tracks.length > 0}
           autoPlay
           loop
           playsInline

--- a/src/components/video-player.tsx
+++ b/src/components/video-player.tsx
@@ -179,6 +179,10 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
     const [muted, setMuted] = useState(initialMuted);
     const [playbackRate, setPlaybackRate] = useState(defaultPlaybackRate);
     const [captionsOn, setCaptionsOn] = useState(captionsDefaultOn);
+    // Active cue text for our custom caption bar. We render captions ourselves
+    // (track mode stays "hidden") so they can sit ABOVE the controls instead of
+    // the browser's default bottom position, which overlaps the control bar.
+    const [activeCueText, setActiveCueText] = useState<string | null>(null);
     const [isFullscreen, setIsFullscreen] = useState(false);
     const [isScrubbing, setIsScrubbing] = useState(false);
     const [controlsVisible, setControlsVisible] = useState(true);
@@ -212,28 +216,65 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       }
     }, [mutedProp]);
 
-    // Apply the captions on/off choice to the <video>'s text tracks. The
-    // browser exposes them via `video.textTracks` once the <track> children
-    // mount; flip every track's mode and persist the preference. Re-runs when
-    // the track set changes so a late-arriving track inherits the current
-    // state.
+    // Drive captions. We never use "showing" mode — that would let the browser
+    // paint cues at the bottom of the video, on top of the controls. Instead we
+    // keep enabled tracks in "hidden" mode (cues still parse and `cuechange`
+    // still fires) and render the active cue ourselves in a bar positioned
+    // above the controls (see the caption overlay in the JSX). When off, tracks
+    // go "disabled" so the browser does no cue work. Persists the preference and
+    // re-runs when the track set changes so a late-arriving track is handled.
     useEffect(() => {
       const v = videoRef.current;
       if (!v) return;
-      const apply = () => {
+
+      const syncMode = () => {
         for (let i = 0; i < v.textTracks.length; i++) {
-          v.textTracks[i]!.mode = captionsOn ? "showing" : "hidden";
+          v.textTracks[i]!.mode = captionsOn ? "hidden" : "disabled";
         }
       };
-      apply();
-      // Tracks can register slightly after mount; `addtrack` catches that.
-      v.textTracks.addEventListener?.("addtrack", apply);
+      const readActiveCue = () => {
+        if (!captionsOn) {
+          setActiveCueText(null);
+          return;
+        }
+        for (let i = 0; i < v.textTracks.length; i++) {
+          const tt = v.textTracks[i]!;
+          if (tt.mode === "disabled") continue;
+          const cues = tt.activeCues;
+          if (cues && cues.length > 0) {
+            setActiveCueText(
+              Array.from(cues)
+                .map((c) => (c as VTTCue).text)
+                .join("\n"),
+            );
+            return;
+          }
+        }
+        setActiveCueText(null);
+      };
+
+      const onAddTrack = () => {
+        syncMode();
+        readActiveCue();
+      };
+
+      syncMode();
+      readActiveCue();
+
+      const tts = Array.from(v.textTracks);
+      tts.forEach((tt) => tt.addEventListener("cuechange", readActiveCue));
+      v.textTracks.addEventListener?.("addtrack", onAddTrack);
+
       try {
         window.localStorage.setItem(CAPTIONS_KEY, captionsOn ? "1" : "0");
       } catch {
         // noop
       }
-      return () => v.textTracks.removeEventListener?.("addtrack", apply);
+
+      return () => {
+        tts.forEach((tt) => tt.removeEventListener("cuechange", readActiveCue));
+        v.textTracks.removeEventListener?.("addtrack", onAddTrack);
+      };
     }, [captionsOn, tracks]);
 
     useEffect(() => {
@@ -671,6 +712,24 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           >
             <Play className="h-7 w-7 translate-x-0.5 fill-current" />
           </button>
+        )}
+
+        {/* Custom caption bar. Sits above the control bar — and lifts further
+            when the controls are visible — so cues never overlap the controls.
+            Driven by the hidden text track's active cue (see the captions
+            effect). */}
+        {captionsOn && activeCueText && (
+          <div
+            aria-live="polite"
+            className={cn(
+              "pointer-events-none absolute inset-x-0 z-10 flex justify-center px-4 transition-[bottom] duration-150",
+              showControls ? "bottom-24" : "bottom-6",
+            )}
+          >
+            <span className="max-w-[90%] whitespace-pre-line rounded bg-black/75 px-2.5 py-1 text-center text-sm font-medium leading-snug text-white [text-shadow:0_1px_2px_rgba(0,0,0,0.6)] backdrop-blur-sm">
+              {activeCueText}
+            </span>
+          </div>
         )}
 
         <div

--- a/src/components/video-player.tsx
+++ b/src/components/video-player.tsx
@@ -13,6 +13,8 @@ import {
 } from "react";
 import * as SliderPrimitive from "@radix-ui/react-slider";
 import {
+  Captions,
+  CaptionsOff,
   Check,
   Maximize2,
   Minimize2,
@@ -34,6 +36,13 @@ import { cn } from "@/lib/utils";
 const RATE_OPTIONS = [0.5, 1, 1.5, 2, 3, 4] as const;
 const VOLUME_KEY = "lastest:videoplayer:volume";
 const MUTED_KEY = "lastest:videoplayer:muted";
+const CAPTIONS_KEY = "lastest:videoplayer:captions";
+
+export interface VideoTextTrack {
+  src: string;
+  srclang: string;
+  label: string;
+}
 
 export interface VideoPlayerHandle {
   play: () => Promise<void>;
@@ -69,6 +78,14 @@ export interface VideoPlayerProps {
    * finite value (via `durationchange`), the real value takes over.
    */
   durationMsFallback?: number | null;
+  /**
+   * Subtitle/caption tracks attached to the `<video>` as `<track>` children
+   * (WebVTT). When present, a CC toggle appears in the controls. Same-origin
+   * sources only — no `crossorigin` is set.
+   */
+  tracks?: VideoTextTrack[];
+  /** Whether captions start visible. Overridden by the user's saved choice. */
+  captionsDefaultOn?: boolean;
 }
 
 function formatTime(s: number): string {
@@ -128,6 +145,8 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       onReady,
       ariaLabel,
       durationMsFallback,
+      tracks,
+      captionsDefaultOn = false,
     },
     ref,
   ) {
@@ -159,6 +178,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
     const initialMuted = mutedProp ?? true;
     const [muted, setMuted] = useState(initialMuted);
     const [playbackRate, setPlaybackRate] = useState(defaultPlaybackRate);
+    const [captionsOn, setCaptionsOn] = useState(captionsDefaultOn);
     const [isFullscreen, setIsFullscreen] = useState(false);
     const [isScrubbing, setIsScrubbing] = useState(false);
     const [controlsVisible, setControlsVisible] = useState(true);
@@ -185,10 +205,36 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           const m = window.localStorage.getItem(MUTED_KEY);
           if (m !== null) setMuted(m === "1");
         }
+        const cc = window.localStorage.getItem(CAPTIONS_KEY);
+        if (cc !== null) setCaptionsOn(cc === "1");
       } catch {
         // localStorage unavailable; fall back to defaults.
       }
     }, [mutedProp]);
+
+    // Apply the captions on/off choice to the <video>'s text tracks. The
+    // browser exposes them via `video.textTracks` once the <track> children
+    // mount; flip every track's mode and persist the preference. Re-runs when
+    // the track set changes so a late-arriving track inherits the current
+    // state.
+    useEffect(() => {
+      const v = videoRef.current;
+      if (!v) return;
+      const apply = () => {
+        for (let i = 0; i < v.textTracks.length; i++) {
+          v.textTracks[i]!.mode = captionsOn ? "showing" : "hidden";
+        }
+      };
+      apply();
+      // Tracks can register slightly after mount; `addtrack` catches that.
+      v.textTracks.addEventListener?.("addtrack", apply);
+      try {
+        window.localStorage.setItem(CAPTIONS_KEY, captionsOn ? "1" : "0");
+      } catch {
+        // noop
+      }
+      return () => v.textTracks.removeEventListener?.("addtrack", apply);
+    }, [captionsOn, tracks]);
 
     useEffect(() => {
       const v = videoRef.current;
@@ -536,6 +582,13 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
             e.preventDefault();
             toggleMute();
             break;
+          case "c":
+          case "C":
+            if (tracks && tracks.length > 0) {
+              e.preventDefault();
+              setCaptionsOn((on) => !on);
+            }
+            break;
           case "f":
           case "F":
             e.preventDefault();
@@ -550,7 +603,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
         }
         wakeControls();
       },
-      [skip, toggleFullscreen, toggleMute, togglePlay, wakeControls],
+      [skip, toggleFullscreen, toggleMute, togglePlay, wakeControls, tracks],
     );
 
     const VolumeIcon =
@@ -597,7 +650,17 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           muted={muted}
           onClick={togglePlay}
           className={cn("block h-full w-full object-contain", videoClassName)}
-        />
+        >
+          {tracks?.map((t) => (
+            <track
+              key={t.src}
+              kind="subtitles"
+              src={t.src}
+              srcLang={t.srclang}
+              label={t.label}
+            />
+          ))}
+        </video>
 
         {!isPlaying && duration > 0 && (
           <button
@@ -722,6 +785,26 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
             </span>
 
             <div className="flex-1" />
+
+            {tracks && tracks.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setCaptionsOn((c) => !c)}
+                aria-label={captionsOn ? "Hide captions" : "Show captions"}
+                aria-pressed={captionsOn}
+                title={captionsOn ? "Hide captions" : "Show captions"}
+                className={cn(
+                  "flex h-7 w-7 items-center justify-center rounded-md text-white transition-colors hover:bg-white/15",
+                  captionsOn && "bg-white/20",
+                )}
+              >
+                {captionsOn ? (
+                  <Captions className="h-4 w-4" />
+                ) : (
+                  <CaptionsOff className="h-4 w-4" />
+                )}
+              </button>
+            )}
 
             <Popover>
               <PopoverTrigger asChild>

--- a/src/lib/ai/index.ts
+++ b/src/lib/ai/index.ts
@@ -101,6 +101,11 @@ export interface GenerateWithAIOptions {
   /** Request structured JSON output. Forwarded to providers that support
    *  `response_format: { type: 'json_object' }` (OpenRouter, OpenAI). Ignored elsewhere. */
   responseFormat?: "json_object";
+  /** Image inputs for vision-capable providers (e.g. screenshots for the
+   *  share-page caption generator). Forwarded to `provider.generate({ images })`.
+   *  Only used on the direct generate path — the MCP tool-calling bridge path
+   *  doesn't accept images. */
+  images?: { base64: string; mediaType: string }[];
 }
 
 export async function generateWithAI(
@@ -213,6 +218,7 @@ export async function generateWithAI(
         systemPrompt: finalSystemPrompt || undefined,
         signal: options?.signal,
         responseFormat: options?.responseFormat,
+        images: options?.images,
       });
     }
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -4155,6 +4155,29 @@ export interface DemoNoteSkippedRoute {
   reason: string;
 }
 
+// One narration cue for the share-page recording. The AI vision pass writes
+// one of these per captured step (aligned to test_results.screenshots[] order)
+// describing what the agent does and what's visible on screen. Cue timing is
+// an EVEN SPLIT of the recording's duration_ms — we don't persist a real
+// per-step video timestamp (see captions.ts / src/lib/share/vtt.ts). `focus`
+// and `annotation` are captured now but only rendered by the (planned)
+// arrow/underline overlay; the v1 subtitle track ignores them.
+export interface VideoCaption {
+  /** 0-based, aligns to test_results.screenshots[] order. */
+  stepIndex: number;
+  /** Cue start in ms (even-split approximation of duration_ms). */
+  startMs: number;
+  /** Cue end in ms. */
+  endMs: number;
+  /** One short present-tense narration line. */
+  text: string;
+  /** Normalized 0..1 region of the primary element the agent acted on.
+   *  Stored for the future annotation overlay; not rendered by the v1 track. */
+  focus?: { x: number; y: number; w: number; h: number };
+  /** How the focus region should be marked once the overlay ships. */
+  annotation?: "arrow" | "underline" | "box";
+}
+
 export interface DemoNotes {
   /** 2–3 sentence overall UI/UX impression. */
   uxSummary: string;
@@ -4166,6 +4189,10 @@ export interface DemoNotes {
   testingStruggles: DemoNoteItem[];
   /** Routes the agent tried but couldn't capture. */
   skippedRoutes?: DemoNoteSkippedRoute[];
+  /** Time-coded narration for the recording, rendered as the <video> subtitle
+   *  track on /r/<slug>. Optional — absent on notes written before captions
+   *  shipped, in which case the share renders no track. */
+  captions?: VideoCaption[];
   generatedAt: string;
   /** Provider/model id used for the AI summary, when applicable. */
   modelId?: string;

--- a/src/lib/share/captions.ts
+++ b/src/lib/share/captions.ts
@@ -1,0 +1,219 @@
+/**
+ * Generate time-coded narration ("captions") for a share-page recording by
+ * running a vision pass over the run's captured step screenshots. One cue per
+ * readable screenshot, describing what the agent does and what's on screen.
+ *
+ * Mirrors the demo-notes generator (src/lib/quickstart/quickstart-notes.ts):
+ * pull the repo's AI settings → getAIConfig → generateWithAI. The only new
+ * wrinkle is passing the screenshots as `images` (vision input), which
+ * generateWithAI now forwards to the provider.
+ *
+ * TIMING IS APPROXIMATE. We don't persist a real per-step video timestamp, so
+ * each cue is placed by evenly splitting the recording's duration_ms across the
+ * steps — the same model the step-strip seek already uses on the share page.
+ * Good enough to keep narration tracking the right step; not frame-accurate.
+ */
+
+import { readFile } from "fs/promises";
+import * as queries from "@/lib/db/queries";
+import { generateWithAI } from "@/lib/ai";
+import { getAIConfig } from "@/lib/playwright/agent-context";
+import { parseAiJson } from "@/lib/ai/json-parse";
+import { resolveStoragePathStrict } from "@/lib/storage/paths";
+import type { VideoCaption } from "@/lib/db/schema";
+
+export interface CaptionStepInput {
+  /** Storage-relative screenshot path (e.g. `/screenshots/<repo>/<file>.png`). */
+  path: string;
+  label?: string | null;
+}
+
+export interface GenerateVideoCaptionsInput {
+  repositoryId: string;
+  productName: string;
+  targetDomain?: string | null;
+  /** Optional run context to ground the narration (the demo-notes uxSummary). */
+  uxSummary?: string | null;
+  /** Recorded duration of the clip; drives cue timing. */
+  durationMs: number | null;
+  /** Captured steps in test_results.screenshots[] order. */
+  steps: CaptionStepInput[];
+}
+
+const DEFAULT_STEP_MS = 3000;
+const MAX_STEPS = 24; // cap the vision payload — long runs get sampled head-heavy
+
+const SYSTEM_PROMPT = `You are narrating a screen recording of an automated browser agent testing a web app, for a viewer watching the replay. You are shown the captured screenshots in order, one per step.
+
+For EACH screenshot, write one short present-tense caption (max ~12 words) that says what the agent is doing and what is visible on screen. Examples: "Opens the pricing page and scans the three plan tiers." / "Fills in the signup email and clicks Create account." / "Dashboard loads with an empty projects list."
+
+Also return, when there is a clear primary element the step is about (a button, field, heading), a normalized focus box (x,y,w,h each between 0 and 1, origin top-left) and an annotation hint of "arrow", "underline", or "box". Omit focus/annotation when no single element dominates.
+
+RULES:
+- Describe only what is visible. Never invent features or text you cannot see.
+- One caption per step, matched by stepIndex.
+- Keep it plain and concrete; no marketing language.
+
+OUTPUT STRICT JSON, no markdown, exactly:
+{ "captions": [ { "stepIndex": 0, "text": "string", "focus": { "x": 0, "y": 0, "w": 0, "h": 0 }, "annotation": "arrow" } ] }`;
+
+type RawCaption = {
+  stepIndex: number;
+  text: string;
+  focus?: { x: number; y: number; w: number; h: number };
+  annotation?: "arrow" | "underline" | "box";
+};
+
+function isRawCaptionPayload(v: unknown): v is { captions: RawCaption[] } {
+  if (!v || typeof v !== "object") return false;
+  const arr = (v as { captions?: unknown }).captions;
+  if (!Array.isArray(arr)) return false;
+  return arr.every(
+    (c) =>
+      c &&
+      typeof c === "object" &&
+      typeof (c as RawCaption).stepIndex === "number" &&
+      typeof (c as RawCaption).text === "string",
+  );
+}
+
+function mediaTypeFor(path: string): string {
+  const ext = path.slice(path.lastIndexOf(".")).toLowerCase();
+  if (ext === ".jpg" || ext === ".jpeg") return "image/jpeg";
+  if (ext === ".webp") return "image/webp";
+  return "image/png";
+}
+
+function normalizeFocus(
+  f: RawCaption["focus"],
+): VideoCaption["focus"] | undefined {
+  if (!f || typeof f !== "object") return undefined;
+  const { x, y, w, h } = f;
+  if (![x, y, w, h].every((n) => typeof n === "number" && Number.isFinite(n)))
+    return undefined;
+  const clamp01 = (n: number) => Math.min(1, Math.max(0, n));
+  return { x: clamp01(x), y: clamp01(y), w: clamp01(w), h: clamp01(h) };
+}
+
+// Even-split timing: step i occupies [i/N, (i+1)/N] of the clip. N is the
+// number of steps we actually narrate, so cues always span the whole timeline.
+function timingFor(
+  stepIndex: number,
+  totalSteps: number,
+  durationMs: number | null,
+): { startMs: number; endMs: number } {
+  const total =
+    durationMs && durationMs > 0 ? durationMs : totalSteps * DEFAULT_STEP_MS;
+  const per = total / Math.max(1, totalSteps);
+  return {
+    startMs: Math.round(stepIndex * per),
+    endMs: Math.round((stepIndex + 1) * per),
+  };
+}
+
+/**
+ * Returns one VideoCaption per readable screenshot. Returns `[]` (never throws)
+ * when there are no readable screenshots or the model output can't be parsed —
+ * callers should treat empty as "no captions to persist".
+ */
+export async function generateVideoCaptions(
+  input: GenerateVideoCaptionsInput,
+  options?: { onLogCreated?: (logId: string) => void },
+): Promise<VideoCaption[]> {
+  const steps = input.steps.slice(0, MAX_STEPS);
+  if (steps.length === 0) return [];
+
+  // Load the screenshots from disk, preserving each step's original index so
+  // the cue's stepIndex still aligns with test_results.screenshots[] even when
+  // some files are missing.
+  const loaded: Array<{
+    index: number;
+    label: string;
+    base64: string;
+    mediaType: string;
+  }> = [];
+  for (let i = 0; i < steps.length; i++) {
+    const s = steps[i]!;
+    const abs = await resolveStoragePathStrict(s.path);
+    if (!abs) continue;
+    try {
+      const buf = await readFile(abs);
+      loaded.push({
+        index: i,
+        label: (s.label ?? `Step ${i + 1}`).trim(),
+        base64: buf.toString("base64"),
+        mediaType: mediaTypeFor(s.path),
+      });
+    } catch {
+      // Unreadable screenshot — skip; the rest still get captions.
+    }
+  }
+  if (loaded.length === 0) return [];
+
+  const settings = await queries.getAISettings(input.repositoryId);
+  const config = getAIConfig(settings);
+
+  const manifest = loaded
+    .map(
+      (l, ord) =>
+        `image ${ord + 1} → stepIndex ${l.index}, label: ${JSON.stringify(l.label)}`,
+    )
+    .join("\n");
+
+  const prompt = `Recording of ${input.productName}${
+    input.targetDomain ? ` (${input.targetDomain})` : ""
+  }.${input.uxSummary ? `\nContext: ${input.uxSummary}` : ""}
+
+The ${loaded.length} attached screenshot(s) are the agent's steps in order:
+${manifest}
+
+Write one caption per step. Return the strict JSON described in the system prompt.`;
+
+  let raw: string;
+  try {
+    raw = await generateWithAI(config, prompt, SYSTEM_PROMPT, {
+      repositoryId: input.repositoryId,
+      actionType: "agent_discover",
+      onLogCreated: options?.onLogCreated,
+      responseFormat: "json_object",
+      images: loaded.map((l) => ({ base64: l.base64, mediaType: l.mediaType })),
+    });
+  } catch {
+    return [];
+  }
+
+  const parsed = parseAiJson(raw, isRawCaptionPayload, { source: "captions" });
+  if (!parsed) return [];
+
+  const validIndexes = new Set(loaded.map((l) => l.index));
+  const byStep = new Map<number, RawCaption>();
+  for (const c of parsed.captions) {
+    if (!validIndexes.has(c.stepIndex)) continue;
+    if (typeof c.text !== "string" || c.text.trim().length === 0) continue;
+    if (!byStep.has(c.stepIndex)) byStep.set(c.stepIndex, c);
+  }
+
+  const totalSteps = steps.length;
+  const out: VideoCaption[] = [];
+  for (const l of loaded) {
+    const c = byStep.get(l.index);
+    if (!c) continue;
+    const { startMs, endMs } = timingFor(l.index, totalSteps, input.durationMs);
+    const annotation =
+      c.annotation === "arrow" ||
+      c.annotation === "underline" ||
+      c.annotation === "box"
+        ? c.annotation
+        : undefined;
+    out.push({
+      stepIndex: l.index,
+      startMs,
+      endMs,
+      text: c.text.trim(),
+      focus: normalizeFocus(c.focus),
+      annotation,
+    });
+  }
+  out.sort((a, b) => a.startMs - b.startMs);
+  return out;
+}

--- a/src/lib/share/generate-captions.ts
+++ b/src/lib/share/generate-captions.ts
@@ -1,0 +1,136 @@
+/**
+ * Server-side glue between a build and its recording captions. Picks the
+ * build's primary test recording, runs the vision pass, and persists the
+ * cues onto the build's `build_demo_notes` payload (alongside any existing
+ * UI/UX summary). Shared by the in-app server action and the v1 API so both
+ * authoring paths store captions identically.
+ */
+
+import * as queries from "@/lib/db/queries";
+import {
+  generateVideoCaptions,
+  type CaptionStepInput,
+} from "@/lib/share/captions";
+import type {
+  CapturedScreenshot,
+  DemoNotes,
+  VideoCaption,
+} from "@/lib/db/schema";
+
+// Seed payload when a build has no demo-notes yet — captions-only. `generatedAt`
+// is empty here and filled with a real timestamp at upsert time (see the `||`
+// below) so we don't capture a module-load time.
+const EMPTY_NOTES: DemoNotes = {
+  uxSummary: "",
+  highlights: [],
+  frictionPoints: [],
+  testingStruggles: [],
+  generatedAt: "",
+};
+
+function hasShots(r: { screenshots?: CapturedScreenshot[] | null }): boolean {
+  return Array.isArray(r.screenshots) && r.screenshots.length > 0;
+}
+
+export interface CaptionTarget {
+  repositoryId: string;
+  productName: string;
+  durationMs: number | null;
+  steps: CaptionStepInput[];
+  uxSummary: string | null;
+}
+
+// Resolve the build's primary recording: prefer an explicit testId, then the
+// first result that has both a video and screenshots, then any result with
+// screenshots. Returns null when nothing capturable exists.
+export async function resolveCaptionTarget(
+  buildId: string,
+  opts?: { testId?: string },
+): Promise<CaptionTarget | null> {
+  const build = await queries.getBuild(buildId);
+  if (!build?.testRunId) return null;
+
+  const results = await queries.getTestResultsByRun(build.testRunId);
+  const candidate =
+    (opts?.testId &&
+      results.find((r) => r.testId === opts.testId && hasShots(r))) ||
+    results.find((r) => r.videoPath && hasShots(r)) ||
+    results.find(hasShots);
+  if (!candidate?.testId || !hasShots(candidate)) return null;
+
+  const test = await queries.getTest(candidate.testId);
+  const repositoryId = test?.repositoryId;
+  if (!repositoryId) return null;
+
+  const existing =
+    (await queries.getBuildDemoNotes(buildId)) ??
+    (await queries.getLatestDemoNotesForRepo(repositoryId));
+
+  return {
+    repositoryId,
+    productName: test?.name ?? "this app",
+    durationMs: candidate.durationMs ?? null,
+    steps: (candidate.screenshots ?? []).map((s) => ({
+      path: s.path,
+      label: s.label ?? null,
+    })),
+    uxSummary: existing?.uxSummary || null,
+  };
+}
+
+// Merge captions into the build's notes payload, seeding from the build's own
+// notes (or the repo's latest) so storing captions never drops an existing
+// UI/UX summary. The merged row carries the summary too, so the share page's
+// `getLatestDemoNotesForRepo` lookup keeps surfacing both.
+export async function storeCaptionsForBuild(
+  buildId: string,
+  captions: VideoCaption[],
+  modelId?: string,
+): Promise<void> {
+  // Seed the merged payload from the build's own notes, falling back to the
+  // repo's latest notes (resolved via the build's recording) so a captions-only
+  // write never erases an existing UI/UX summary.
+  let base = await queries.getBuildDemoNotes(buildId);
+  if (!base) {
+    const target = await resolveCaptionTarget(buildId);
+    if (target) {
+      base = await queries.getLatestDemoNotesForRepo(target.repositoryId);
+    }
+  }
+  const merged = base ?? EMPTY_NOTES;
+
+  await queries.upsertBuildDemoNotes(buildId, {
+    ...merged,
+    captions,
+    generatedAt: merged.generatedAt || new Date().toISOString(),
+    modelId: modelId ?? merged.modelId,
+  });
+}
+
+/**
+ * Generate captions for a build's primary recording via the AI vision pass and
+ * persist them. Returns the number of cues written (0 = nothing capturable or
+ * the model produced no usable output).
+ */
+export async function generateAndStoreCaptionsForBuild(
+  buildId: string,
+  opts?: { testId?: string; onLogCreated?: (logId: string) => void },
+): Promise<{ count: number; reason?: string }> {
+  const target = await resolveCaptionTarget(buildId, { testId: opts?.testId });
+  if (!target) return { count: 0, reason: "no_recording" };
+
+  const captions = await generateVideoCaptions(
+    {
+      repositoryId: target.repositoryId,
+      productName: target.productName,
+      uxSummary: target.uxSummary,
+      durationMs: target.durationMs,
+      steps: target.steps,
+    },
+    { onLogCreated: opts?.onLogCreated },
+  );
+  if (captions.length === 0) return { count: 0, reason: "no_captions" };
+
+  await storeCaptionsForBuild(buildId, captions);
+  return { count: captions.length };
+}

--- a/src/lib/share/vtt.test.ts
+++ b/src/lib/share/vtt.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { captionsToVtt, msToVttTimestamp } from "./vtt";
+import type { VideoCaption } from "@/lib/db/schema";
+
+function cap(p: Partial<VideoCaption>): VideoCaption {
+  return {
+    stepIndex: 0,
+    startMs: 0,
+    endMs: 1000,
+    text: "hello",
+    ...p,
+  };
+}
+
+describe("msToVttTimestamp", () => {
+  it("formats zero", () => {
+    expect(msToVttTimestamp(0)).toBe("00:00:00.000");
+  });
+  it("formats sub-second millis with padding", () => {
+    expect(msToVttTimestamp(1500)).toBe("00:00:01.500");
+    expect(msToVttTimestamp(50)).toBe("00:00:00.050");
+  });
+  it("formats minutes and hours", () => {
+    expect(msToVttTimestamp(65_000)).toBe("00:01:05.000");
+    expect(msToVttTimestamp(3_661_001)).toBe("01:01:01.001");
+  });
+  it("clamps negative / non-finite to zero", () => {
+    expect(msToVttTimestamp(-10)).toBe("00:00:00.000");
+    expect(msToVttTimestamp(NaN)).toBe("00:00:00.000");
+  });
+});
+
+describe("captionsToVtt", () => {
+  it("emits a header-only doc when there are no usable cues", () => {
+    expect(captionsToVtt([])).toBe("WEBVTT\n");
+  });
+
+  it("emits numbered cues with timestamps", () => {
+    const vtt = captionsToVtt([
+      cap({ startMs: 0, endMs: 2000, text: "Opens the page" }),
+      cap({ startMs: 2000, endMs: 4000, text: "Clicks sign in" }),
+    ]);
+    expect(vtt).toBe(
+      [
+        "WEBVTT",
+        "",
+        "1",
+        "00:00:00.000 --> 00:00:02.000",
+        "Opens the page",
+        "",
+        "2",
+        "00:00:02.000 --> 00:00:04.000",
+        "Clicks sign in",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("sorts cues by start time", () => {
+    const vtt = captionsToVtt([
+      cap({ startMs: 4000, endMs: 6000, text: "later" }),
+      cap({ startMs: 0, endMs: 2000, text: "earlier" }),
+    ]);
+    expect(vtt.indexOf("earlier")).toBeLessThan(vtt.indexOf("later"));
+  });
+
+  it("neutralizes the --> delimiter and collapses newlines in cue text", () => {
+    const vtt = captionsToVtt([cap({ text: "a --> b\nsecond   line" })]);
+    expect(vtt).not.toContain("a --> b");
+    expect(vtt).toContain("a → b second line");
+  });
+
+  it("drops empty-text and non-positive-duration cues", () => {
+    const vtt = captionsToVtt([
+      cap({ startMs: 0, endMs: 0, text: "zero duration" }),
+      cap({ startMs: 100, endMs: 50, text: "negative duration" }),
+      cap({ startMs: 0, endMs: 1000, text: "   " }),
+      cap({ startMs: 0, endMs: 1000, text: "kept" }),
+    ]);
+    expect(vtt).toContain("kept");
+    expect(vtt).not.toContain("zero duration");
+    expect(vtt).not.toContain("negative duration");
+    // exactly one cue survived
+    expect(vtt.match(/-->/g)?.length).toBe(1);
+  });
+});

--- a/src/lib/share/vtt.ts
+++ b/src/lib/share/vtt.ts
@@ -1,0 +1,63 @@
+import type { VideoCaption } from "@/lib/db/schema";
+
+// Build a WebVTT document from time-coded captions for the share-page <video>
+// subtitle track. Pure + side-effect-free so it's unit-testable and can run in
+// the route handler with no I/O.
+//
+// Cue timing comes straight off each caption's startMs/endMs. Those are an
+// even-split approximation of the recording duration (we don't persist a real
+// per-step video timestamp) — see src/lib/share/captions.ts. Good enough to
+// keep the narration roughly aligned with the step it describes; not
+// frame-accurate.
+
+/** WebVTT timestamp: HH:MM:SS.mmm (hours are required by the spec when > 0 and
+ *  harmless when zero, so we always emit them for a stable, simple format). */
+export function msToVttTimestamp(ms: number): string {
+  const safe = Number.isFinite(ms) && ms > 0 ? Math.floor(ms) : 0;
+  const h = Math.floor(safe / 3_600_000);
+  const m = Math.floor((safe % 3_600_000) / 60_000);
+  const s = Math.floor((safe % 60_000) / 1000);
+  const millis = safe % 1000;
+  const pad = (n: number, w = 2) => n.toString().padStart(w, "0");
+  return `${pad(h)}:${pad(m)}:${pad(s)}.${pad(millis, 3)}`;
+}
+
+// Cue text can't contain the "-->" sequence (it's the timing delimiter) and
+// must be single-logical-line per our renderer — collapse newlines to spaces
+// and neutralize any stray arrow so a model-authored caption can never break
+// the document structure.
+function sanitizeCueText(text: string): string {
+  return text
+    .replace(/\r?\n/g, " ")
+    .replace(/-->/g, "→")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Render captions to a WebVTT document. Captions are sorted by start time and
+ * any with empty text or a non-positive duration are dropped so the track is
+ * always valid. Returns an empty-cue VTT (`WEBVTT` header only) when there's
+ * nothing to show — callers that want a 404 should check `captions.length`
+ * first.
+ */
+export function captionsToVtt(captions: VideoCaption[]): string {
+  const cues = [...captions]
+    .filter((c) => c && typeof c.text === "string" && c.text.trim().length > 0)
+    .map((c) => ({
+      start: Math.max(0, Math.floor(c.startMs)),
+      end: Math.max(0, Math.floor(c.endMs)),
+      text: sanitizeCueText(c.text),
+    }))
+    .filter((c) => c.end > c.start && c.text.length > 0)
+    .sort((a, b) => a.start - b.start);
+
+  const body = cues
+    .map(
+      (c, i) =>
+        `${i + 1}\n${msToVttTimestamp(c.start)} --> ${msToVttTimestamp(c.end)}\n${c.text}`,
+    )
+    .join("\n\n");
+
+  return body ? `WEBVTT\n\n${body}\n` : "WEBVTT\n";
+}

--- a/src/server/actions/captions.ts
+++ b/src/server/actions/captions.ts
@@ -1,0 +1,41 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import * as queries from "@/lib/db/queries";
+import { requireRepoAccess } from "@/lib/auth/session";
+import { generateAndStoreCaptionsForBuild } from "@/lib/share/generate-captions";
+
+/**
+ * Generate AI subtitle captions for a build's primary recording and persist
+ * them onto the build's demo-notes payload. The /r/<slug> share page then
+ * serves them as the <video> subtitle track (see the captions.vtt route).
+ *
+ * Auth: the build must belong to the caller's team. We resolve the build →
+ * test run → repository to run `requireRepoAccess`, reusing the same boundary
+ * every other repo-scoped action uses.
+ */
+export async function generateShareCaptions(
+  buildId: string,
+): Promise<{ ok: true; count: number } | { ok: false; error: string }> {
+  const build = await queries.getBuild(buildId);
+  if (!build?.testRunId) return { ok: false, error: "Build has no run" };
+
+  const testRun = await queries.getTestRun(build.testRunId);
+  if (!testRun?.repositoryId)
+    return { ok: false, error: "Build has no repository" };
+
+  await requireRepoAccess(testRun.repositoryId);
+
+  const result = await generateAndStoreCaptionsForBuild(buildId);
+  if (result.count === 0) {
+    return {
+      ok: false,
+      error: result.reason ?? "No captions generated",
+    };
+  }
+
+  // Public share reads notes live (revalidate=0), but revalidate the in-app
+  // build view so a "Generate captions" button reflects immediately.
+  revalidatePath(`/builds/${buildId}`);
+  return { ok: true, count: result.count };
+}


### PR DESCRIPTION
## What

Adds **time-synced subtitles/captions to the recording** on public `/r/<slug>` share pages. Previously the player had only a static `<figcaption>` and the side "In this video" chapter rail — no captions overlaid on the video itself.

This is the previously-shelved `subtitle` branch (built Jun 16), **rebased onto current `origin/main`** (1 conflict in `page.tsx` resolved — keeps main's `<figure>`/`<figcaption>` + `ChapterRail` and adds the new `tracks={captionTracks}` prop).

## How

- **`src/lib/share/vtt.ts`** — build a WebVTT document from timed cues (unit-tested, 9 tests).
- **`src/lib/share/captions.ts` + `generate-captions.ts`** — resolve a build's primary recording and produce caption cues, persisted onto the build's `build_demo_notes` payload.
- **`src/lib/db/schema.ts`** — `VideoCaption` type + `DemoNotes.captions` field.
- **`src/app/(public)/share/[slug]/captions.vtt/route.ts`** — serves the VTT track for a share.
- **`src/components/video-player.tsx` / `replay-player.tsx`** — render caption `<track>`s on the recording (attached to the first clip).
- **`src/app/(public)/r/[slug]/page.tsx`** — pass `captionTracks` into the player.
- **`src/server/actions/captions.ts` + `api/v1/[...slug]/route.ts`** — in-app action + v1 API to (re)generate captions for a build.

## Validation

- `tsc --noEmit` — clean (exit 0)
- `vitest run src/lib/share/vtt.test.ts` — 9/9 pass

## Notes / follow-ups

- Caption text currently comes from the branch's AI vision pass; there's an open ask to optionally derive cues directly from step labels + `atMs` (deterministic, no AI). Can be a follow-up.
- Requires a prod deploy for existing/new shares to render captions; captions are generated per build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)