### PR TITLE
Issue RCA

### DIFF
--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1861,6 +1861,11 @@ export const notificationSettings = pgTable("notification_settings", {
   issueTrackerProvider: text("issue_tracker_provider")
     .default("github")
     .notNull(),
+  // GitHub login auto-assigned to every issue Lastest files (visual diff +
+  // verify cases). Point it at your AI engineer bot (e.g. copilot, devin) so
+  // filed regressions are picked up without a human dispatcher. Null = no
+  // auto-assignment. Invalid logins are dropped by GitHub, not an error.
+  issueAssignee: text("issue_assignee"),
   createdAt: timestamp("created_at"),
   updatedAt: timestamp("updated_at"),
 });
@@ -1877,6 +1882,7 @@ export const DEFAULT_NOTIFICATION_SETTINGS = {
   customWebhookEnabled: false,
   customWebhookMethod: "POST" as const,
   issueTrackerProvider: "github" as IssueTrackerProvider,
+  issueAssignee: null as string | null,
 };
 
 // Selector statistics for optimizing fallback strategy

--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -198,11 +198,25 @@ export async function POST(request: NextRequest) {
         });
       }
 
-      const steps = await queries.getStepComparisonsByGithubIssue(
+      // Issue numbers are only unique per repo — never match by number alone.
+      const repositoryId = await resolveRepositoryId(data);
+      if (!repositoryId) {
+        return NextResponse.json({ message: "Repository not tracked" });
+      }
+      const allSteps = await queries.getStepComparisonsByGithubIssueInRepo(
+        repositoryId,
         data.issue.number,
       );
+      // Skip cases already reconciled — when confirm-on-green closed the
+      // issue itself it flipped the state first, so this delivery (caused by
+      // our own PATCH) must not queue another rerun and loop forever.
+      const steps = allSteps.filter((s) => s.githubIssueState !== "closed");
       if (steps.length === 0) {
-        return NextResponse.json({ message: "No linked step comparisons" });
+        return NextResponse.json({
+          message: allSteps.length
+            ? "Cases already reconciled"
+            : "No linked step comparisons",
+        });
       }
 
       // Mark each linked case as closed so the verify board reflects the
@@ -213,19 +227,15 @@ export async function POST(request: NextRequest) {
         ),
       );
 
-      // Kick a focused build per repo grouping. createAndRunBuildCore is the
-      // auth-less variant — webhooks can't carry a user session. The build
-      // executor + verify scoring already populate stepComparisons for the
-      // new build, and the reviewer can drop the resulting card to "done" to
-      // finalize.
-      const repositoryId = await resolveRepositoryId(data);
-      if (repositoryId) {
-        const testIds = Array.from(new Set(steps.map((s) => s.testId)));
-        try {
-          await createAndRunBuildCore("webhook", testIds, repositoryId);
-        } catch (err) {
-          console.error("[webhook] verify rerun failed:", err);
-        }
+      // Kick a focused build. createAndRunBuildCore is the auth-less variant —
+      // webhooks can't carry a user session. When the rerun finalizes as
+      // safe_to_merge, confirm-on-green reconciles any remaining open tickets;
+      // auto-approve marks the green cases Done on the verify board.
+      const testIds = Array.from(new Set(steps.map((s) => s.testId)));
+      try {
+        await createAndRunBuildCore("webhook", testIds, repositoryId);
+      } catch (err) {
+        console.error("[webhook] verify rerun failed:", err);
       }
 
       return NextResponse.json({

--- a/src/components/settings/notification-settings-card.tsx
+++ b/src/components/settings/notification-settings-card.tsx
@@ -95,6 +95,9 @@ export function NotificationSettingsCard({
     useState<IssueTrackerProvider>(
       (settings.issueTrackerProvider as IssueTrackerProvider) || "github",
     );
+  const [issueAssignee, setIssueAssignee] = useState(
+    settings.issueAssignee || "",
+  );
   const [customWebhookHeaders, setCustomWebhookHeaders] = useState<
     Array<{ key: string; value: string }>
   >(() => {
@@ -133,6 +136,7 @@ export function NotificationSettingsCard({
     customWebhookHeaders: settings.customWebhookHeaders || "",
     issueTrackerProvider:
       (settings.issueTrackerProvider as IssueTrackerProvider) || "github",
+    issueAssignee: settings.issueAssignee || "",
   });
 
   // Convert headers array to JSON string
@@ -163,6 +167,7 @@ export function NotificationSettingsCard({
         customWebhookMethod,
         customWebhookHeaders: headersJson,
         issueTrackerProvider,
+        issueAssignee: issueAssignee.trim() || null,
       });
       toast.success("Notification settings saved");
     });
@@ -179,6 +184,7 @@ export function NotificationSettingsCard({
     customWebhookMethod,
     headersJson,
     issueTrackerProvider,
+    issueAssignee,
   ]);
 
   // Auto-save with debounce - only when values differ from original props
@@ -195,7 +201,8 @@ export function NotificationSettingsCard({
       customWebhookUrl !== orig.customWebhookUrl ||
       customWebhookMethod !== orig.customWebhookMethod ||
       (headersJson || "") !== orig.customWebhookHeaders ||
-      issueTrackerProvider !== orig.issueTrackerProvider;
+      issueTrackerProvider !== orig.issueTrackerProvider ||
+      issueAssignee !== orig.issueAssignee;
 
     if (!hasChanges) return;
 
@@ -224,6 +231,7 @@ export function NotificationSettingsCard({
     customWebhookMethod,
     headersJson,
     issueTrackerProvider,
+    issueAssignee,
     doSave,
   ]);
 
@@ -440,6 +448,23 @@ export function NotificationSettingsCard({
               </p>
             )}
           </div>
+          {issueTrackerProvider === "github" && (
+            <div className="space-y-2">
+              <Label htmlFor="issueAssignee">Auto-assign to</Label>
+              <Input
+                id="issueAssignee"
+                placeholder="github-username (e.g. your AI engineer bot)"
+                value={issueAssignee}
+                onChange={(e) => setIssueAssignee(e.target.value)}
+                className="w-64"
+              />
+              <p className="text-xs text-muted-foreground">
+                Every issue Lastest files is assigned to this GitHub user, so an
+                AI engineer can pick it up immediately. Leave empty to skip
+                assignment.
+              </p>
+            </div>
+          )}
         </div>
 
         {/* Custom Webhook */}

--- a/src/lib/db/queries/settings.ts
+++ b/src/lib/db/queries/settings.ts
@@ -670,6 +670,7 @@ export async function getNotificationSettings(repositoryId?: string | null) {
     customWebhookMethod: DEFAULT_NOTIFICATION_SETTINGS.customWebhookMethod,
     customWebhookHeaders: null,
     issueTrackerProvider: DEFAULT_NOTIFICATION_SETTINGS.issueTrackerProvider,
+    issueAssignee: DEFAULT_NOTIFICATION_SETTINGS.issueAssignee,
     createdAt: null,
     updatedAt: null,
   };

--- a/src/lib/db/queries/step-comparisons.ts
+++ b/src/lib/db/queries/step-comparisons.ts
@@ -4,9 +4,9 @@
  */
 
 import { db } from "../index";
-import { stepComparisons } from "../schema";
+import { stepComparisons, builds, testRuns } from "../schema";
 import type { NewStepComparison, StepComparison } from "../schema";
-import { eq, and } from "drizzle-orm";
+import { eq, and, inArray, isNotNull } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 export async function createStepComparison(
@@ -101,22 +101,6 @@ export async function getStepComparisonForStep(
   return row;
 }
 
-/**
- * Verify-phase reverse lookup: which step has this GH issue linked? Used by
- * the issues webhook to auto-rerun + close the case when the issue closes.
- * Multiple steps may legitimately reference the same issue if a reviewer
- * filed it manually then linked it elsewhere — we return all of them so the
- * webhook can rerun each affected test.
- */
-export async function getStepComparisonsByGithubIssue(
-  issueNumber: number,
-): Promise<StepComparison[]> {
-  return await db
-    .select()
-    .from(stepComparisons)
-    .where(eq(stepComparisons.githubIssueNumber, issueNumber));
-}
-
 export async function updateStepComparisonIssueState(
   id: string,
   state: StepComparison["githubIssueState"],
@@ -125,4 +109,67 @@ export async function updateStepComparisonIssueState(
     .update(stepComparisons)
     .set({ githubIssueState: state })
     .where(eq(stepComparisons.id, id));
+}
+
+/** Link a GitHub issue to a step comparison (url + number + state + kind). */
+export async function setStepComparisonIssue(
+  id: string,
+  issue: {
+    githubIssueUrl: string;
+    githubIssueNumber: number;
+    githubIssueState: StepComparison["githubIssueState"];
+    githubIssueKind: StepComparison["githubIssueKind"];
+  },
+): Promise<void> {
+  await db.update(stepComparisons).set(issue).where(eq(stepComparisons.id, id));
+}
+
+/**
+ * Confirm-on-green lookup: step comparisons in this repo for the given tests
+ * that still carry an open Lastest-filed issue ('auto'/'open' — deliberately
+ * NOT 'linked', which is someone else's issue we must not auto-close).
+ * Scoped through builds → test_runs because step_comparisons has no repo
+ * column; issue numbers are only unique per repo.
+ */
+export async function getOpenIssueStepsForTests(
+  repositoryId: string,
+  testIds: string[],
+): Promise<StepComparison[]> {
+  if (testIds.length === 0) return [];
+  const rows = await db
+    .select({ step: stepComparisons })
+    .from(stepComparisons)
+    .innerJoin(builds, eq(stepComparisons.buildId, builds.id))
+    .innerJoin(testRuns, eq(builds.testRunId, testRuns.id))
+    .where(
+      and(
+        eq(testRuns.repositoryId, repositoryId),
+        inArray(stepComparisons.testId, testIds),
+        isNotNull(stepComparisons.githubIssueNumber),
+        inArray(stepComparisons.githubIssueState, ["auto", "open"]),
+      ),
+    );
+  return rows.map((r) => r.step);
+}
+
+/**
+ * Repo-scoped variant of the webhook reverse lookup. Issue numbers repeat
+ * across repos, so the webhook must never match by number alone.
+ */
+export async function getStepComparisonsByGithubIssueInRepo(
+  repositoryId: string,
+  issueNumber: number,
+): Promise<StepComparison[]> {
+  const rows = await db
+    .select({ step: stepComparisons })
+    .from(stepComparisons)
+    .innerJoin(builds, eq(stepComparisons.buildId, builds.id))
+    .innerJoin(testRuns, eq(builds.testRunId, testRuns.id))
+    .where(
+      and(
+        eq(testRuns.repositoryId, repositoryId),
+        eq(stepComparisons.githubIssueNumber, issueNumber),
+      ),
+    );
+  return rows.map((r) => r.step);
 }

--- a/src/lib/integrations/github-issue-body.test.ts
+++ b/src/lib/integrations/github-issue-body.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { buildVisualDiffBody, buildVerifyCaseBody } from "./github-issue-body";
+import type { RcaVerdict, StepComparison, VisualDiff } from "@/lib/db/schema";
+
+const BASE_URL = "https://lastest.example";
+
+function rca(over: Partial<RcaVerdict> = {}): RcaVerdict {
+  return {
+    headline: "code",
+    signals: [
+      {
+        category: "code:structural",
+        confidence: 0.9,
+        reason: "DOM nodes were added in a code-flagged area",
+      },
+    ],
+    changedFiles: ["src/components/banner.tsx"],
+    regionCauses: [
+      {
+        region: { x: 0, y: 0, width: 100, height: 40 },
+        selector: '[data-testid="promo-banner"]',
+        changeType: ["removed"],
+        cssDeltas: [{ property: "display", baseline: "flex", current: "none" }],
+      },
+    ],
+    version: 1,
+    computedAt: "2026-06-16T00:00:00.000Z",
+    ...over,
+  };
+}
+
+function diff(over: Partial<VisualDiff> = {}): VisualDiff {
+  return {
+    id: "diff-1",
+    buildId: "build-1",
+    testId: "test-1",
+    testResultId: null,
+    stepLabel: "Checkout",
+    browser: "chromium",
+    baselineImagePath: null,
+    currentImagePath: null,
+    diffImagePath: null,
+    pixelDifference: 1234,
+    percentageDifference: "2.5",
+    classification: "changed",
+    status: "pending",
+    metadata: { changedRegions: [], rca: rca() },
+    aiAnalysis: null,
+    aiRecommendation: null,
+    issueUrl: null,
+    issueProvider: null,
+    ...over,
+  } as VisualDiff;
+}
+
+function step(over: Partial<StepComparison> = {}): StepComparison {
+  return {
+    id: "step-1",
+    buildId: "build-1",
+    testId: "test-1",
+    testResultId: null,
+    visualDiffId: "diff-1",
+    stepIndex: 0,
+    stepLabel: "Checkout",
+    verdict: "red",
+    evidence: [{ layer: "visual", signal: "high", summary: "2.5% pixel diff" }],
+    layers: {},
+    githubIssueUrl: null,
+    githubIssueNumber: null,
+    githubIssueState: null,
+    githubIssueKind: null,
+    confirmedBy: null,
+    confirmedAt: null,
+    reviewerNote: null,
+    createdAt: new Date(),
+    ...over,
+  } as StepComparison;
+}
+
+describe("suspected-cause (RCA) section", () => {
+  it("renders headline, signals, changed files, and failing selector in the visual diff body", () => {
+    const { body } = buildVisualDiffBody({
+      diff: diff(),
+      test: { id: "test-1", name: "Checkout flow", targetUrl: null },
+      functionalAreaName: null,
+      build: { id: "build-1" },
+      testRun: { gitBranch: "main", gitCommit: "abc1234" },
+      testResult: null,
+      stepComparison: null,
+      repoFullName: "acme/shop",
+      reporterEmail: "qa@acme.dev",
+      baseUrl: BASE_URL,
+    });
+    expect(body).toContain("### Suspected cause");
+    expect(body).toContain("🔴 code change");
+    expect(body).toContain("`code:structural` (90%)");
+    expect(body).toContain("src/components/banner.tsx");
+    expect(body).toContain('[data-testid="promo-banner"]');
+    expect(body).toContain("`display: flex → none`");
+  });
+
+  it("renders the RCA section in the verify case body even when the visual layer is filtered out", () => {
+    const { body } = buildVerifyCaseBody({
+      step: step(),
+      diff: diff(),
+      test: { id: "test-1", name: "Checkout flow", targetUrl: null },
+      functionalAreaName: null,
+      build: { id: "build-1" },
+      testRun: { gitBranch: "main", gitCommit: "abc1234" },
+      testResult: null,
+      repoFullName: "acme/shop",
+      reporterEmail: null,
+      baseUrl: BASE_URL,
+      includedLayers: ["network"],
+      reviewerNote: null,
+    });
+    expect(body).not.toContain("### Visual diff");
+    expect(body).toContain("### Suspected cause");
+    expect(body).toContain('[data-testid="promo-banner"]');
+  });
+
+  it("omits the section when no RCA verdict was computed", () => {
+    const { body } = buildVisualDiffBody({
+      diff: diff({ metadata: { changedRegions: [] } }),
+      test: { id: "test-1", name: "Checkout flow", targetUrl: null },
+      functionalAreaName: null,
+      build: { id: "build-1" },
+      testRun: null,
+      testResult: null,
+      stepComparison: null,
+      repoFullName: "acme/shop",
+      reporterEmail: "qa@acme.dev",
+      baseUrl: BASE_URL,
+    });
+    expect(body).not.toContain("### Suspected cause");
+  });
+});

--- a/src/lib/integrations/github-issue-body.ts
+++ b/src/lib/integrations/github-issue-body.ts
@@ -14,8 +14,9 @@
  *  3. Reviewer note (verify only)
  *  4. Top-line evidence chips
  *  5. Per-layer drill-downs (visual / console / network / dom / a11y / url / perf)
- *  6. AI triage + AI diff recommendation
- *  7. Resources (open in Lastest, baseline/current/diff images, video)
+ *  6. Suspected cause (RCA verdict: code vs test, failing selectors, CSS deltas)
+ *  7. AI triage + AI diff recommendation
+ *  8. Resources (open in Lastest, baseline/current/diff images, video)
  *
  * The composer is pure (no DB / fetch). Callers gather the inputs and pass them in.
  */
@@ -32,6 +33,7 @@ import type {
   NetworkDiffSummary,
   NetworkRequest,
   PerfDiffSummary,
+  RcaVerdict,
   StepComparison,
   StepComparisonEvidence,
   Test,
@@ -527,6 +529,64 @@ function renderPerfDrill(diff: PerfDiffSummary | undefined): string[] {
   return lines;
 }
 
+// ── section: suspected cause (RCA verdict) ─────────────────────────────────
+
+/**
+ * "Is this diff the test or the code?" — the post-build RCA verdict from
+ * `diff.metadata.rca`. This is the section an AI engineer keys off: headline
+ * bucket, ranked signals, the build's changed files, and element-level
+ * region causes carrying the failing selector + CSS deltas.
+ */
+function renderRcaDrill(rca: RcaVerdict | null | undefined): string[] {
+  if (!rca) return [];
+  const lines: string[] = ["### Suspected cause", ""];
+  const badge =
+    rca.headline === "code"
+      ? "🔴 code change"
+      : rca.headline === "test"
+        ? "🟡 test / environment noise"
+        : "⚪ uncertain";
+  lines.push(`**Verdict:** ${badge}`);
+  if (rca.narrative) lines.push("", rca.narrative);
+  if (rca.signals.length > 0) {
+    lines.push("", "**Signals:**", "");
+    for (const s of rca.signals.slice(0, 5)) {
+      lines.push(
+        `- \`${s.category}\` (${(s.confidence * 100).toFixed(0)}%): ${s.reason}`,
+      );
+    }
+  }
+  if (rca.changedFiles.length > 0) {
+    lines.push("", "**Changed files in this build:**", "");
+    for (const f of rca.changedFiles.slice(0, 20)) lines.push(`- \`${f}\``);
+    if (rca.changedFiles.length > 20)
+      lines.push(`- _… ${rca.changedFiles.length - 20} more_`);
+  }
+  if (rca.regionCauses && rca.regionCauses.length > 0) {
+    lines.push(
+      "",
+      `<details><summary>Element-level causes (${rca.regionCauses.length})</summary>`,
+      "",
+    );
+    for (const rc of rca.regionCauses.slice(0, 15)) {
+      const css = rc.cssDeltas?.length
+        ? ` — ${rc.cssDeltas
+            .slice(0, 3)
+            .map((cd) => `\`${cd.property}: ${cd.baseline} → ${cd.current}\``)
+            .join(", ")}`
+        : "";
+      lines.push(
+        `- \`${truncate(rc.selector, 140)}\` (${rc.changeType.join("/")})${css}`,
+      );
+    }
+    if (rca.regionCauses.length > 15)
+      lines.push(`- _… ${rca.regionCauses.length - 15} more_`);
+    lines.push("</details>");
+  }
+  lines.push("");
+  return lines;
+}
+
 // ── section: triage ────────────────────────────────────────────────────────
 
 function renderTriage(
@@ -723,6 +783,7 @@ export function buildVisualDiffBody(input: VisualDiffBodyInput): {
 
   // Visual is always emitted for the diff path — that's the whole point.
   lines.push(...renderVisualDrill({ diff, baseUrl }));
+  lines.push(...renderRcaDrill(diff.metadata?.rca));
 
   if (includedLayers.has("console")) {
     lines.push(
@@ -869,6 +930,9 @@ export function buildVerifyCaseBody(input: VerifyCaseBodyInput): {
   if (includedLayers.has("visual") && diff) {
     lines.push(...renderVisualDrill({ diff, baseUrl }));
   }
+  // Suspected cause rides along whenever RCA ran, regardless of the layer
+  // filter — it's the "what do I fix" pointer the assignee needs.
+  lines.push(...renderRcaDrill(diff?.metadata?.rca));
   if (includedLayers.has("console")) {
     lines.push(
       ...renderConsoleDrill(testResult?.consoleErrors, layers.consoleDiff),

--- a/src/lib/integrations/github-issues.ts
+++ b/src/lib/integrations/github-issues.ts
@@ -1,11 +1,4 @@
-import type {
-  AIDiffAnalysis,
-  A11yViolation,
-  BugReportContext,
-  BugReportSeverity,
-  Test,
-  VisualDiff,
-} from "@/lib/db/schema";
+import type { BugReportContext, BugReportSeverity } from "@/lib/db/schema";
 
 export interface BugReportIssueData {
   description: string;
@@ -60,168 +53,24 @@ function buildIssueBody(data: BugReportIssueData): string {
 }
 
 // ===== Visual diff issue submission =====
-
-export interface VisualDiffIssueInput {
-  diff: VisualDiff & {
-    errorMessage?: string | null;
-    a11yViolations?: A11yViolation[] | null;
-    consoleErrors?: string[] | null;
-  };
-  test: Pick<Test, "name"> | null;
-  functionalAreaName?: string | null;
-  build: { id: string };
-  branch: string | null;
-  commit: string | null;
-  repoFullName: string;
-  reporterEmail: string;
-  /** Absolute origin (no trailing slash), used to build links to /api/media + the diff page. */
-  baseUrl: string;
-}
-
-function shortSha(sha: string | null | undefined): string {
-  if (!sha) return "unknown";
-  return sha.length > 8 ? sha.slice(0, 8) : sha;
-}
-
-function mediaUrl(
-  baseUrl: string,
-  relativePath: string | null | undefined,
-): string | null {
-  if (!relativePath) return null;
-  const clean = relativePath.replace(/^\/+/, "");
-  return `${baseUrl.replace(/\/+$/, "")}/api/media/${clean}`;
-}
-
-export function buildVisualDiffIssue(input: VisualDiffIssueInput): {
-  title: string;
-  body: string;
-  labels: string[];
-} {
-  const {
-    diff,
-    test,
-    functionalAreaName,
-    build,
-    branch,
-    commit,
-    repoFullName,
-    reporterEmail,
-    baseUrl,
-  } = input;
-  const trimmedBase = baseUrl.replace(/\/+$/, "");
-  const testName = test?.name || "Visual diff";
-  const pct = diff.percentageDifference
-    ? `${diff.percentageDifference}%`
-    : "0%";
-  const classification = diff.classification || "changed";
-
-  const title = `Visual diff: ${testName}${diff.stepLabel ? ` — ${diff.stepLabel}` : ""} (${pct})`;
-
-  const lines: string[] = [];
-  lines.push("## Visual diff review");
-  lines.push("");
-  lines.push(
-    `**Test:** ${testName}${functionalAreaName ? ` _(area: ${functionalAreaName})_` : ""}`,
-  );
-  if (diff.stepLabel) lines.push(`**Step:** \`${diff.stepLabel}\``);
-  lines.push(`**Classification:** \`${classification}\``);
-  lines.push(`**Difference:** ${pct} (${diff.pixelDifference ?? 0} px)`);
-  lines.push(`**Browser:** ${diff.browser || "chromium"}`);
-  lines.push(`**Reporter:** ${reporterEmail}`);
-  lines.push("");
-  lines.push("### Build context");
-  lines.push("");
-  lines.push("| Field | Value |");
-  lines.push("|-------|-------|");
-  lines.push(`| Repo | \`${repoFullName}\` |`);
-  lines.push(`| Build | \`${build.id}\` |`);
-  lines.push(`| Branch | \`${branch ?? "unknown"}\` |`);
-  lines.push(`| Commit | \`${shortSha(commit)}\` |`);
-  lines.push("");
-
-  if (diff.errorMessage) {
-    lines.push("### Error");
-    lines.push("");
-    lines.push("```");
-    lines.push(diff.errorMessage.slice(0, 4000));
-    lines.push("```");
-    lines.push("");
-  }
-
-  if (diff.consoleErrors && diff.consoleErrors.length > 0) {
-    lines.push(
-      `<details><summary>Console errors (${diff.consoleErrors.length})</summary>`,
-    );
-    lines.push("");
-    lines.push("```");
-    lines.push(diff.consoleErrors.slice(0, 20).join("\n"));
-    lines.push("```");
-    lines.push("</details>");
-    lines.push("");
-  }
-
-  if (diff.a11yViolations && diff.a11yViolations.length > 0) {
-    lines.push(
-      `<details><summary>Accessibility violations (${diff.a11yViolations.length})</summary>`,
-    );
-    lines.push("");
-    for (const v of diff.a11yViolations.slice(0, 10)) {
-      lines.push(
-        `- **${v.id}** (${v.impact ?? "unknown"}) — ${v.help ?? v.description ?? ""}`,
-      );
-    }
-    lines.push("</details>");
-    lines.push("");
-  }
-
-  const aiText =
-    diff.aiRecommendation ||
-    (diff.aiAnalysis as AIDiffAnalysis | null | undefined)?.summary;
-  if (aiText) {
-    lines.push("### AI analysis");
-    lines.push("");
-    if (diff.aiRecommendation)
-      lines.push(`**Recommendation:** \`${diff.aiRecommendation}\``);
-    const summary = (diff.aiAnalysis as AIDiffAnalysis | null | undefined)
-      ?.summary;
-    if (summary) {
-      lines.push("");
-      lines.push(summary);
-    }
-    lines.push("");
-  }
-
-  const diffImg = mediaUrl(trimmedBase, diff.diffImagePath);
-  const baseImg = mediaUrl(trimmedBase, diff.baselineImagePath);
-  const currImg = mediaUrl(trimmedBase, diff.currentImagePath);
-  if (diffImg || baseImg || currImg) {
-    lines.push("### Screenshots");
-    lines.push("");
-    lines.push("_Login to Lastest required to view._");
-    lines.push("");
-    if (diffImg) lines.push(`- [Diff](${diffImg})`);
-    if (baseImg) lines.push(`- [Baseline](${baseImg})`);
-    if (currImg) lines.push(`- [Current](${currImg})`);
-    lines.push("");
-  }
-
-  lines.push("---");
-  lines.push(
-    `👉 [Open in Lastest](${trimmedBase}/builds/${build.id}/diff/${diff.id})`,
-  );
-
-  return {
-    title,
-    body: lines.join("\n"),
-    labels: ["lastest", "visual-diff"],
-  };
-}
+//
+// The issue body is composed by `buildVisualDiffBody` in
+// `@/lib/integrations/github-issue-body` (the shared enriched composer).
+// The legacy thin composer that used to live here was removed — every
+// Lastest-filed issue must carry the full snapshot evidence trail.
 
 export async function createVisualDiffIssue(
   token: string,
   owner: string,
   repo: string,
-  payload: { title: string; body: string; labels: string[] },
+  payload: {
+    title: string;
+    body: string;
+    labels: string[];
+    /** GitHub logins to auto-assign (e.g. the team's AI engineer bot).
+     *  Invalid/non-collaborator logins are silently dropped by GitHub. */
+    assignees?: string[];
+  },
 ): Promise<{
   success: boolean;
   issueUrl?: string;

--- a/src/lib/verify/confirm-on-green.ts
+++ b/src/lib/verify/confirm-on-green.ts
@@ -1,0 +1,160 @@
+import * as queries from "@/lib/db/queries";
+
+// NOTE: Plain module, NOT a `"use server"` file. This closes GitHub issues on
+// behalf of the team without a user session — exposing it as a server action
+// would let any caller close another team's tickets. It is called only from
+// trusted build-finalization code (same convention as auto-approve.ts).
+
+/**
+ * Confirm-on-green — the closing arc of the diff→fix→re-run loop:
+ *
+ *   1. Lastest files an issue (evidence-packed, assigned to the AI engineer).
+ *   2. The engineer lands a fix and closes the issue ("closes #N" on the PR).
+ *   3. The issues webhook auto-reruns the linked tests.
+ *   4. THIS runs when that build finalizes as `safe_to_merge`: every open
+ *      Lastest-filed issue whose test came back fully green is closed with a
+ *      comment linking the green build, and the case is marked closed on the
+ *      verify board.
+ *
+ * It also covers the human path — an issue left open after someone shipped a
+ * fix closes itself on the next green run, matching the product promise
+ * "the issue closes itself once the re-run comes back safe_to_merge".
+ *
+ * Scope guards:
+ *   - Only issues Lastest filed (state 'auto'/'open'). Manually 'linked'
+ *     issues belong to someone else's workflow and are never auto-closed.
+ *   - 'improvement' tickets are skipped: they track an intent gap, which a
+ *     green-vs-baseline rerun cannot prove fixed.
+ *   - Only tests whose EVERY step in this build has a green verdict.
+ *
+ * Idempotent: the state filter excludes already-closed links, and the DB is
+ * flipped to 'closed' before the GitHub PATCH so the resulting issues-webhook
+ * delivery finds nothing left to rerun.
+ */
+export async function closeIssuesOnGreen(
+  buildId: string,
+): Promise<{ closed: number }> {
+  const build = await queries.getBuild(buildId);
+  if (!build || build.overallStatus !== "safe_to_merge") return { closed: 0 };
+  const testRun = build.testRunId
+    ? await queries.getTestRun(build.testRunId)
+    : null;
+  const repositoryId = testRun?.repositoryId ?? null;
+  if (!repositoryId) return { closed: 0 };
+
+  // Tests where every step of this build is green — a single yellow/red step
+  // means the fix isn't proven even if the build overall was approved green.
+  const steps = await queries.getStepComparisonsByBuild(buildId);
+  if (steps.length === 0) return { closed: 0 };
+  const verdictsByTest = new Map<string, boolean>();
+  for (const s of steps) {
+    const prev = verdictsByTest.get(s.testId) ?? true;
+    verdictsByTest.set(s.testId, prev && s.verdict === "green");
+  }
+  const greenTestIds = [...verdictsByTest.entries()]
+    .filter(([, allGreen]) => allGreen)
+    .map(([testId]) => testId);
+  if (greenTestIds.length === 0) return { closed: 0 };
+
+  const candidates = (
+    await queries.getOpenIssueStepsForTests(repositoryId, greenTestIds)
+  ).filter((s) => s.buildId !== buildId && s.githubIssueKind !== "improvement");
+  if (candidates.length === 0) return { closed: 0 };
+
+  const repo = await queries.getRepository(repositoryId);
+  if (!repo || repo.provider !== "github" || !repo.owner || !repo.name)
+    return { closed: 0 };
+  const account = repo.teamId
+    ? await queries.getGithubAccountByTeam(repo.teamId)
+    : null;
+  if (!account?.accessToken) return { closed: 0 };
+
+  const baseUrl = (
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.BETTER_AUTH_BASE_URL ||
+    "http://localhost:3000"
+  ).replace(/\/+$/, "");
+
+  // One issue may back several step comparisons — close it once.
+  const stepsByIssue = new Map<number, typeof candidates>();
+  for (const s of candidates) {
+    const n = s.githubIssueNumber!;
+    stepsByIssue.set(n, [...(stepsByIssue.get(n) ?? []), s]);
+  }
+
+  let closed = 0;
+  for (const [issueNumber, linkedSteps] of stepsByIssue) {
+    // Flip the DB first so the issues-webhook fired by our own PATCH sees
+    // state 'closed' and does not queue a redundant rerun.
+    await Promise.all(
+      linkedSteps.map((s) =>
+        queries.updateStepComparisonIssueState(s.id, "closed"),
+      ),
+    );
+    try {
+      const headers = {
+        Authorization: `Bearer ${account.accessToken}`,
+        Accept: "application/vnd.github.v3+json",
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      };
+      const testNames = [
+        ...new Set(linkedSteps.map((s) => s.stepLabel ?? s.testId)),
+      ];
+      await fetch(
+        `https://api.github.com/repos/${repo.owner}/${repo.name}/issues/${issueNumber}/comments`,
+        {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            body:
+              `✅ Re-run came back **safe_to_merge** — closing.\n\n` +
+              `Verified green: ${testNames.map((n) => `\`${n}\``).join(", ")}\n\n` +
+              `👉 [Green build in Lastest](${baseUrl}/builds/${buildId})`,
+          }),
+        },
+      );
+      const res = await fetch(
+        `https://api.github.com/repos/${repo.owner}/${repo.name}/issues/${issueNumber}`,
+        {
+          method: "PATCH",
+          headers,
+          body: JSON.stringify({ state: "closed", state_reason: "completed" }),
+        },
+      );
+      if (res.ok) {
+        closed++;
+      } else {
+        // GitHub rejected the close (revoked token, issue deleted…) — restore
+        // the link state so the next green build retries instead of orphaning
+        // an open issue that Lastest believes is closed.
+        const text = await res.text().catch(() => "");
+        console.error(
+          `[confirm-on-green] failed to close #${issueNumber} on ${repo.fullName}: ${res.status} ${text.slice(0, 200)}`,
+        );
+        await Promise.all(
+          linkedSteps.map((s) =>
+            queries.updateStepComparisonIssueState(
+              s.id,
+              s.githubIssueState ?? "open",
+            ),
+          ),
+        );
+      }
+    } catch (err) {
+      console.error(
+        `[confirm-on-green] error closing #${issueNumber} on ${repo.fullName}:`,
+        err,
+      );
+      await Promise.all(
+        linkedSteps.map((s) =>
+          queries.updateStepComparisonIssueState(
+            s.id,
+            s.githubIssueState ?? "open",
+          ),
+        ),
+      );
+    }
+  }
+  return { closed };
+}

--- a/src/server/actions/builds.ts
+++ b/src/server/actions/builds.ts
@@ -1632,6 +1632,22 @@ async function runBuildAsync(
       })
       .catch(console.error);
 
+    // Fire-and-forget confirm-on-green — when a run comes back safe_to_merge,
+    // close every open Lastest-filed GitHub issue whose test ran fully green,
+    // completing the diff → issue → fix → re-run loop without a human.
+    if (overallStatus === "safe_to_merge") {
+      import("@/lib/verify/confirm-on-green")
+        .then(({ closeIssuesOnGreen }) => {
+          closeIssuesOnGreen(buildId).catch((e) => {
+            console.error(
+              `[verify] confirm-on-green failed for build ${buildId}:`,
+              e,
+            );
+          });
+        })
+        .catch(console.error);
+    }
+
     // Phase 2: If this was a comparison baseline build, chain the feature build
     const completedBuild = await queries.getBuild(buildId);
     if (

--- a/src/server/actions/diffs.ts
+++ b/src/server/actions/diffs.ts
@@ -651,11 +651,21 @@ export async function submitDiffAsIssue(diffId: string): Promise<{
     baseUrl,
   });
 
+  // Tag with `verify` whenever the diff has a step comparison so the issues
+  // webhook recognizes the close event and auto-reruns the test — without it
+  // the diff-submitted ticket falls out of the diff→fix→re-run loop.
+  const labels = stepComparison
+    ? [...payload.labels, "verify"]
+    : payload.labels;
+  // Auto-assign the configured AI engineer so the ticket is picked up
+  // without a human dispatcher.
+  const assignees = notif.issueAssignee ? [notif.issueAssignee] : undefined;
+
   const result = await createVisualDiffIssue(
     ghAccount.accessToken,
     repo.owner,
     repo.name,
-    payload,
+    { ...payload, labels, assignees },
   );
 
   if (!result.success || !result.issueUrl) {
@@ -666,6 +676,18 @@ export async function submitDiffAsIssue(diffId: string): Promise<{
   }
 
   await queries.setDiffIssue(diffId, result.issueUrl, "github");
+
+  // Mirror the link onto the step comparison so the verify board shows the
+  // ticket and the close-webhook can find the case to rerun + reconcile.
+  if (stepComparison && result.issueNumber) {
+    await queries.setStepComparisonIssue(stepComparison.id, {
+      githubIssueUrl: result.issueUrl,
+      githubIssueNumber: result.issueNumber,
+      githubIssueState: "open",
+      githubIssueKind:
+        stepComparison.verdict === "red" ? "bugfix" : "verification",
+    });
+  }
 
   revalidatePath("/builds");
   if (diff.buildId) {

--- a/src/server/actions/settings.ts
+++ b/src/server/actions/settings.ts
@@ -214,6 +214,7 @@ export async function saveNotificationSettings(data: {
   customWebhookMethod?: string;
   customWebhookHeaders?: string | null;
   issueTrackerProvider?: "github" | "gitlab";
+  issueAssignee?: string | null;
 }) {
   if (data.repositoryId) await requireRepoAccess(data.repositoryId);
   else await requireTeamAccess();

--- a/src/server/actions/verify-issues.ts
+++ b/src/server/actions/verify-issues.ts
@@ -132,6 +132,11 @@ export async function createIssueForCase(
     input.kind ?? (step.verdict === "red" ? "bugfix" : "verification");
   const labels = ["verify", kind, ...(kind === "bugfix" ? ["regression"] : [])];
 
+  // Auto-assign the configured AI engineer (Settings → Notifications → Issue
+  // Tracker) so filed cases are picked up without a human dispatcher.
+  const notif = await queries.getNotificationSettings(repoId);
+  const assignees = notif.issueAssignee ? [notif.issueAssignee] : undefined;
+
   try {
     const response = await fetch(
       `https://api.github.com/repos/${repo.owner}/${repo.name}/issues`,
@@ -143,7 +148,7 @@ export async function createIssueForCase(
           "Content-Type": "application/json",
           "X-GitHub-Api-Version": "2022-11-28",
         },
-        body: JSON.stringify({ title, body, labels }),
+        body: JSON.stringify({ title, body, labels, assignees }),
       },
     );
     if (!response.ok) {


### PR DESCRIPTION
## Summary

Implements the "confirm-on-green" feature that automatically closes GitHub issues filed by Lastest when a re-run of the linked test comes back `safe_to_merge`. This completes the diff → issue → fix → re-run loop without manual intervention, fulfilling the product promise that "the issue closes itself once the re-run comes back safe_to_merge".

## Key Changes

**New confirm-on-green module** (`src/lib/verify/confirm-on-green.ts`):
- Runs fire-and-forget when a build finalizes as `safe_to_merge`
- Closes every open Lastest-filed issue (`auto`/`open` state, not `linked`) whose test ran fully green in this build
- Skips `improvement` tickets (they track intent gaps, not regressions)
- Flips DB state to `closed` before GitHub PATCH to prevent webhook loops
- Includes error recovery: restores link state if GitHub PATCH fails (revoked token, deleted issue, etc.)
- Posts a comment linking the green build before closing

**Issue filing & linking** (`src/server/actions/diffs.ts`):
- Tags visual diff issues with `verify` label so the issues webhook recognizes close events and auto-reruns
- Auto-assigns configured AI engineer (Settings → Notifications → Issue Tracker)
- Mirrors GitHub issue link onto `step_comparisons` table so verify board shows the ticket and webhook can find the case

**Webhook improvements** (`src/app/api/webhooks/github/route.ts`):
- Changed `getStepComparisonsByGithubIssue` to repo-scoped `getStepComparisonsByGithubIssueInRepo` (issue numbers repeat across repos)
- Filters out already-closed cases to prevent re-run loops when confirm-on-green closes the issue itself
- Improved error messaging to distinguish "already reconciled" from "no linked steps"

**Database queries** (`src/lib/db/queries/step-comparisons.ts`):
- Added `setStepComparisonIssue()` to link GitHub issue metadata to a step comparison
- Added `getOpenIssueStepsForTests()` for confirm-on-green to find candidates
- Added `getStepComparisonsByGithubIssueInRepo()` for repo-scoped webhook lookups

**Issue body composer** (`src/lib/integrations/github-issue-body.ts`):
- Added RCA (Root Cause Analysis) section rendering (`renderRcaDrill()`)
- Shows verdict (code vs test vs uncertain), ranked signals, changed files, and element-level causes with CSS deltas
- Included in both visual diff and verify case bodies (rides along even when visual layer is filtered)
- Removed legacy thin visual diff composer; all Lastest-filed issues now carry full snapshot evidence trail

**Settings & schema**:
- Added `issueAssignee` field to `notification_settings` table (GitHub login)
- UI in `NotificationSettingsCard` to configure auto-assign target
- Passed through to issue creation in `createIssueForCase()` and `submitDiffAsIssue()`

**Build finalization** (`src/server/actions/builds.ts`):
- Calls `closeIssuesOnGreen()` fire-and-forget when `overallStatus === "safe_to_merge"`

**Tests** (`src/lib/integrations/github-issue-body.test.ts`):
- Added test suite for RCA section rendering in visual diff and verify case bodies
- Covers headline, signals, changed files, failing selectors, and CSS deltas

## Implementation Details

- **Idempotent**: State filter excludes already-closed links; DB flipped before GitHub PATCH so resulting webhook delivery finds nothing to rerun
- **Scope guards**: Only auto-closes Lastest-filed issues (`auto`/`open`), skips `improvement` tickets, requires every step in the build to be green
- **Error recovery**: If GitHub PATCH fails, restores link state so next green build retries instead of orphaning an open issue
- **No user session required**: Uses team's GitHub account token (same

https://claude.ai/code/session_016nN5Vq1mLwuxu323D8YBHK