### PR TITLE
Add QA Agent: comprehensive test suite builder with AI planning

### DIFF
--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -384,6 +384,34 @@ export class LastestClient {
     return this.get(`/api/v1/repos/${repoId}/coverage`);
   }
 
+  // --- QA Agent (ongoing agent: runs, direction queue) ---
+
+  async getQaAgentStatus(repoId: string): Promise<unknown> {
+    return this.get(`/api/v1/repos/${repoId}/qa-agent`);
+  }
+
+  async startQaAgentRun(
+    repoId: string,
+    opts: { mode?: string; targetUrl?: string } = {},
+  ): Promise<unknown> {
+    return this.post(`/api/v1/repos/${repoId}/qa-agent/runs`, opts);
+  }
+
+  async getQaSession(sessionId: string): Promise<unknown> {
+    return this.get(`/api/v1/qa-sessions/${sessionId}`);
+  }
+
+  async listQaTasks(repoId: string): Promise<unknown> {
+    return this.get(`/api/v1/repos/${repoId}/qa-tasks`);
+  }
+
+  async addQaTask(
+    repoId: string,
+    opts: { title: string; description?: string },
+  ): Promise<unknown> {
+    return this.post(`/api/v1/repos/${repoId}/qa-tasks`, opts);
+  }
+
   // --- AI Operations ---
 
   async createTest(opts: {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1906,6 +1906,166 @@ export function createServer(client: LastestClient): McpServer {
     },
   );
 
+  // ===== lastest_qa_agent (ongoing QA agent: status, runs, direction queue) =====
+  server.tool(
+    "lastest_qa_agent",
+    'Drive the ongoing QA agent for a repository (needs repositoryId). `action`: "status" (live session, latest coverage summary, task board, trigger config), "start_run" (start an autonomous run — optional mode full|refresh_spec|fill_gaps and targetUrl; 409 when a session is already running), "run_status" (poll a session by sessionId), "add_task" (queue a directive on the agent\'s task board — it picks tasks up when idle, works them with the right protocol, and replies on the card), "list_tasks" (the task board).',
+    {
+      action: z
+        .enum(["status", "start_run", "run_status", "add_task", "list_tasks"])
+        .describe(
+          '"status" = agent overview; "start_run" = start a run; "run_status" = poll a run; "add_task" = queue a directive; "list_tasks" = task board',
+        ),
+      repositoryId: z
+        .string()
+        .optional()
+        .describe("Repository ID (required for all actions except run_status)"),
+      sessionId: z
+        .string()
+        .optional()
+        .describe("QA session ID (run_status only)"),
+      mode: z
+        .enum(["full", "refresh_spec", "fill_gaps"])
+        .optional()
+        .describe(
+          "start_run only. Omit to let the agent pick (fill_gaps when a stored plan exists, else full).",
+        ),
+      targetUrl: z
+        .string()
+        .optional()
+        .describe(
+          "start_run only. Override the target app URL (defaults to the last run's URL or the repo's env base URL).",
+        ),
+      title: z
+        .string()
+        .optional()
+        .describe(
+          'add_task only. The directive, e.g. "Cover the billing flow".',
+        ),
+      description: z
+        .string()
+        .optional()
+        .describe("add_task only. Extra context for the agent."),
+    },
+    async (
+      params,
+    ): Promise<{ content: Array<{ type: "text"; text: string }> }> => {
+      const action = params.action as
+        | "status"
+        | "start_run"
+        | "run_status"
+        | "add_task"
+        | "list_tasks";
+      const repositoryId = params.repositoryId as string | undefined;
+
+      const respond = (response: ToolResponse) => ({
+        content: [
+          { type: "text" as const, text: JSON.stringify(response, null, 2) },
+        ],
+      });
+      const needRepo = () =>
+        respond({
+          status: "error",
+          summary: "repositoryId is required for this action",
+          details: {},
+        });
+
+      if (action === "run_status") {
+        if (!params.sessionId) {
+          return respond({
+            status: "error",
+            summary: "sessionId is required for run_status",
+            details: {},
+          });
+        }
+        const session = (await client.getQaSession(
+          params.sessionId as string,
+        )) as Record<string, unknown>;
+        return respond({
+          status: `run_${session.status}`,
+          summary: `QA session ${session.id}: ${session.status} (step: ${session.currentStepId ?? "?"})`,
+          details: session,
+        });
+      }
+
+      if (!repositoryId) return needRepo();
+
+      if (action === "status") {
+        const status = (await client.getQaAgentStatus(repositoryId)) as Record<
+          string,
+          unknown
+        >;
+        const live = status.liveSession as Record<string, unknown> | null;
+        const tasks = (status.tasks ?? []) as Array<Record<string, unknown>>;
+        const queued = tasks.filter((t) => t.status === "queued").length;
+        return respond({
+          status: live ? "agent_working" : "agent_idle",
+          summary: live
+            ? `QA agent is ${live.status} (step: ${live.currentStepId ?? "?"}) on ${live.targetUrl ?? "?"}`
+            : `QA agent is idle. ${queued} task(s) queued.`,
+          details: status,
+        });
+      }
+
+      if (action === "start_run") {
+        // The v1 API answers 409 when a session is already running (the
+        // client surfaces non-2xx as a thrown error) — convert that into a
+        // "queue a task instead" hint rather than a hard failure.
+        try {
+          const result = (await client.startQaAgentRun(repositoryId, {
+            mode: params.mode as string | undefined,
+            targetUrl: params.targetUrl as string | undefined,
+          })) as Record<string, unknown>;
+          return respond({
+            status: "run_started",
+            summary: `QA agent run started (session ${result.sessionId}). Poll with action:"run_status".`,
+            details: result,
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return respond({
+            status: "not_started",
+            summary: `Could not start: ${message}`,
+            actionRequired: [
+              'Queue the work with action:"add_task" instead — the agent picks tasks up as soon as it is idle.',
+            ],
+            details: { error: message },
+          });
+        }
+      }
+
+      if (action === "add_task") {
+        if (!params.title || !(params.title as string).trim()) {
+          return respond({
+            status: "error",
+            summary: "title is required for add_task",
+            details: {},
+          });
+        }
+        const task = (await client.addQaTask(repositoryId, {
+          title: params.title as string,
+          description: params.description as string | undefined,
+        })) as Record<string, unknown>;
+        return respond({
+          status: "task_queued",
+          summary: `Task "${task.title}" queued for the QA agent. It will pick it up when idle and reply on the card; check with action:"list_tasks".`,
+          details: task,
+        });
+      }
+
+      // action === 'list_tasks'
+      const tasks = (await client.listQaTasks(repositoryId)) as Array<
+        Record<string, unknown>
+      >;
+      const byStatus = (s: string) => tasks.filter((t) => t.status === s);
+      return respond({
+        status: "tasks_listed",
+        summary: `${byStatus("queued").length} queued · ${byStatus("working").length} working · ${byStatus("needs_input").length} waiting on a human · ${byStatus("done").length} done`,
+        details: { tasks },
+      });
+    },
+  );
+
   // ===== Workflow verbs (standalone, unchanged) =====
 
   // --- lastest_run_tests ---

--- a/src/app/(app)/qa-agent/page.tsx
+++ b/src/app/(app)/qa-agent/page.tsx
@@ -13,14 +13,34 @@ import {
 import type { AgentSession } from "@/lib/db/schema";
 import { getEnvironmentConfig } from "@/server/actions/environment";
 import { QaAgentClient } from "@/components/qa-agent/qa-agent-client";
+import { QaAgentUpgradeGate } from "@/components/qa-agent/qa-agent-upgrade-gate";
+import {
+  hasQaAgentAccess,
+  qaAgentMinPlanName,
+} from "@/lib/billing/feature-access";
+import { planConfig } from "@/lib/billing/plans";
 import { Bot } from "lucide-react";
 
 export const dynamic = "force-dynamic";
 
 export default async function QaAgentPage() {
   const session = await getCurrentSession();
-  const teamId = session?.team?.id;
+  const team = session?.team;
+  const teamId = team?.id;
   const userId = session?.user?.id;
+
+  // QA Agent is a Pro-tier feature. Gate before anything else so teams below
+  // the required plan always land on the upgrade screen (regardless of whether
+  // they've connected a repo yet).
+  if (team && !hasQaAgentAccess(team.plan)) {
+    return (
+      <QaAgentUpgradeGate
+        currentPlanName={planConfig(team.plan).name}
+        requiredPlanName={qaAgentMinPlanName()}
+      />
+    );
+  }
+
   const selectedRepo = teamId
     ? await getSelectedRepository(userId, teamId)
     : null;

--- a/src/app/(app)/qa-agent/page.tsx
+++ b/src/app/(app)/qa-agent/page.tsx
@@ -8,7 +8,9 @@ import {
   getAISettings,
   getDefaultSetupSteps,
   getStorageStates,
+  getQaTasksByRepo,
 } from "@/lib/db/queries";
+import type { AgentSession } from "@/lib/db/schema";
 import { getEnvironmentConfig } from "@/server/actions/environment";
 import { QaAgentClient } from "@/components/qa-agent/qa-agent-client";
 import { Bot } from "lucide-react";
@@ -51,6 +53,7 @@ export default async function QaAgentPage() {
   const [
     qaSession,
     recentSessions,
+    qaTasks,
     ghAccount,
     envConfig,
     aiSettings,
@@ -59,6 +62,7 @@ export default async function QaAgentPage() {
   ] = await Promise.all([
     getLatestAgentSession(selectedRepo.id, "qa").catch(() => null),
     getRecentAgentSessions(selectedRepo.id, "qa", 10).catch(() => []),
+    getQaTasksByRepo(selectedRepo.id).catch(() => []),
     teamId ? getGithubAccountByTeam(teamId).catch(() => null) : null,
     getEnvironmentConfig(selectedRepo.id).catch(() => null),
     getAISettings(selectedRepo.id).catch(() => null),
@@ -97,18 +101,16 @@ export default async function QaAgentPage() {
   const hasExistingAuthSetup = hasDefaultSetupSteps || hasLiveStorageState;
 
   // Credentials never reach the client; drop the password from the snapshot.
-  const initialSession = qaSession
-    ? {
-        ...qaSession,
-        metadata: (({ quickstartPassword: _pw, ...rest }) => rest)(
-          qaSession.metadata,
-        ),
-      }
-    : null;
+  const sanitize = (s: AgentSession): AgentSession => ({
+    ...s,
+    metadata: (({ quickstartPassword: _pw, ...rest }) => rest)(s.metadata),
+  });
+  const initialSession = qaSession ? sanitize(qaSession) : null;
+  const sanitizedRecent = recentSessions.map(sanitize);
 
   return (
     <div className="flex-1 p-6 overflow-auto">
-      <div className="max-w-4xl mx-auto space-y-6">
+      <div className="max-w-5xl mx-auto space-y-6">
         <header className="space-y-1">
           <h1 className="text-2xl font-semibold flex items-center gap-2">
             <Bot className="h-6 w-6" />
@@ -130,6 +132,8 @@ export default async function QaAgentPage() {
           storedPlanInfo={storedPlanInfo}
           hasExistingAuthSetup={hasExistingAuthSetup}
           initialSession={initialSession}
+          recentSessions={sanitizedRecent}
+          initialTasks={qaTasks}
         />
       </div>
     </div>

--- a/src/app/(app)/qa-agent/page.tsx
+++ b/src/app/(app)/qa-agent/page.tsx
@@ -1,0 +1,101 @@
+import Link from "next/link";
+import { getCurrentSession } from "@/lib/auth";
+import {
+  getSelectedRepository,
+  getLatestAgentSession,
+  getGithubAccountByTeam,
+  getAISettings,
+} from "@/lib/db/queries";
+import { getEnvironmentConfig } from "@/server/actions/environment";
+import { QaAgentClient } from "@/components/qa-agent/qa-agent-client";
+import { Bot } from "lucide-react";
+
+export const dynamic = "force-dynamic";
+
+export default async function QaAgentPage() {
+  const session = await getCurrentSession();
+  const teamId = session?.team?.id;
+  const userId = session?.user?.id;
+  const selectedRepo = teamId
+    ? await getSelectedRepository(userId, teamId)
+    : null;
+
+  if (!selectedRepo) {
+    return (
+      <div className="flex-1 p-6 overflow-auto">
+        <div className="max-w-4xl mx-auto space-y-6">
+          <header>
+            <h1 className="text-2xl font-semibold flex items-center gap-2">
+              <Bot className="h-6 w-6" />
+              QA Agent
+            </h1>
+          </header>
+          <div className="rounded-lg border border-dashed p-10 text-center text-sm text-muted-foreground">
+            Connect and select a repository first — the QA agent builds its
+            suite into a repo.{" "}
+            <Link href="/tests" className="underline">
+              Add a repository
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const activeBranch =
+    selectedRepo.selectedBranch || selectedRepo.defaultBranch || "main";
+
+  const [qaSession, ghAccount, envConfig, aiSettings] = await Promise.all([
+    getLatestAgentSession(selectedRepo.id, "qa").catch(() => null),
+    teamId ? getGithubAccountByTeam(teamId).catch(() => null) : null,
+    getEnvironmentConfig(selectedRepo.id).catch(() => null),
+    getAISettings(selectedRepo.id).catch(() => null),
+  ]);
+
+  const githubConnected = Boolean(
+    ghAccount?.accessToken &&
+    selectedRepo.provider === "github" &&
+    selectedRepo.owner,
+  );
+  const aiConfigured = Boolean(
+    aiSettings?.provider && aiSettings.provider !== "none",
+  );
+  const defaultUrl =
+    selectedRepo.branchBaseUrls?.[activeBranch] ?? envConfig?.baseUrl ?? "";
+
+  // Credentials never reach the client; drop the password from the snapshot.
+  const initialSession = qaSession
+    ? {
+        ...qaSession,
+        metadata: (({ quickstartPassword: _pw, ...rest }) => rest)(
+          qaSession.metadata,
+        ),
+      }
+    : null;
+
+  return (
+    <div className="flex-1 p-6 overflow-auto">
+      <div className="max-w-4xl mx-auto space-y-6">
+        <header className="space-y-1">
+          <h1 className="text-2xl font-semibold flex items-center gap-2">
+            <Bot className="h-6 w-6" />
+            QA Agent
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            An orchestrated agent team — scout, planner, generator, healer —
+            that discovers your app, plans coverage against testing best
+            practices, and builds a complete E2E suite you can watch and steer.
+          </p>
+        </header>
+        <QaAgentClient
+          repositoryId={selectedRepo.id}
+          repositoryName={selectedRepo.fullName ?? selectedRepo.name ?? "repo"}
+          defaultUrl={defaultUrl}
+          githubConnected={githubConnected}
+          aiConfigured={aiConfigured}
+          initialSession={initialSession}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/qa-agent/page.tsx
+++ b/src/app/(app)/qa-agent/page.tsx
@@ -6,6 +6,8 @@ import {
   getRecentAgentSessions,
   getGithubAccountByTeam,
   getAISettings,
+  getDefaultSetupSteps,
+  getStorageStates,
 } from "@/lib/db/queries";
 import { getEnvironmentConfig } from "@/server/actions/environment";
 import { QaAgentClient } from "@/components/qa-agent/qa-agent-client";
@@ -46,14 +48,29 @@ export default async function QaAgentPage() {
   const activeBranch =
     selectedRepo.selectedBranch || selectedRepo.defaultBranch || "main";
 
-  const [qaSession, recentSessions, ghAccount, envConfig, aiSettings] =
-    await Promise.all([
-      getLatestAgentSession(selectedRepo.id, "qa").catch(() => null),
-      getRecentAgentSessions(selectedRepo.id, "qa", 10).catch(() => []),
-      teamId ? getGithubAccountByTeam(teamId).catch(() => null) : null,
-      getEnvironmentConfig(selectedRepo.id).catch(() => null),
-      getAISettings(selectedRepo.id).catch(() => null),
-    ]);
+  const [
+    qaSession,
+    recentSessions,
+    ghAccount,
+    envConfig,
+    aiSettings,
+    hasDefaultSetupSteps,
+    hasLiveStorageState,
+  ] = await Promise.all([
+    getLatestAgentSession(selectedRepo.id, "qa").catch(() => null),
+    getRecentAgentSessions(selectedRepo.id, "qa", 10).catch(() => []),
+    teamId ? getGithubAccountByTeam(teamId).catch(() => null) : null,
+    getEnvironmentConfig(selectedRepo.id).catch(() => null),
+    getAISettings(selectedRepo.id).catch(() => null),
+    getDefaultSetupSteps(selectedRepo.id)
+      .then((steps) => steps.length > 0)
+      .catch(() => false),
+    getStorageStates(selectedRepo.id)
+      .then((rows) =>
+        rows.some((s) => !s.expiresAt || s.expiresAt.getTime() > Date.now()),
+      )
+      .catch(() => false),
+  ]);
 
   // Latest stored plan (any prior full/refresh run) powers the fill-gaps mode.
   const planSource = recentSessions.find((s) => s.metadata.qaPlan);
@@ -75,6 +92,9 @@ export default async function QaAgentPage() {
   );
   const defaultUrl =
     selectedRepo.branchBaseUrls?.[activeBranch] ?? envConfig?.baseUrl ?? "";
+  // The Login step checks setup steps / storage states first — surface that
+  // in the setup form so the user knows creds may be unnecessary.
+  const hasExistingAuthSetup = hasDefaultSetupSteps || hasLiveStorageState;
 
   // Credentials never reach the client; drop the password from the snapshot.
   const initialSession = qaSession
@@ -108,6 +128,7 @@ export default async function QaAgentPage() {
           aiConfigured={aiConfigured}
           hasStoredPlan={Boolean(storedPlan)}
           storedPlanInfo={storedPlanInfo}
+          hasExistingAuthSetup={hasExistingAuthSetup}
           initialSession={initialSession}
         />
       </div>

--- a/src/app/(app)/qa-agent/page.tsx
+++ b/src/app/(app)/qa-agent/page.tsx
@@ -3,6 +3,7 @@ import { getCurrentSession } from "@/lib/auth";
 import {
   getSelectedRepository,
   getLatestAgentSession,
+  getRecentAgentSessions,
   getGithubAccountByTeam,
   getAISettings,
 } from "@/lib/db/queries";
@@ -45,12 +46,24 @@ export default async function QaAgentPage() {
   const activeBranch =
     selectedRepo.selectedBranch || selectedRepo.defaultBranch || "main";
 
-  const [qaSession, ghAccount, envConfig, aiSettings] = await Promise.all([
-    getLatestAgentSession(selectedRepo.id, "qa").catch(() => null),
-    teamId ? getGithubAccountByTeam(teamId).catch(() => null) : null,
-    getEnvironmentConfig(selectedRepo.id).catch(() => null),
-    getAISettings(selectedRepo.id).catch(() => null),
-  ]);
+  const [qaSession, recentSessions, ghAccount, envConfig, aiSettings] =
+    await Promise.all([
+      getLatestAgentSession(selectedRepo.id, "qa").catch(() => null),
+      getRecentAgentSessions(selectedRepo.id, "qa", 10).catch(() => []),
+      teamId ? getGithubAccountByTeam(teamId).catch(() => null) : null,
+      getEnvironmentConfig(selectedRepo.id).catch(() => null),
+      getAISettings(selectedRepo.id).catch(() => null),
+    ]);
+
+  // Latest stored plan (any prior full/refresh run) powers the fill-gaps mode.
+  const planSource = recentSessions.find((s) => s.metadata.qaPlan);
+  const storedPlan = planSource?.metadata.qaPlan;
+  const storedPlanInfo = storedPlan
+    ? `${storedPlan.items.length} items, ${storedPlan.journeys.length} journeys` +
+      (planSource?.createdAt
+        ? ` (from ${new Date(planSource.createdAt).toLocaleDateString()})`
+        : "")
+    : null;
 
   const githubConnected = Boolean(
     ghAccount?.accessToken &&
@@ -93,6 +106,8 @@ export default async function QaAgentPage() {
           defaultUrl={defaultUrl}
           githubConnected={githubConnected}
           aiConfigured={aiConfigured}
+          hasStoredPlan={Boolean(storedPlan)}
+          storedPlanInfo={storedPlanInfo}
           initialSession={initialSession}
         />
       </div>

--- a/src/app/(app)/qa-agent/page.tsx
+++ b/src/app/(app)/qa-agent/page.tsx
@@ -9,6 +9,7 @@ import {
   getDefaultSetupSteps,
   getStorageStates,
   getQaTasksByRepo,
+  getQaAgentTrigger,
 } from "@/lib/db/queries";
 import type { AgentSession } from "@/lib/db/schema";
 import { getEnvironmentConfig } from "@/server/actions/environment";
@@ -74,6 +75,7 @@ export default async function QaAgentPage() {
     qaSession,
     recentSessions,
     qaTasks,
+    qaTriggerConfig,
     ghAccount,
     envConfig,
     aiSettings,
@@ -83,6 +85,9 @@ export default async function QaAgentPage() {
     getLatestAgentSession(selectedRepo.id, "qa").catch(() => null),
     getRecentAgentSessions(selectedRepo.id, "qa", 10).catch(() => []),
     getQaTasksByRepo(selectedRepo.id).catch(() => []),
+    getQaAgentTrigger(selectedRepo.id)
+      .then((t) => t ?? null)
+      .catch(() => null),
     teamId ? getGithubAccountByTeam(teamId).catch(() => null) : null,
     getEnvironmentConfig(selectedRepo.id).catch(() => null),
     getAISettings(selectedRepo.id).catch(() => null),
@@ -154,6 +159,7 @@ export default async function QaAgentPage() {
           initialSession={initialSession}
           recentSessions={sanitizedRecent}
           initialTasks={qaTasks}
+          initialTriggerConfig={qaTriggerConfig}
         />
       </div>
     </div>

--- a/src/app/api/qa-agent/[sessionId]/route.ts
+++ b/src/app/api/qa-agent/[sessionId]/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAgentSession } from "@/lib/db/queries";
+import { getCurrentSession } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> },
+) {
+  const auth = await getCurrentSession();
+  if (!auth?.team) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { sessionId } = await params;
+  const session = await getAgentSession(sessionId);
+
+  if (!session || session.kind !== "qa") {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  if (session.teamId && session.teamId !== auth.team.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Credentials never leave the server — strip before returning.
+  const { quickstartPassword: _pw, ...metadata } = session.metadata;
+  return NextResponse.json(
+    { ...session, metadata },
+    {
+      headers: {
+        "Cache-Control": "no-store, no-cache, must-revalidate",
+      },
+    },
+  );
+}

--- a/src/app/api/v1/[...slug]/route.ts
+++ b/src/app/api/v1/[...slug]/route.ts
@@ -57,6 +57,11 @@
  *   DELETE /api/v1/setup-scripts/:id - Delete a setup script (refuses if still wired into a test)
  *   DELETE /api/v1/tests/:id - Soft-delete a test
  *   DELETE /api/v1/functional-areas/:id - Soft-delete a functional area
+ *   GET  /api/v1/repos/:id/qa-agent - QA agent status (live session, coverage, tasks, triggers)
+ *   POST /api/v1/repos/:id/qa-agent/runs - Start a QA agent run (body: { mode?, targetUrl? }; 409 when busy)
+ *   GET  /api/v1/qa-sessions/:id - QA agent session status (slim, secret-free)
+ *   GET  /api/v1/repos/:id/qa-tasks - List QA agent direction-queue tasks
+ *   POST /api/v1/repos/:id/qa-tasks - Queue a task for the QA agent (body: { title, description? })
  */
 
 import { NextRequest, NextResponse } from "next/server";
@@ -92,6 +97,37 @@ import type { VideoCaption } from "@/lib/db/schema";
 // downstream server actions share the same resolution path.
 async function verifyAuth(_request: NextRequest) {
   return getCurrentSession();
+}
+
+// Slim, secret-free view of a QA agent session for the v1 API. Session
+// metadata carries encrypted-at-rest credentials (quickstartEmail/Password)
+// and bulky discovery blobs — expose only what an external agent needs.
+function slimQaSession(s: import("@/lib/db/schema").AgentSession) {
+  const m = s.metadata;
+  return {
+    id: s.id,
+    status: s.status,
+    mode: m.qaMode ?? "full",
+    trigger: m.qaTrigger ?? "manual",
+    currentStepId: s.currentStepId,
+    targetUrl: m.qaTargetUrl ?? null,
+    taskId: m.qaTaskId ?? null,
+    steps: s.steps.map((st) => ({
+      id: st.id,
+      status: st.status,
+      label: st.label,
+      error: st.error ?? null,
+    })),
+    generatedTests: (m.qaGeneratedTests ?? []).map((t) => ({
+      name: t.name,
+      group: t.group,
+      status: t.status,
+      testId: t.testId ?? null,
+    })),
+    summary: m.qaSummary ?? null,
+    createdAt: s.createdAt,
+    completedAt: s.completedAt,
+  };
 }
 
 // Coerce an untrusted request body into a clean VideoCaption[] (used by the
@@ -731,6 +767,46 @@ export async function GET(
         return NextResponse.json({ routeCoverage, areaCoverage });
       }
 
+      // GET /api/v1/repos/:id/qa-agent — QA agent status for external agents:
+      // live session, latest coverage summary, direction-queue tasks, triggers
+      if (subResource === "qa-agent") {
+        const [live, recent, tasks, trigger] = await Promise.all([
+          queries.getActiveAgentSession(id, "qa"),
+          queries.getRecentAgentSessions(id, "qa", 5),
+          queries.getQaTasksByRepo(id, { terminalLimit: 10 }),
+          queries.getQaAgentTrigger(id),
+        ]);
+        const summarySource = recent.find((s) => s.metadata.qaSummary);
+        return NextResponse.json({
+          liveSession: live ? slimQaSession(live) : null,
+          recentRuns: recent.map(slimQaSession),
+          coverage: summarySource
+            ? {
+                sessionId: summarySource.id,
+                updatedAt: summarySource.completedAt ?? summarySource.createdAt,
+                summary: summarySource.metadata.qaSummary,
+              }
+            : null,
+          tasks,
+          triggers: trigger
+            ? {
+                scheduleEnabled: trigger.scheduleEnabled,
+                cronExpression: trigger.cronExpression,
+                scheduleMode: trigger.scheduleMode,
+                prEnabled: trigger.prEnabled,
+                prMode: trigger.prMode,
+                nextRunAt: trigger.nextRunAt,
+              }
+            : null,
+        });
+      }
+
+      // GET /api/v1/repos/:id/qa-tasks — direction-queue tasks
+      if (subResource === "qa-tasks") {
+        const tasks = await queries.getQaTasksByRepo(id);
+        return NextResponse.json(tasks);
+      }
+
       // GET /api/v1/repos/:id/export — full export for migration
       if (subResource === "export") {
         const areas = await queries.getFunctionalAreasByRepo(id);
@@ -876,6 +952,19 @@ export async function GET(
     }
 
     // Visual diffs
+    // GET /api/v1/qa-sessions/:id — QA agent session status (slim)
+    if (resource === "qa-sessions" && id) {
+      const s = await queries.getAgentSession(id);
+      if (
+        !s ||
+        s.kind !== "qa" ||
+        (s.teamId && s.teamId !== session.team?.id)
+      ) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+      }
+      return NextResponse.json(slimQaSession(s));
+    }
+
     if (resource === "diffs" && id && !subResource) {
       // Verify team ownership via diff → build → test run → repo
       if (!(await verifyDiffOwnership(id, session))) {
@@ -1236,6 +1325,83 @@ export async function POST(
   const { resource, id, subResource } = parseSlug(slug);
 
   try {
+    // Start a QA agent run: POST /api/v1/repos/:id/qa-agent/runs
+    // Body: { mode?, targetUrl? }. 409 when a session is already running.
+    if (
+      resource === "repos" &&
+      id &&
+      subResource === "qa-agent" &&
+      slug[3] === "runs"
+    ) {
+      if (!(await verifyRepoOwnership(id, session))) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+      }
+      const repo = await queries.getRepository(id);
+      if (!repo?.teamId) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+      }
+      const body = await request.json().catch(() => ({}));
+      const mode = body?.mode;
+      if (
+        mode !== undefined &&
+        !["full", "refresh_spec", "fill_gaps"].includes(mode)
+      ) {
+        return NextResponse.json(
+          { error: "mode must be full | refresh_spec | fill_gaps" },
+          { status: 400 },
+        );
+      }
+      const { startQaAgentFromTrigger } =
+        await import("@/server/actions/qa-agent");
+      const result = await startQaAgentFromTrigger({
+        repositoryId: id,
+        teamId: repo.teamId,
+        trigger: "mcp",
+        mode,
+        targetUrl:
+          typeof body?.targetUrl === "string" ? body.targetUrl : undefined,
+        reason: `via API by ${session.user.name || session.user.email}`,
+      });
+      if (result.sessionId) {
+        return NextResponse.json(
+          { sessionId: result.sessionId },
+          { status: 201 },
+        );
+      }
+      const busy = result.skipped?.includes("already running");
+      return NextResponse.json(
+        { error: result.skipped ?? "Could not start" },
+        { status: busy ? 409 : 400 },
+      );
+    }
+
+    // Queue a QA agent task: POST /api/v1/repos/:id/qa-tasks
+    // Body: { title, description? } — files with source "mcp" so the board
+    // shows the external-agent actor chip.
+    if (resource === "repos" && id && subResource === "qa-tasks" && !slug[3]) {
+      if (!(await verifyRepoOwnership(id, session))) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+      }
+      const body = await request.json().catch(() => ({}));
+      if (
+        !body?.title ||
+        typeof body.title !== "string" ||
+        !body.title.trim()
+      ) {
+        return NextResponse.json({ error: "title required" }, { status: 400 });
+      }
+      const { addQaTask } = await import("@/server/actions/qa-agent");
+      const { taskId } = await addQaTask({
+        repositoryId: id,
+        title: body.title,
+        description:
+          typeof body.description === "string" ? body.description : undefined,
+        source: "mcp",
+      });
+      const task = await queries.getQaTask(taskId);
+      return NextResponse.json(task, { status: 201 });
+    }
+
     // Create storage state: POST /api/v1/repos/:id/storage-states
     // Body: { name, storageStateJson }
     if (resource === "repos" && id && subResource === "storage-states") {

--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -98,6 +98,27 @@ export async function POST(request: NextRequest) {
         // Trigger build for PR
         await createAndRunBuild("webhook", undefined, repositoryId);
 
+        // Optionally kick the QA agent (per-repo qa_agent_triggers config).
+        // Never blocks the webhook response — the agent run is fire-and-forget
+        // and skips itself when a session is already running.
+        if (repositoryId) {
+          void (async () => {
+            const trigger = await queries.getQaAgentTrigger(repositoryId);
+            if (!trigger?.prEnabled) return;
+            const { startQaAgentFromTrigger } =
+              await import("@/server/actions/qa-agent");
+            await startQaAgentFromTrigger({
+              repositoryId,
+              teamId: trigger.teamId,
+              trigger: "pr",
+              mode: trigger.prMode,
+              reason: `PR #${data.pull_request.number} ${data.action}`,
+            });
+          })().catch((error) =>
+            console.error("[webhook] QA agent PR trigger failed:", error),
+          );
+        }
+
         return NextResponse.json({ message: "Build triggered for PR" });
       }
 

--- a/src/app/oauth/authorize/route.ts
+++ b/src/app/oauth/authorize/route.ts
@@ -21,7 +21,7 @@ import * as queries from "@/lib/db/queries";
 import {
   isValidClientId,
   isAllowedRedirectUri,
-  LAUNCH_SCOPE,
+  scopeForClient,
 } from "@/lib/launch/oauth-config";
 import { DEFAULT_LAUNCH } from "@/lib/db/schema";
 
@@ -32,13 +32,14 @@ export async function GET(request: NextRequest) {
   const clientId = sp.get("client_id");
   const redirectUri = sp.get("redirect_uri");
   const responseType = sp.get("response_type") ?? "token";
-  const requestedScope = sp.get("scope") ?? LAUNCH_SCOPE;
   const state = sp.get("state") ?? "";
 
   // Hard failures (never redirect to an un-allowed URI — that's the token-leak guard).
   if (!isValidClientId(clientId)) {
     return NextResponse.json({ error: "invalid_client" }, { status: 400 });
   }
+  const clientScope = scopeForClient(clientId)!;
+  const requestedScope = sp.get("scope") ?? clientScope;
   if (!isAllowedRedirectUri(redirectUri)) {
     return NextResponse.json(
       { error: "invalid_redirect_uri" },
@@ -62,13 +63,13 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(loginUrl);
   }
 
-  // Grant only scopes we support (intersect requested with LAUNCH_SCOPE).
-  const supported = LAUNCH_SCOPE.split(" ");
+  // Grant only scopes the client is registered for (intersect requested).
+  const supported = clientScope.split(" ");
   const granted =
     requestedScope
       .split(/\s+/)
       .filter((s) => supported.includes(s))
-      .join(" ") || LAUNCH_SCOPE;
+      .join(" ") || clientScope;
 
   const token = randomBytes(32).toString("base64url");
   const ttl = DEFAULT_LAUNCH.tokenTtlSeconds;

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -19,6 +19,7 @@ import {
   GitCommit,
   Wrench,
   Bot,
+  Lock,
 } from "lucide-react";
 import Image from "next/image";
 import {
@@ -31,6 +32,7 @@ import { ActivityFeedIndicator } from "@/components/activity-feed/activity-feed-
 import { UserMenu } from "@/components/auth/user-menu";
 import { InlineScore } from "@/components/gamification/user-score-chip";
 import { SidebarQuickActions } from "./sidebar-quick-actions";
+import { hasQaAgentAccess } from "@/lib/billing/feature-access";
 import type { Repository, User, Team, EmbeddedSession } from "@/lib/db/schema";
 
 interface SidebarProps {
@@ -112,6 +114,9 @@ export function Sidebar({
   const earlyAdopter = team?.earlyAdopterMode ?? false;
   const gamificationEnabled = team?.gamificationEnabled ?? false;
   const verifyPhaseEnabled = team?.verifyPhaseEnabled ?? false;
+  // QA Agent is a Pro-tier feature — surface a lock on the nav item so the
+  // gated destination doesn't look identical to unlocked pages.
+  const qaAgentLocked = team ? !hasQaAgentAccess(team.plan) : false;
 
   const filteredDefinitionNav = earlyAdopter
     ? definitionNav
@@ -256,6 +261,7 @@ export function Sidebar({
               const isActive =
                 pathname === item.href || pathname.startsWith(item.href);
               const isVerify = item.name === "Verify";
+              const isLockedQaAgent = item.name === "QA Agent" && qaAgentLocked;
               return (
                 <li key={item.name}>
                   <Link
@@ -269,6 +275,21 @@ export function Sidebar({
                   >
                     <item.icon className="h-4 w-4" />
                     <span className="flex-1">{item.name}</span>
+                    {isLockedQaAgent && (
+                      <span
+                        className={cn(
+                          "inline-flex items-center gap-1 rounded-full px-1.5 h-[18px] text-[10px] font-semibold leading-none ring-1",
+                          isActive
+                            ? "bg-white/20 text-primary-foreground ring-white/30"
+                            : "bg-primary/10 text-primary ring-primary/20",
+                        )}
+                        aria-label="Pro feature"
+                        title="QA Agent is available on the Pro plan"
+                      >
+                        <Lock className="h-2.5 w-2.5" />
+                        Pro
+                      </span>
+                    )}
                     {isVerify && verifyPendingCount > 0 && (
                       <span
                         className={cn(

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -18,6 +18,7 @@ import {
   ShieldCheck,
   GitCommit,
   Wrench,
+  Bot,
 } from "lucide-react";
 import Image from "next/image";
 import {
@@ -75,6 +76,7 @@ const definitionNav = [
 
 const executionNav = [
   { name: "Runs", href: "/run", icon: Play },
+  { name: "QA Agent", href: "/qa-agent", icon: Bot },
   { name: "Compare", href: "/compare", icon: GitCompare },
   { name: "URL Diff", href: "/url-diff", icon: SplitSquareHorizontal },
   { name: "Impact", href: "/analytics/impact", icon: TrendingDown },

--- a/src/components/qa-agent/qa-agent-client.tsx
+++ b/src/components/qa-agent/qa-agent-client.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import type {
   ActivitySourceType,
   AgentSession,
+  QaAgentTrigger,
   QaRunMode,
   QaTask,
   QaTestGroup,
@@ -22,6 +23,11 @@ import type { CoverageRequestHint } from "./qa-results-panel";
 import { BrowserViewer } from "@/components/embedded-browser/browser-viewer-client";
 import { QaTaskBoard } from "./qa-task-board";
 import { QaRunHistory } from "./qa-run-history";
+import {
+  QaTriggerConfig,
+  describeTriggers,
+  triggerStateFrom,
+} from "./qa-trigger-config";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -483,6 +489,7 @@ export function QaAgentClient({
   initialSession,
   recentSessions,
   initialTasks,
+  initialTriggerConfig,
 }: {
   repositoryId: string;
   repositoryName: string;
@@ -500,6 +507,8 @@ export function QaAgentClient({
   recentSessions: AgentSession[];
   /** Direction-queue snapshot for the task board. */
   initialTasks: QaTask[];
+  /** Automation config (cron/PR triggers), null when never configured. */
+  initialTriggerConfig: QaAgentTrigger | null;
 }) {
   const {
     session,
@@ -538,6 +547,9 @@ export function QaAgentClient({
   }, []);
 
   const [setupOpen, setSetupOpen] = useState(false);
+  const [triggerState, setTriggerState] = useState(() =>
+    triggerStateFrom(initialTriggerConfig),
+  );
 
   // A dispatcher-started task run isn't in this tab's polling loop yet —
   // attach as soon as the board reports its session id.
@@ -644,6 +656,7 @@ export function QaAgentClient({
         loading={loading}
         setupOpen={showSetup}
         canStartRun={!neverRan}
+        triggerSummary={describeTriggers(triggerState)}
         onToggleSetup={() => setSetupOpen((v) => !v)}
         onPause={pause}
         onResume={resume}
@@ -749,6 +762,14 @@ export function QaAgentClient({
         onAdd={addTask}
         onRetry={retryTask}
         onDrop={dropTask}
+      />
+
+      {/* Automation triggers (cron + PR) */}
+      <QaTriggerConfig
+        repositoryId={repositoryId}
+        githubConnected={githubConnected}
+        state={triggerState}
+        onSaved={setTriggerState}
       />
 
       <QaRunHistory

--- a/src/components/qa-agent/qa-agent-client.tsx
+++ b/src/components/qa-agent/qa-agent-client.tsx
@@ -183,6 +183,9 @@ function PhaseTimeline({ session }: { session: AgentSession }) {
                       : "text-muted-foreground"
                   }`}
                 >
+                  {step.id === "qa_login" && (
+                    <Lock className="inline h-3 w-3 mr-0.5 align-[-1px]" />
+                  )}
                   {step.label}
                 </span>
               </div>
@@ -276,6 +279,7 @@ function SetupCard({
   aiConfigured,
   hasStoredPlan,
   storedPlanInfo,
+  hasExistingAuthSetup,
   loading,
   error,
   onStart,
@@ -285,6 +289,7 @@ function SetupCard({
   aiConfigured: boolean;
   hasStoredPlan: boolean;
   storedPlanInfo: string | null;
+  hasExistingAuthSetup: boolean;
   loading: boolean;
   error: string | null;
   onStart: (opts: {
@@ -294,6 +299,7 @@ function SetupCard({
     email?: string;
     password?: string;
     autoApprove?: boolean;
+    allowRegistration?: boolean;
   }) => void;
 }) {
   const [targetUrl, setTargetUrl] = useState(defaultUrl);
@@ -301,6 +307,7 @@ function SetupCard({
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [autoApprove, setAutoApprove] = useState(false);
+  const [allowRegistration, setAllowRegistration] = useState(true);
   const [groups, setGroups] = useState<Set<QaTestGroup>>(
     () => new Set(QA_GROUPS.map((g) => g.id)),
   );
@@ -447,9 +454,35 @@ function SetupCard({
           </div>
         </div>
         <p className="text-xs text-muted-foreground -mt-3">
-          Credentials are encrypted at rest and let the agent plan and verify
-          authenticated journeys. Without them it covers the public surface.
+          Credentials are encrypted at rest. The Login step verifies them live,
+          captures the session, and runs discovery on the post-login state — any
+          existing setup script or storage state is checked first.
         </p>
+        {hasExistingAuthSetup && (
+          <Badge
+            variant="outline"
+            className="bg-success/10 text-success border-success/30"
+          >
+            <Lock className="h-3 w-3" />
+            Existing login setup detected — the agent will reuse it
+          </Badge>
+        )}
+
+        <div className="flex items-center justify-between rounded-md border p-3">
+          <div>
+            <div className="text-sm font-medium">
+              Allow the agent to register a test account
+            </div>
+            <div className="text-xs text-muted-foreground">
+              Used only when no credentials or working setup exist and a sign-up
+              page is discovered — creates a throwaway account on the target app
+            </div>
+          </div>
+          <Switch
+            checked={allowRegistration}
+            onCheckedChange={setAllowRegistration}
+          />
+        </div>
 
         {mode !== "fill_gaps" && (
           <div className="space-y-1.5">
@@ -519,6 +552,7 @@ function SetupCard({
               email: email.trim() || undefined,
               password: password || undefined,
               autoApprove,
+              allowRegistration,
             })
           }
         >
@@ -546,6 +580,7 @@ export function QaAgentClient({
   aiConfigured,
   hasStoredPlan,
   storedPlanInfo,
+  hasExistingAuthSetup,
   initialSession,
 }: {
   repositoryId: string;
@@ -556,6 +591,9 @@ export function QaAgentClient({
   /** A prior run stored a plan — enables the "fill coverage gaps" mode. */
   hasStoredPlan: boolean;
   storedPlanInfo: string | null;
+  /** Repo already has default setup steps or a storage state — the Login
+   *  step will check/reuse them. */
+  hasExistingAuthSetup: boolean;
   initialSession: AgentSession | null;
 }) {
   const {
@@ -594,6 +632,7 @@ export function QaAgentClient({
         aiConfigured={aiConfigured}
         hasStoredPlan={hasStoredPlan}
         storedPlanInfo={storedPlanInfo}
+        hasExistingAuthSetup={hasExistingAuthSetup}
         loading={loading}
         error={error}
         onStart={start}

--- a/src/components/qa-agent/qa-agent-client.tsx
+++ b/src/components/qa-agent/qa-agent-client.tsx
@@ -860,6 +860,7 @@ export function QaAgentClient({
         <QaPlanReview
           key={awaitingReview ? "review" : "readonly"}
           plan={plan}
+          discovery={session?.metadata.qaDiscovery}
           readOnly={!awaitingReview}
           loading={loading}
           onApprove={approve}

--- a/src/components/qa-agent/qa-agent-client.tsx
+++ b/src/components/qa-agent/qa-agent-client.tsx
@@ -28,6 +28,7 @@ import {
   CheckCircle2,
   Circle,
   CircleDashed,
+  FileText,
   Github,
   Loader2,
   Lock,
@@ -39,6 +40,7 @@ import {
   RotateCcw,
   SkipForward,
   UserRound,
+  X,
   XCircle,
 } from "lucide-react";
 
@@ -300,6 +302,7 @@ function SetupCard({
     password?: string;
     autoApprove?: boolean;
     allowRegistration?: boolean;
+    docs?: Array<{ name: string; contentBase64: string }>;
   }) => void;
 }) {
   const [targetUrl, setTargetUrl] = useState(defaultUrl);
@@ -308,9 +311,40 @@ function SetupCard({
   const [password, setPassword] = useState("");
   const [autoApprove, setAutoApprove] = useState(false);
   const [allowRegistration, setAllowRegistration] = useState(true);
+  const [docs, setDocs] = useState<File[]>([]);
   const [groups, setGroups] = useState<Set<QaTestGroup>>(
     () => new Set(QA_GROUPS.map((g) => g.id)),
   );
+
+  const addDocs = (files: FileList | null) => {
+    if (!files) return;
+    setDocs((prev) => {
+      const next = [...prev];
+      for (const file of Array.from(files)) {
+        if (file.size > 10 * 1024 * 1024) continue;
+        if (next.some((f) => f.name === file.name)) continue;
+        next.push(file);
+      }
+      return next.slice(0, 5);
+    });
+  };
+
+  const encodeDocs = async (): Promise<
+    Array<{ name: string; contentBase64: string }>
+  > => {
+    const encoded: Array<{ name: string; contentBase64: string }> = [];
+    for (const file of docs) {
+      const buffer = await file.arrayBuffer();
+      const bytes = new Uint8Array(buffer);
+      let binary = "";
+      const CHUNK = 0x8000;
+      for (let i = 0; i < bytes.length; i += CHUNK) {
+        binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+      }
+      encoded.push({ name: file.name, contentBase64: btoa(binary) });
+    }
+    return encoded;
+  };
 
   const toggleGroup = (id: QaTestGroup) => {
     setGroups((prev) => {
@@ -486,6 +520,58 @@ function SetupCard({
 
         {mode !== "fill_gaps" && (
           <div className="space-y-1.5">
+            <Label htmlFor="qa-docs" className="flex items-center gap-1.5">
+              <FileText className="h-3 w-3" />
+              Product documentation{" "}
+              <span className="text-muted-foreground">(optional)</span>
+            </Label>
+            <Input
+              id="qa-docs"
+              type="file"
+              multiple
+              accept=".md,.txt,.pdf,.docx"
+              onChange={(e) => {
+                addDocs(e.target.files);
+                e.target.value = "";
+              }}
+            />
+            {docs.length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {docs.map((file) => (
+                  <Badge
+                    key={file.name}
+                    variant="outline"
+                    className="gap-1 text-xs font-normal"
+                  >
+                    <FileText className="h-3 w-3" />
+                    {file.name}
+                    <button
+                      type="button"
+                      className="ml-0.5 text-muted-foreground hover:text-foreground"
+                      onClick={() =>
+                        setDocs((prev) =>
+                          prev.filter((f) => f.name !== file.name),
+                        )
+                      }
+                      aria-label={`Remove ${file.name}`}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </Badge>
+                ))}
+              </div>
+            )}
+            <p className="text-xs text-muted-foreground">
+              Requirements, specs, or manuals (.md/.txt/.pdf/.docx, up to 5
+              files). The planner treats them as authoritative for intended
+              behavior — including flows the crawl can&apos;t reach. Only a
+              condensed digest is stored.
+            </p>
+          </div>
+        )}
+
+        {mode !== "fill_gaps" && (
+          <div className="space-y-1.5">
             <Label>Coverage groups</Label>
             <div className="grid sm:grid-cols-2 gap-1.5">
               {QA_GROUPS.map((group) => (
@@ -544,7 +630,7 @@ function SetupCard({
 
         <Button
           disabled={!canStart}
-          onClick={() =>
+          onClick={async () =>
             onStart({
               targetUrl: targetUrl.trim(),
               mode,
@@ -553,6 +639,10 @@ function SetupCard({
               password: password || undefined,
               autoApprove,
               allowRegistration,
+              docs:
+                mode !== "fill_gaps" && docs.length > 0
+                  ? await encodeDocs()
+                  : undefined,
             })
           }
         >
@@ -674,6 +764,8 @@ export function QaAgentClient({
               </div>
               <div className="text-xs opacity-80 truncate">
                 {repositoryName} → {session.metadata.qaTargetUrl}
+                {(session.metadata.qaDocs?.length ?? 0) > 0 &&
+                  ` · ${session.metadata.qaDocs!.length} doc${session.metadata.qaDocs!.length === 1 ? "" : "s"} provided`}
               </div>
             </div>
             <div className="flex items-center gap-2">

--- a/src/components/qa-agent/qa-agent-client.tsx
+++ b/src/components/qa-agent/qa-agent-client.tsx
@@ -607,6 +607,7 @@ export function QaAgentClient({
     start,
     approve,
     requestChanges,
+    addJourneys,
     pause,
     resume,
     cancel,
@@ -771,6 +772,7 @@ export function QaAgentClient({
           loading={loading}
           onApprove={approve}
           onRequestChanges={requestChanges}
+          onAddJourneys={addJourneys}
         />
       )}
 

--- a/src/components/qa-agent/qa-agent-client.tsx
+++ b/src/components/qa-agent/qa-agent-client.tsx
@@ -205,6 +205,26 @@ function PhaseTimeline({ session }: { session: AgentSession }) {
                 {activeStep.error}
               </div>
             )}
+            {activeStep.result?.manual === true && (
+              <div className="mt-2 space-y-2 rounded-md border border-warning/40 bg-warning/5 p-2">
+                <div className="text-xs font-medium">Proceed manually</div>
+                {typeof activeStep.result.manualHint === "string" && (
+                  <p className="text-xs text-muted-foreground">
+                    {activeStep.result.manualHint}
+                  </p>
+                )}
+                {typeof activeStep.result.rawOutput === "string" && (
+                  <div className="space-y-1">
+                    <div className="text-[11px] font-medium text-muted-foreground">
+                      Raw planner output
+                    </div>
+                    <pre className="max-h-64 overflow-auto rounded bg-muted/50 p-2 text-[11px] leading-snug whitespace-pre-wrap break-words">
+                      {activeStep.result.rawOutput}
+                    </pre>
+                  </div>
+                )}
+              </div>
+            )}
             {(activeStep.substeps?.length ?? 0) > 0 && (
               <div className="max-h-56 overflow-y-auto">
                 {activeStep.substeps!.map((substep, i) => (

--- a/src/components/qa-agent/qa-agent-client.tsx
+++ b/src/components/qa-agent/qa-agent-client.tsx
@@ -1,0 +1,617 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import type {
+  AgentSession,
+  AgentStepState,
+  QaTestGroup,
+} from "@/lib/db/schema";
+import { QA_GROUPS } from "@/lib/qa-agent/plan";
+import { useQaAgent } from "./use-qa-agent";
+import { QaPlanReview } from "./qa-plan-review";
+import { QaGeneratedTestsPanel, QaSummaryPanel } from "./qa-results-panel";
+import { BrowserViewer } from "@/components/embedded-browser/browser-viewer-client";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Progress } from "@/components/ui/progress";
+import { Switch } from "@/components/ui/switch";
+import {
+  AlertTriangle,
+  Ban,
+  Bot,
+  CheckCircle2,
+  Circle,
+  CircleDashed,
+  Github,
+  Loader2,
+  Lock,
+  MonitorPlay,
+  Pause,
+  Play,
+  RotateCcw,
+  SkipForward,
+  UserRound,
+  XCircle,
+} from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Status hero
+// ---------------------------------------------------------------------------
+
+const SESSION_STATUS_META: Record<
+  AgentSession["status"],
+  { label: string; className: string; spin?: boolean; icon: typeof Bot }
+> = {
+  active: {
+    label: "Running",
+    className: "bg-info/10 border-info/30 text-info",
+    spin: true,
+    icon: Loader2,
+  },
+  paused: {
+    label: "Waiting for you",
+    className: "bg-warning/10 border-warning/30 text-warning",
+    icon: UserRound,
+  },
+  completed: {
+    label: "Completed",
+    className: "bg-success/10 border-success/30 text-success",
+    icon: CheckCircle2,
+  },
+  failed: {
+    label: "Failed",
+    className: "bg-destructive/10 border-destructive/30 text-destructive",
+    icon: XCircle,
+  },
+  cancelled: {
+    label: "Cancelled",
+    className: "bg-muted border-border text-muted-foreground",
+    icon: Ban,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Phase timeline
+// ---------------------------------------------------------------------------
+
+function StepDot({ step }: { step: AgentStepState }) {
+  switch (step.status) {
+    case "completed":
+      return <CheckCircle2 className="h-4 w-4 text-success" />;
+    case "active":
+      return <Loader2 className="h-4 w-4 text-info animate-spin" />;
+    case "waiting_user":
+      return <UserRound className="h-4 w-4 text-warning" />;
+    case "failed":
+      return <XCircle className="h-4 w-4 text-destructive" />;
+    case "skipped":
+      return <SkipForward className="h-4 w-4 text-muted-foreground" />;
+    default:
+      return <Circle className="h-4 w-4 text-muted-foreground/40" />;
+  }
+}
+
+const AGENT_BADGE_STYLES: Record<string, string> = {
+  orchestrator: "bg-primary/10 text-primary border-primary/30",
+  planner: "bg-info/10 text-info border-info/30",
+  scout: "bg-success/10 text-success border-success/30",
+  ranger: "bg-success/10 text-success border-success/30",
+  generator: "bg-warning/10 text-warning border-warning/30",
+  healer: "bg-destructive/10 text-destructive border-destructive/30",
+};
+
+function SubstepRow({
+  substep,
+}: {
+  substep: NonNullable<AgentStepState["substeps"]>[number];
+}) {
+  return (
+    <div className="flex items-start gap-2 text-sm py-0.5">
+      <span className="mt-0.5 shrink-0">
+        {substep.status === "running" ? (
+          <Loader2 className="h-3.5 w-3.5 text-info animate-spin" />
+        ) : substep.status === "done" ? (
+          <CheckCircle2 className="h-3.5 w-3.5 text-success" />
+        ) : substep.status === "error" ? (
+          <XCircle className="h-3.5 w-3.5 text-destructive" />
+        ) : (
+          <CircleDashed className="h-3.5 w-3.5 text-muted-foreground/50" />
+        )}
+      </span>
+      {substep.agent && (
+        <Badge
+          variant="outline"
+          className={`text-[10px] px-1.5 shrink-0 ${AGENT_BADGE_STYLES[substep.agent] ?? ""}`}
+        >
+          {substep.agent}
+        </Badge>
+      )}
+      <span className="min-w-0">
+        <span className="truncate">{substep.label}</span>
+        {substep.detail && (
+          <span className="block text-xs text-muted-foreground truncate">
+            {substep.detail}
+          </span>
+        )}
+      </span>
+      {substep.durationMs !== undefined && (
+        <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+          {(substep.durationMs / 1000).toFixed(1)}s
+        </span>
+      )}
+    </div>
+  );
+}
+
+function PhaseTimeline({ session }: { session: AgentSession }) {
+  const activeStep = session.steps.find(
+    (s) =>
+      s.status === "active" ||
+      s.status === "waiting_user" ||
+      s.status === "failed",
+  );
+  return (
+    <Card>
+      <CardContent className="pt-4 space-y-4">
+        <div className="flex items-start gap-0 overflow-x-auto pb-1">
+          {session.steps.map((step, i) => (
+            <div key={step.id} className="flex items-start min-w-0">
+              {i > 0 && (
+                <div
+                  className={`h-px w-5 sm:w-8 mt-2 shrink-0 ${
+                    step.status === "pending" ? "bg-border" : "bg-success/50"
+                  }`}
+                />
+              )}
+              <div
+                className="flex flex-col items-center gap-1 px-1 min-w-14"
+                title={step.description}
+              >
+                <StepDot step={step} />
+                <span
+                  className={`text-[11px] leading-tight text-center ${
+                    step.status === "active" || step.status === "waiting_user"
+                      ? "text-foreground font-medium"
+                      : "text-muted-foreground"
+                  }`}
+                >
+                  {step.label}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {activeStep && (
+          <div className="rounded-md border bg-muted/30 p-3 space-y-1">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              <StepDot step={activeStep} />
+              {activeStep.label}
+              <span className="font-normal text-muted-foreground text-xs">
+                {activeStep.description}
+              </span>
+            </div>
+            {activeStep.error && (
+              <div className="flex items-start gap-1.5 text-sm text-destructive">
+                <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                {activeStep.error}
+              </div>
+            )}
+            {(activeStep.substeps?.length ?? 0) > 0 && (
+              <div className="max-h-56 overflow-y-auto">
+                {activeStep.substeps!.map((substep, i) => (
+                  <SubstepRow key={`${substep.label}-${i}`} substep={substep} />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Setup form
+// ---------------------------------------------------------------------------
+
+function SetupCard({
+  defaultUrl,
+  githubConnected,
+  aiConfigured,
+  loading,
+  error,
+  onStart,
+}: {
+  defaultUrl: string;
+  githubConnected: boolean;
+  aiConfigured: boolean;
+  loading: boolean;
+  error: string | null;
+  onStart: (opts: {
+    targetUrl: string;
+    groups: QaTestGroup[];
+    email?: string;
+    password?: string;
+    autoApprove?: boolean;
+  }) => void;
+}) {
+  const [targetUrl, setTargetUrl] = useState(defaultUrl);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [autoApprove, setAutoApprove] = useState(false);
+  const [groups, setGroups] = useState<Set<QaTestGroup>>(
+    () => new Set(QA_GROUPS.map((g) => g.id)),
+  );
+
+  const toggleGroup = (id: QaTestGroup) => {
+    setGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      next.add("journey");
+      return next;
+    });
+  };
+
+  const canStart =
+    aiConfigured && /^https?:\/\/.+/i.test(targetUrl.trim()) && !loading;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Bot className="h-4 w-4" />
+          Build a comprehensive test suite
+        </CardTitle>
+        <p className="text-sm text-muted-foreground">
+          The QA agent discovers your app (source routes + live DOM), designs a
+          risk-prioritized plan across the selected coverage groups, waits for
+          your approval, then generates, runs, and heals the suite.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <div className="flex flex-wrap gap-2">
+          <Badge
+            variant="outline"
+            className={
+              githubConnected
+                ? "bg-success/10 text-success border-success/30"
+                : "bg-muted text-muted-foreground"
+            }
+          >
+            <Github className="h-3 w-3" />
+            {githubConnected
+              ? "GitHub connected — repo-aware discovery"
+              : "GitHub not connected — live discovery only"}
+          </Badge>
+          {!aiConfigured && (
+            <Badge
+              variant="outline"
+              className="bg-destructive/10 text-destructive border-destructive/30"
+            >
+              <AlertTriangle className="h-3 w-3" />
+              No AI provider —{" "}
+              <Link href="/settings" className="underline">
+                configure in Settings
+              </Link>
+            </Badge>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="qa-url">Target app URL</Label>
+          <Input
+            id="qa-url"
+            placeholder="https://your-app.example.com"
+            value={targetUrl}
+            onChange={(e) => setTargetUrl(e.target.value)}
+          />
+        </div>
+
+        <div className="grid sm:grid-cols-2 gap-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="qa-email" className="flex items-center gap-1.5">
+              <Lock className="h-3 w-3" />
+              Login email{" "}
+              <span className="text-muted-foreground">(optional)</span>
+            </Label>
+            <Input
+              id="qa-email"
+              type="email"
+              autoComplete="off"
+              placeholder="qa@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="qa-password">
+              Password <span className="text-muted-foreground">(optional)</span>
+            </Label>
+            <Input
+              id="qa-password"
+              type="password"
+              autoComplete="new-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </div>
+        </div>
+        <p className="text-xs text-muted-foreground -mt-3">
+          Credentials are encrypted at rest and let the agent plan and verify
+          authenticated journeys. Without them it covers the public surface.
+        </p>
+
+        <div className="space-y-1.5">
+          <Label>Coverage groups</Label>
+          <div className="grid sm:grid-cols-2 gap-1.5">
+            {QA_GROUPS.map((group) => (
+              <label
+                key={group.id}
+                className={`flex items-start gap-2 rounded-md border p-2 text-sm ${
+                  group.locked
+                    ? "opacity-90"
+                    : "cursor-pointer hover:bg-muted/50"
+                }`}
+              >
+                <Checkbox
+                  checked={groups.has(group.id)}
+                  disabled={group.locked}
+                  onCheckedChange={() => toggleGroup(group.id)}
+                  className="mt-0.5"
+                />
+                <span>
+                  <span className="font-medium">
+                    {group.label}
+                    {group.locked && (
+                      <span className="text-xs text-muted-foreground font-normal">
+                        {" "}
+                        (always on)
+                      </span>
+                    )}
+                  </span>
+                  <span className="block text-xs text-muted-foreground">
+                    {group.description}
+                  </span>
+                </span>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between rounded-md border p-3">
+          <div>
+            <div className="text-sm font-medium">Auto-approve plan</div>
+            <div className="text-xs text-muted-foreground">
+              Skip the human review gate and generate immediately
+            </div>
+          </div>
+          <Switch checked={autoApprove} onCheckedChange={setAutoApprove} />
+        </div>
+
+        {error && (
+          <div className="flex items-start gap-1.5 text-sm text-destructive">
+            <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+            {error}
+          </div>
+        )}
+
+        <Button
+          disabled={!canStart}
+          onClick={() =>
+            onStart({
+              targetUrl: targetUrl.trim(),
+              groups: [...groups],
+              email: email.trim() || undefined,
+              password: password || undefined,
+              autoApprove,
+            })
+          }
+        >
+          {loading ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Play className="h-4 w-4" />
+          )}
+          Start QA agent
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main client
+// ---------------------------------------------------------------------------
+
+export function QaAgentClient({
+  repositoryId,
+  repositoryName,
+  defaultUrl,
+  githubConnected,
+  aiConfigured,
+  initialSession,
+}: {
+  repositoryId: string;
+  repositoryName: string;
+  defaultUrl: string;
+  githubConnected: boolean;
+  aiConfigured: boolean;
+  initialSession: AgentSession | null;
+}) {
+  const {
+    session,
+    loading,
+    error,
+    isRunning,
+    isPaused,
+    isTerminal,
+    progress,
+    start,
+    approve,
+    requestChanges,
+    pause,
+    resume,
+    cancel,
+    dismiss,
+  } = useQaAgent(repositoryId, initialSession);
+
+  const reviewStep = session?.steps.find((s) => s.id === "qa_plan_review");
+  const awaitingReview = reviewStep?.status === "waiting_user";
+  const plan = session?.metadata.qaPlan;
+  const generated = useMemo(
+    () => session?.metadata.qaGeneratedTests ?? [],
+    [session?.metadata.qaGeneratedTests],
+  );
+  const summary = session?.metadata.qaSummary;
+  const streamUrl = session?.metadata.streamUrl;
+  const queuedForBrowser = session?.metadata.queuedForBrowser;
+
+  if (!session) {
+    return (
+      <SetupCard
+        defaultUrl={defaultUrl}
+        githubConnected={githubConnected}
+        aiConfigured={aiConfigured}
+        loading={loading}
+        error={error}
+        onStart={start}
+      />
+    );
+  }
+
+  const statusMeta = SESSION_STATUS_META[session.status];
+  const StatusIcon = statusMeta.icon;
+  const planStepDone = session.steps.some(
+    (s) => s.id === "qa_plan" && s.status === "completed",
+  );
+
+  return (
+    <div className="space-y-4">
+      {/* Status hero + controls */}
+      <Card className={`border ${statusMeta.className}`}>
+        <CardContent className="pt-4">
+          <div className="flex flex-wrap items-center gap-3">
+            <StatusIcon
+              className={`h-5 w-5 ${statusMeta.spin ? "animate-spin" : ""}`}
+            />
+            <div className="min-w-0 flex-1">
+              <div className="font-medium">
+                QA agent — {statusMeta.label}
+                {awaitingReview && ": review the plan below"}
+              </div>
+              <div className="text-xs opacity-80 truncate">
+                {repositoryName} → {session.metadata.qaTargetUrl}
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              {isRunning && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={pause}
+                  disabled={loading}
+                >
+                  <Pause className="h-3.5 w-3.5" />
+                  Pause
+                </Button>
+              )}
+              {isPaused && !awaitingReview && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={resume}
+                  disabled={loading}
+                >
+                  <Play className="h-3.5 w-3.5" />
+                  Resume
+                </Button>
+              )}
+              {(isRunning || isPaused) && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={cancel}
+                  disabled={loading}
+                >
+                  <Ban className="h-3.5 w-3.5" />
+                  Cancel
+                </Button>
+              )}
+              {isTerminal && (
+                <Button size="sm" variant="outline" onClick={dismiss}>
+                  <RotateCcw className="h-3.5 w-3.5" />
+                  New run
+                </Button>
+              )}
+            </div>
+          </div>
+          <Progress value={progress} className="mt-3 h-1.5" />
+        </CardContent>
+      </Card>
+
+      {error && (
+        <div className="flex items-start gap-1.5 text-sm text-destructive">
+          <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+          {error}
+        </div>
+      )}
+
+      <PhaseTimeline session={session} />
+
+      {/* Live browser while an agent holds an EB */}
+      {(streamUrl || queuedForBrowser) && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <MonitorPlay className="h-4 w-4" />
+              Live browser
+              <span className="text-xs font-normal text-muted-foreground">
+                {queuedForBrowser
+                  ? "waiting for a browser from the pool…"
+                  : "watching the agent work"}
+              </span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {streamUrl ? (
+              <BrowserViewer
+                streamUrl={streamUrl}
+                interactive={false}
+                hideToolbar
+                className="rounded-md overflow-hidden border"
+              />
+            ) : (
+              <div className="flex items-center justify-center h-40 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                Waiting for an embedded browser…
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Plan: interactive at the review gate, read-only afterwards */}
+      {plan && (awaitingReview || planStepDone) && (
+        <QaPlanReview
+          key={awaitingReview ? "review" : "readonly"}
+          plan={plan}
+          readOnly={!awaitingReview}
+          loading={loading}
+          onApprove={approve}
+          onRequestChanges={requestChanges}
+        />
+      )}
+
+      {generated.length > 0 && <QaGeneratedTestsPanel generated={generated} />}
+
+      {summary && <QaSummaryPanel summary={summary} plan={plan} />}
+    </div>
+  );
+}

--- a/src/components/qa-agent/qa-agent-client.tsx
+++ b/src/components/qa-agent/qa-agent-client.tsx
@@ -1,248 +1,47 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { toast } from "sonner";
 import type {
+  ActivitySourceType,
   AgentSession,
-  AgentStepState,
   QaRunMode,
+  QaTask,
   QaTestGroup,
 } from "@/lib/db/schema";
 import { QA_GROUPS } from "@/lib/qa-agent/plan";
 import { useQaAgent } from "./use-qa-agent";
+import { useQaTasks } from "./use-qa-tasks";
+import { useActivityFeed } from "@/components/activity-feed/use-activity-feed";
+import { QaAgentHeader } from "./qa-agent-header";
+import { PhaseTimeline } from "./qa-phase-timeline";
 import { QaPlanReview } from "./qa-plan-review";
 import { QaGeneratedTestsPanel, QaSummaryPanel } from "./qa-results-panel";
+import type { CoverageRequestHint } from "./qa-results-panel";
 import { BrowserViewer } from "@/components/embedded-browser/browser-viewer-client";
+import { QaTaskBoard } from "./qa-task-board";
+import { QaRunHistory } from "./qa-run-history";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Progress } from "@/components/ui/progress";
 import { Switch } from "@/components/ui/switch";
 import {
   AlertTriangle,
-  Ban,
   Bot,
-  CheckCircle2,
-  Circle,
-  CircleDashed,
   FileText,
   Github,
   Loader2,
   Lock,
   MonitorPlay,
   PackagePlus,
-  Pause,
   Play,
   RefreshCw,
-  RotateCcw,
-  SkipForward,
-  UserRound,
   X,
-  XCircle,
 } from "lucide-react";
-
-// ---------------------------------------------------------------------------
-// Status hero
-// ---------------------------------------------------------------------------
-
-const SESSION_STATUS_META: Record<
-  AgentSession["status"],
-  { label: string; className: string; spin?: boolean; icon: typeof Bot }
-> = {
-  active: {
-    label: "Running",
-    className: "bg-info/10 border-info/30 text-info",
-    spin: true,
-    icon: Loader2,
-  },
-  paused: {
-    label: "Waiting for you",
-    className: "bg-warning/10 border-warning/30 text-warning",
-    icon: UserRound,
-  },
-  completed: {
-    label: "Completed",
-    className: "bg-success/10 border-success/30 text-success",
-    icon: CheckCircle2,
-  },
-  failed: {
-    label: "Failed",
-    className: "bg-destructive/10 border-destructive/30 text-destructive",
-    icon: XCircle,
-  },
-  cancelled: {
-    label: "Cancelled",
-    className: "bg-muted border-border text-muted-foreground",
-    icon: Ban,
-  },
-};
-
-// ---------------------------------------------------------------------------
-// Phase timeline
-// ---------------------------------------------------------------------------
-
-function StepDot({ step }: { step: AgentStepState }) {
-  switch (step.status) {
-    case "completed":
-      return <CheckCircle2 className="h-4 w-4 text-success" />;
-    case "active":
-      return <Loader2 className="h-4 w-4 text-info animate-spin" />;
-    case "waiting_user":
-      return <UserRound className="h-4 w-4 text-warning" />;
-    case "failed":
-      return <XCircle className="h-4 w-4 text-destructive" />;
-    case "skipped":
-      return <SkipForward className="h-4 w-4 text-muted-foreground" />;
-    default:
-      return <Circle className="h-4 w-4 text-muted-foreground/40" />;
-  }
-}
-
-const AGENT_BADGE_STYLES: Record<string, string> = {
-  orchestrator: "bg-primary/10 text-primary border-primary/30",
-  planner: "bg-info/10 text-info border-info/30",
-  scout: "bg-success/10 text-success border-success/30",
-  ranger: "bg-success/10 text-success border-success/30",
-  generator: "bg-warning/10 text-warning border-warning/30",
-  healer: "bg-destructive/10 text-destructive border-destructive/30",
-};
-
-function SubstepRow({
-  substep,
-}: {
-  substep: NonNullable<AgentStepState["substeps"]>[number];
-}) {
-  return (
-    <div className="flex items-start gap-2 text-sm py-0.5">
-      <span className="mt-0.5 shrink-0">
-        {substep.status === "running" ? (
-          <Loader2 className="h-3.5 w-3.5 text-info animate-spin" />
-        ) : substep.status === "done" ? (
-          <CheckCircle2 className="h-3.5 w-3.5 text-success" />
-        ) : substep.status === "error" ? (
-          <XCircle className="h-3.5 w-3.5 text-destructive" />
-        ) : (
-          <CircleDashed className="h-3.5 w-3.5 text-muted-foreground/50" />
-        )}
-      </span>
-      {substep.agent && (
-        <Badge
-          variant="outline"
-          className={`text-[10px] px-1.5 shrink-0 ${AGENT_BADGE_STYLES[substep.agent] ?? ""}`}
-        >
-          {substep.agent}
-        </Badge>
-      )}
-      <span className="min-w-0">
-        <span className="truncate">{substep.label}</span>
-        {substep.detail && (
-          <span className="block text-xs text-muted-foreground truncate">
-            {substep.detail}
-          </span>
-        )}
-      </span>
-      {substep.durationMs !== undefined && (
-        <span className="ml-auto shrink-0 text-xs text-muted-foreground">
-          {(substep.durationMs / 1000).toFixed(1)}s
-        </span>
-      )}
-    </div>
-  );
-}
-
-function PhaseTimeline({ session }: { session: AgentSession }) {
-  const activeStep = session.steps.find(
-    (s) =>
-      s.status === "active" ||
-      s.status === "waiting_user" ||
-      s.status === "failed",
-  );
-  return (
-    <Card>
-      <CardContent className="pt-4 space-y-4">
-        <div className="flex items-start gap-0 overflow-x-auto pb-1">
-          {session.steps.map((step, i) => (
-            <div key={step.id} className="flex items-start min-w-0">
-              {i > 0 && (
-                <div
-                  className={`h-px w-5 sm:w-8 mt-2 shrink-0 ${
-                    step.status === "pending" ? "bg-border" : "bg-success/50"
-                  }`}
-                />
-              )}
-              <div
-                className="flex flex-col items-center gap-1 px-1 min-w-14"
-                title={step.description}
-              >
-                <StepDot step={step} />
-                <span
-                  className={`text-[11px] leading-tight text-center ${
-                    step.status === "active" || step.status === "waiting_user"
-                      ? "text-foreground font-medium"
-                      : "text-muted-foreground"
-                  }`}
-                >
-                  {step.id === "qa_login" && (
-                    <Lock className="inline h-3 w-3 mr-0.5 align-[-1px]" />
-                  )}
-                  {step.label}
-                </span>
-              </div>
-            </div>
-          ))}
-        </div>
-
-        {activeStep && (
-          <div className="rounded-md border bg-muted/30 p-3 space-y-1">
-            <div className="flex items-center gap-2 text-sm font-medium">
-              <StepDot step={activeStep} />
-              {activeStep.label}
-              <span className="font-normal text-muted-foreground text-xs">
-                {activeStep.description}
-              </span>
-            </div>
-            {activeStep.error && (
-              <div className="flex items-start gap-1.5 text-sm text-destructive">
-                <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-                {activeStep.error}
-              </div>
-            )}
-            {activeStep.result?.manual === true && (
-              <div className="mt-2 space-y-2 rounded-md border border-warning/40 bg-warning/5 p-2">
-                <div className="text-xs font-medium">Proceed manually</div>
-                {typeof activeStep.result.manualHint === "string" && (
-                  <p className="text-xs text-muted-foreground">
-                    {activeStep.result.manualHint}
-                  </p>
-                )}
-                {typeof activeStep.result.rawOutput === "string" && (
-                  <div className="space-y-1">
-                    <div className="text-[11px] font-medium text-muted-foreground">
-                      Raw planner output
-                    </div>
-                    <pre className="max-h-64 overflow-auto rounded bg-muted/50 p-2 text-[11px] leading-snug whitespace-pre-wrap break-words">
-                      {activeStep.result.rawOutput}
-                    </pre>
-                  </div>
-                )}
-              </div>
-            )}
-            {(activeStep.substeps?.length ?? 0) > 0 && (
-              <div className="max-h-56 overflow-y-auto">
-                {activeStep.substeps!.map((substep, i) => (
-                  <SubstepRow key={`${substep.label}-${i}`} substep={substep} />
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Setup form
@@ -659,8 +458,18 @@ function SetupCard({
 }
 
 // ---------------------------------------------------------------------------
-// Main client
+// Main client — the ongoing agent management page
 // ---------------------------------------------------------------------------
+
+const SOURCE_LABELS: Record<ActivitySourceType, string> = {
+  play_agent: "Play agent",
+  mcp_server: "MCP agent",
+  generate_agent: "Generator agent",
+  heal_agent: "Healer agent",
+  qa_agent: "QA agent",
+};
+
+const EXTERNAL_ACTIVITY_WINDOW_MS = 5 * 60 * 1000;
 
 export function QaAgentClient({
   repositoryId,
@@ -672,6 +481,8 @@ export function QaAgentClient({
   storedPlanInfo,
   hasExistingAuthSetup,
   initialSession,
+  recentSessions,
+  initialTasks,
 }: {
   repositoryId: string;
   repositoryName: string;
@@ -685,134 +496,159 @@ export function QaAgentClient({
    *  step will check/reuse them. */
   hasExistingAuthSetup: boolean;
   initialSession: AgentSession | null;
+  /** Recent runs (any status), newest first — the run-history list. */
+  recentSessions: AgentSession[];
+  /** Direction-queue snapshot for the task board. */
+  initialTasks: QaTask[];
 }) {
   const {
     session,
     loading,
     error,
-    isRunning,
-    isPaused,
-    isTerminal,
     progress,
     start,
+    rerun,
+    attach,
     approve,
     requestChanges,
     addJourneys,
     pause,
     resume,
     cancel,
-    dismiss,
   } = useQaAgent(repositoryId, initialSession);
 
-  const reviewStep = session?.steps.find((s) => s.id === "qa_plan_review");
+  const {
+    tasks,
+    workingTask,
+    pending: taskPending,
+    error: taskError,
+    add: addTask,
+    retry: retryTask,
+    drop: dropTask,
+    refresh: refreshTasks,
+  } = useQaTasks(repositoryId, initialTasks);
+
+  // Team-wide live feed for this repo: powers the header narration for
+  // task-run pickups and the "another agent is working via MCP" indicator.
+  const { events } = useActivityFeed({ repoId: repositoryId });
+  const [nowTick, setNowTick] = useState(() => Date.now());
+  useEffect(() => {
+    const interval = setInterval(() => setNowTick(Date.now()), 30_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const [setupOpen, setSetupOpen] = useState(false);
+
+  // A dispatcher-started task run isn't in this tab's polling loop yet —
+  // attach as soon as the board reports its session id.
+  const workingSessionId = workingTask?.sessionId;
+  useEffect(() => {
+    if (workingSessionId && workingSessionId !== session?.id) {
+      attach(workingSessionId);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workingSessionId]);
+
+  // Task events arrive over the feed faster than the board's poll — refresh.
+  const lastEvent = events[events.length - 1];
+  useEffect(() => {
+    if (lastEvent?.eventType.startsWith("task:")) void refreshTasks();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lastEvent?.id]);
+
+  const liveSession =
+    session && (session.status === "active" || session.status === "paused")
+      ? session
+      : null;
+
+  const reviewStep = liveSession?.steps.find((s) => s.id === "qa_plan_review");
   const awaitingReview = reviewStep?.status === "waiting_user";
-  const plan = session?.metadata.qaPlan;
+  const plan = liveSession?.metadata.qaPlan;
+  const planStepDone = Boolean(
+    liveSession?.steps.some(
+      (s) => s.id === "qa_plan" && s.status === "completed",
+    ),
+  );
   const generated = useMemo(
-    () => session?.metadata.qaGeneratedTests ?? [],
-    [session?.metadata.qaGeneratedTests],
+    () => liveSession?.metadata.qaGeneratedTests ?? [],
+    [liveSession?.metadata.qaGeneratedTests],
   );
-  const summary = session?.metadata.qaSummary;
-  const streamUrl = session?.metadata.streamUrl;
-  const queuedForBrowser = session?.metadata.queuedForBrowser;
+  const streamUrl = liveSession?.metadata.streamUrl;
+  const queuedForBrowser = liveSession?.metadata.queuedForBrowser;
 
-  if (!session) {
-    return (
-      <SetupCard
-        defaultUrl={defaultUrl}
-        githubConnected={githubConnected}
-        aiConfigured={aiConfigured}
-        hasStoredPlan={hasStoredPlan}
-        storedPlanInfo={storedPlanInfo}
-        hasExistingAuthSetup={hasExistingAuthSetup}
-        loading={loading}
-        error={error}
-        onStart={start}
-      />
+  // Run history: the polled session is fresher than the server snapshot.
+  const historySessions = useMemo(() => {
+    const map = new Map<string, AgentSession>();
+    if (session) map.set(session.id, session);
+    for (const s of recentSessions) if (!map.has(s.id)) map.set(s.id, s);
+    return [...map.values()].sort(
+      (a, b) =>
+        new Date(b.createdAt ?? 0).getTime() -
+        new Date(a.createdAt ?? 0).getTime(),
     );
-  }
+  }, [session, recentSessions]);
 
-  const statusMeta = SESSION_STATUS_META[session.status];
-  const StatusIcon = statusMeta.icon;
-  const planStepDone = session.steps.some(
-    (s) => s.id === "qa_plan" && s.status === "completed",
+  // Persistent coverage dashboard: the newest summary from any run.
+  const coverageSource = useMemo(
+    () => historySessions.find((s) => s.metadata.qaSummary),
+    [historySessions],
   );
+
+  // Most recent activity from another agent (MCP, quickstart…) on this repo.
+  const externalActivity = useMemo(() => {
+    for (let i = events.length - 1; i >= 0; i--) {
+      const e = events[i];
+      if (e.sourceType === "qa_agent") continue;
+      if (
+        new Date(e.createdAt as unknown as string).getTime() <
+        nowTick - EXTERNAL_ACTIVITY_WINDOW_MS
+      ) {
+        return null;
+      }
+      return {
+        summary: e.summary,
+        sourceLabel: SOURCE_LABELS[e.sourceType] ?? e.sourceType,
+      };
+    }
+    return null;
+  }, [events, nowTick]);
+
+  const handleRequestCoverage = useCallback(
+    (hint: CoverageRequestHint) => {
+      const groupLabel = hint.group
+        ? (QA_GROUPS.find((g) => g.id === hint.group)?.label ?? hint.group)
+        : null;
+      const title =
+        hint.area && groupLabel
+          ? `Increase coverage: ${hint.area} × ${groupLabel}`
+          : "Increase overall coverage — close the current gaps";
+      void addTask(title, { source: "coverage_gap" }).then((ok) => {
+        if (ok) toast.success("Coverage task queued for the agent");
+      });
+    },
+    [addTask],
+  );
+
+  const neverRan = historySessions.length === 0;
+  const showSetup = !liveSession && (setupOpen || neverRan);
 
   return (
     <div className="space-y-4">
-      {/* Status hero + controls */}
-      <Card className={`border ${statusMeta.className}`}>
-        <CardContent className="pt-4">
-          <div className="flex flex-wrap items-center gap-3">
-            <StatusIcon
-              className={`h-5 w-5 ${statusMeta.spin ? "animate-spin" : ""}`}
-            />
-            <div className="min-w-0 flex-1">
-              <div className="font-medium">
-                QA agent — {statusMeta.label}
-                {awaitingReview && ": review the plan below"}
-                {session.metadata.qaMode &&
-                  session.metadata.qaMode !== "full" && (
-                    <Badge
-                      variant="outline"
-                      className="ml-2 align-middle text-[10px] px-1.5"
-                    >
-                      {session.metadata.qaMode === "refresh_spec"
-                        ? "spec refresh"
-                        : "fill gaps"}
-                    </Badge>
-                  )}
-              </div>
-              <div className="text-xs opacity-80 truncate">
-                {repositoryName} → {session.metadata.qaTargetUrl}
-                {(session.metadata.qaDocs?.length ?? 0) > 0 &&
-                  ` · ${session.metadata.qaDocs!.length} doc${session.metadata.qaDocs!.length === 1 ? "" : "s"} provided`}
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              {isRunning && (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={pause}
-                  disabled={loading}
-                >
-                  <Pause className="h-3.5 w-3.5" />
-                  Pause
-                </Button>
-              )}
-              {isPaused && !awaitingReview && (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={resume}
-                  disabled={loading}
-                >
-                  <Play className="h-3.5 w-3.5" />
-                  Resume
-                </Button>
-              )}
-              {(isRunning || isPaused) && (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={cancel}
-                  disabled={loading}
-                >
-                  <Ban className="h-3.5 w-3.5" />
-                  Cancel
-                </Button>
-              )}
-              {isTerminal && (
-                <Button size="sm" variant="outline" onClick={dismiss}>
-                  <RotateCcw className="h-3.5 w-3.5" />
-                  New run
-                </Button>
-              )}
-            </div>
-          </div>
-          <Progress value={progress} className="mt-3 h-1.5" />
-        </CardContent>
-      </Card>
+      <QaAgentHeader
+        repositoryName={repositoryName}
+        session={liveSession}
+        awaitingReview={awaitingReview}
+        workingTask={workingTask}
+        externalActivity={externalActivity}
+        progress={progress}
+        loading={loading}
+        setupOpen={showSetup}
+        canStartRun={!neverRan}
+        onToggleSetup={() => setSetupOpen((v) => !v)}
+        onPause={pause}
+        onResume={resume}
+        onCancel={cancel}
+      />
 
       {error && (
         <div className="flex items-start gap-1.5 text-sm text-destructive">
@@ -821,57 +657,106 @@ export function QaAgentClient({
         </div>
       )}
 
-      <PhaseTimeline session={session} />
-
-      {/* Live browser while an agent holds an EB */}
-      {(streamUrl || queuedForBrowser) && (
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="flex items-center gap-2 text-base">
-              <MonitorPlay className="h-4 w-4" />
-              Live browser
-              <span className="text-xs font-normal text-muted-foreground">
-                {queuedForBrowser
-                  ? "waiting for a browser from the pool…"
-                  : "watching the agent work"}
-              </span>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {streamUrl ? (
-              <BrowserViewer
-                streamUrl={streamUrl}
-                interactive={false}
-                hideToolbar
-                className="rounded-md overflow-hidden border"
-              />
-            ) : (
-              <div className="flex items-center justify-center h-40 text-sm text-muted-foreground">
-                <Loader2 className="h-4 w-4 animate-spin mr-2" />
-                Waiting for an embedded browser…
-              </div>
-            )}
-          </CardContent>
-        </Card>
+      {showSetup && (
+        <div className="animate-in fade-in slide-in-from-top-2 duration-200">
+          <SetupCard
+            defaultUrl={defaultUrl}
+            githubConnected={githubConnected}
+            aiConfigured={aiConfigured}
+            hasStoredPlan={hasStoredPlan}
+            storedPlanInfo={storedPlanInfo}
+            hasExistingAuthSetup={hasExistingAuthSetup}
+            loading={loading}
+            error={error}
+            onStart={(opts) => {
+              setSetupOpen(false);
+              void start(opts);
+            }}
+          />
+        </div>
       )}
 
-      {/* Plan: interactive at the review gate, read-only afterwards */}
-      {plan && (awaitingReview || planStepDone) && (
-        <QaPlanReview
-          key={awaitingReview ? "review" : "readonly"}
-          plan={plan}
-          discovery={session?.metadata.qaDiscovery}
-          readOnly={!awaitingReview}
-          loading={loading}
-          onApprove={approve}
-          onRequestChanges={requestChanges}
-          onAddJourneys={addJourneys}
+      {/* Active run — collapses into history when it ends */}
+      {liveSession && (
+        <>
+          <PhaseTimeline session={liveSession} />
+          {/* Live browser while an agent holds an EB */}
+          {(streamUrl || queuedForBrowser) && (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <MonitorPlay className="h-4 w-4" />
+                  Live browser
+                  <span className="text-xs font-normal text-muted-foreground">
+                    {queuedForBrowser
+                      ? "waiting for a browser from the pool…"
+                      : "watching the agent work"}
+                  </span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {streamUrl ? (
+                  <BrowserViewer
+                    streamUrl={streamUrl}
+                    interactive={false}
+                    hideToolbar
+                    className="rounded-md overflow-hidden border"
+                  />
+                ) : (
+                  <div className="flex items-center justify-center h-40 text-sm text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                    Waiting for an embedded browser…
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          )}
+          {plan && (awaitingReview || planStepDone) && (
+            <QaPlanReview
+              key={awaitingReview ? "review" : "readonly"}
+              plan={plan}
+              discovery={liveSession.metadata.qaDiscovery}
+              readOnly={!awaitingReview}
+              loading={loading}
+              onApprove={approve}
+              onRequestChanges={requestChanges}
+              onAddJourneys={addJourneys}
+            />
+          )}
+          {generated.length > 0 && (
+            <QaGeneratedTestsPanel generated={generated} />
+          )}
+        </>
+      )}
+
+      {/* Persistent coverage dashboard — the agent's standing artifact */}
+      {coverageSource?.metadata.qaSummary && (
+        <QaSummaryPanel
+          summary={coverageSource.metadata.qaSummary}
+          plan={coverageSource.metadata.qaPlan}
+          persistent
+          updatedAt={coverageSource.completedAt ?? coverageSource.createdAt}
+          onRequestCoverage={handleRequestCoverage}
+          requestPending={taskPending}
         />
       )}
 
-      {generated.length > 0 && <QaGeneratedTestsPanel generated={generated} />}
+      {/* Direction queue */}
+      <QaTaskBoard
+        tasks={tasks}
+        pending={taskPending}
+        error={taskError}
+        onAdd={addTask}
+        onRetry={retryTask}
+        onDrop={dropTask}
+      />
 
-      {summary && <QaSummaryPanel summary={summary} plan={plan} />}
+      <QaRunHistory
+        sessions={historySessions}
+        liveSessionId={liveSession?.id ?? null}
+        loading={loading}
+        onRerun={(sid) => void rerun(sid)}
+      />
     </div>
   );
 }

--- a/src/components/qa-agent/qa-agent-client.tsx
+++ b/src/components/qa-agent/qa-agent-client.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import type {
   AgentSession,
   AgentStepState,
+  QaRunMode,
   QaTestGroup,
 } from "@/lib/db/schema";
 import { QA_GROUPS } from "@/lib/qa-agent/plan";
@@ -31,8 +32,10 @@ import {
   Loader2,
   Lock,
   MonitorPlay,
+  PackagePlus,
   Pause,
   Play,
+  RefreshCw,
   RotateCcw,
   SkipForward,
   UserRound,
@@ -220,10 +223,39 @@ function PhaseTimeline({ session }: { session: AgentSession }) {
 // Setup form
 // ---------------------------------------------------------------------------
 
+const RUN_MODES: Array<{
+  id: QaRunMode;
+  label: string;
+  description: string;
+  /** Needs a previously stored plan. */
+  needsPlan?: boolean;
+}> = [
+  {
+    id: "full",
+    label: "Full run",
+    description: "Discover → plan → review → generate → run → heal → summary",
+  },
+  {
+    id: "refresh_spec",
+    label: "Refresh specification",
+    description:
+      "Re-discover the app and re-plan against the current suite (code or manual test changes) — no generation, ends with a covered-vs-gaps report",
+  },
+  {
+    id: "fill_gaps",
+    label: "Fill coverage gaps",
+    description:
+      "Reuse the latest plan and generate + run only the items not yet covered by an existing test",
+    needsPlan: true,
+  },
+];
+
 function SetupCard({
   defaultUrl,
   githubConnected,
   aiConfigured,
+  hasStoredPlan,
+  storedPlanInfo,
   loading,
   error,
   onStart,
@@ -231,10 +263,13 @@ function SetupCard({
   defaultUrl: string;
   githubConnected: boolean;
   aiConfigured: boolean;
+  hasStoredPlan: boolean;
+  storedPlanInfo: string | null;
   loading: boolean;
   error: string | null;
   onStart: (opts: {
     targetUrl: string;
+    mode: QaRunMode;
     groups: QaTestGroup[];
     email?: string;
     password?: string;
@@ -242,6 +277,7 @@ function SetupCard({
   }) => void;
 }) {
   const [targetUrl, setTargetUrl] = useState(defaultUrl);
+  const [mode, setMode] = useState<QaRunMode>("full");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [autoApprove, setAutoApprove] = useState(false);
@@ -272,10 +308,57 @@ function SetupCard({
         <p className="text-sm text-muted-foreground">
           The QA agent discovers your app (source routes + live DOM), designs a
           risk-prioritized plan across the selected coverage groups, waits for
-          your approval, then generates, runs, and heals the suite.
+          your approval, then generates, runs, and heals the suite. Re-run it
+          any time — repeat runs plan against the tests that already exist.
         </p>
       </CardHeader>
       <CardContent className="space-y-5">
+        <div className="space-y-1.5">
+          <Label>Run mode</Label>
+          <div className="grid sm:grid-cols-3 gap-1.5">
+            {RUN_MODES.map((m) => {
+              const disabled = Boolean(m.needsPlan && !hasStoredPlan);
+              const selected = mode === m.id;
+              return (
+                <button
+                  key={m.id}
+                  type="button"
+                  disabled={disabled}
+                  onClick={() => setMode(m.id)}
+                  className={`rounded-md border p-2.5 text-left text-sm transition-colors ${
+                    selected
+                      ? "border-primary bg-primary/5"
+                      : "hover:bg-muted/50"
+                  } ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
+                >
+                  <span className="font-medium flex items-center gap-1.5">
+                    {m.id === "full" && <Play className="h-3.5 w-3.5" />}
+                    {m.id === "refresh_spec" && (
+                      <RefreshCw className="h-3.5 w-3.5" />
+                    )}
+                    {m.id === "fill_gaps" && (
+                      <PackagePlus className="h-3.5 w-3.5" />
+                    )}
+                    {m.label}
+                  </span>
+                  <span className="block text-xs text-muted-foreground mt-0.5">
+                    {m.description}
+                  </span>
+                  {m.needsPlan && !hasStoredPlan && (
+                    <span className="block text-[11px] text-warning mt-1">
+                      Run full or refresh first to store a plan
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+          {mode === "fill_gaps" && storedPlanInfo && (
+            <p className="text-xs text-muted-foreground">
+              Using stored plan: {storedPlanInfo}
+            </p>
+          )}
+        </div>
         <div className="flex flex-wrap gap-2">
           <Badge
             variant="outline"
@@ -348,52 +431,56 @@ function SetupCard({
           authenticated journeys. Without them it covers the public surface.
         </p>
 
-        <div className="space-y-1.5">
-          <Label>Coverage groups</Label>
-          <div className="grid sm:grid-cols-2 gap-1.5">
-            {QA_GROUPS.map((group) => (
-              <label
-                key={group.id}
-                className={`flex items-start gap-2 rounded-md border p-2 text-sm ${
-                  group.locked
-                    ? "opacity-90"
-                    : "cursor-pointer hover:bg-muted/50"
-                }`}
-              >
-                <Checkbox
-                  checked={groups.has(group.id)}
-                  disabled={group.locked}
-                  onCheckedChange={() => toggleGroup(group.id)}
-                  className="mt-0.5"
-                />
-                <span>
-                  <span className="font-medium">
-                    {group.label}
-                    {group.locked && (
-                      <span className="text-xs text-muted-foreground font-normal">
-                        {" "}
-                        (always on)
-                      </span>
-                    )}
+        {mode !== "fill_gaps" && (
+          <div className="space-y-1.5">
+            <Label>Coverage groups</Label>
+            <div className="grid sm:grid-cols-2 gap-1.5">
+              {QA_GROUPS.map((group) => (
+                <label
+                  key={group.id}
+                  className={`flex items-start gap-2 rounded-md border p-2 text-sm ${
+                    group.locked
+                      ? "opacity-90"
+                      : "cursor-pointer hover:bg-muted/50"
+                  }`}
+                >
+                  <Checkbox
+                    checked={groups.has(group.id)}
+                    disabled={group.locked}
+                    onCheckedChange={() => toggleGroup(group.id)}
+                    className="mt-0.5"
+                  />
+                  <span>
+                    <span className="font-medium">
+                      {group.label}
+                      {group.locked && (
+                        <span className="text-xs text-muted-foreground font-normal">
+                          {" "}
+                          (always on)
+                        </span>
+                      )}
+                    </span>
+                    <span className="block text-xs text-muted-foreground">
+                      {group.description}
+                    </span>
                   </span>
-                  <span className="block text-xs text-muted-foreground">
-                    {group.description}
-                  </span>
-                </span>
-              </label>
-            ))}
-          </div>
-        </div>
-
-        <div className="flex items-center justify-between rounded-md border p-3">
-          <div>
-            <div className="text-sm font-medium">Auto-approve plan</div>
-            <div className="text-xs text-muted-foreground">
-              Skip the human review gate and generate immediately
+                </label>
+              ))}
             </div>
           </div>
-          <Switch checked={autoApprove} onCheckedChange={setAutoApprove} />
-        </div>
+        )}
+
+        {mode !== "fill_gaps" && (
+          <div className="flex items-center justify-between rounded-md border p-3">
+            <div>
+              <div className="text-sm font-medium">Auto-approve plan</div>
+              <div className="text-xs text-muted-foreground">
+                Skip the human review gate and continue immediately
+              </div>
+            </div>
+            <Switch checked={autoApprove} onCheckedChange={setAutoApprove} />
+          </div>
+        )}
 
         {error && (
           <div className="flex items-start gap-1.5 text-sm text-destructive">
@@ -407,6 +494,7 @@ function SetupCard({
           onClick={() =>
             onStart({
               targetUrl: targetUrl.trim(),
+              mode,
               groups: [...groups],
               email: email.trim() || undefined,
               password: password || undefined,
@@ -436,6 +524,8 @@ export function QaAgentClient({
   defaultUrl,
   githubConnected,
   aiConfigured,
+  hasStoredPlan,
+  storedPlanInfo,
   initialSession,
 }: {
   repositoryId: string;
@@ -443,6 +533,9 @@ export function QaAgentClient({
   defaultUrl: string;
   githubConnected: boolean;
   aiConfigured: boolean;
+  /** A prior run stored a plan — enables the "fill coverage gaps" mode. */
+  hasStoredPlan: boolean;
+  storedPlanInfo: string | null;
   initialSession: AgentSession | null;
 }) {
   const {
@@ -479,6 +572,8 @@ export function QaAgentClient({
         defaultUrl={defaultUrl}
         githubConnected={githubConnected}
         aiConfigured={aiConfigured}
+        hasStoredPlan={hasStoredPlan}
+        storedPlanInfo={storedPlanInfo}
         loading={loading}
         error={error}
         onStart={start}
@@ -505,6 +600,17 @@ export function QaAgentClient({
               <div className="font-medium">
                 QA agent — {statusMeta.label}
                 {awaitingReview && ": review the plan below"}
+                {session.metadata.qaMode &&
+                  session.metadata.qaMode !== "full" && (
+                    <Badge
+                      variant="outline"
+                      className="ml-2 align-middle text-[10px] px-1.5"
+                    >
+                      {session.metadata.qaMode === "refresh_spec"
+                        ? "spec refresh"
+                        : "fill gaps"}
+                    </Badge>
+                  )}
               </div>
               <div className="text-xs opacity-80 truncate">
                 {repositoryName} → {session.metadata.qaTargetUrl}

--- a/src/components/qa-agent/qa-agent-header.tsx
+++ b/src/components/qa-agent/qa-agent-header.tsx
@@ -95,6 +95,7 @@ export function QaAgentHeader({
   loading,
   setupOpen,
   canStartRun,
+  triggerSummary,
   onToggleSetup,
   onPause,
   onResume,
@@ -113,6 +114,8 @@ export function QaAgentHeader({
   loading: boolean;
   setupOpen: boolean;
   canStartRun: boolean;
+  /** From the automation config — e.g. "manual runs · task queue · on PR". */
+  triggerSummary: string;
   onToggleSetup: () => void;
   onPause: () => void;
   onResume: () => void;
@@ -242,8 +245,7 @@ export function QaAgentHeader({
           <Progress value={progress} className="h-1.5" />
         )}
         <div className="text-[11px] text-muted-foreground">
-          Triggers: manual runs · task queue · re-runs — PR and schedule
-          triggers are coming next
+          Triggers: {triggerSummary} — configure below
         </div>
       </CardContent>
     </Card>

--- a/src/components/qa-agent/qa-agent-header.tsx
+++ b/src/components/qa-agent/qa-agent-header.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import type { AgentSession, QaTask } from "@/lib/db/schema";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import {
+  Ban,
+  Bot,
+  ChevronDown,
+  ChevronUp,
+  ListTodo,
+  Pause,
+  Play,
+  Plug,
+  Plus,
+} from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Agent status header — identity, live state, narration, controls
+// ---------------------------------------------------------------------------
+
+type AgentState = "working" | "waiting" | "paused" | "idle";
+
+const STATE_META: Record<
+  AgentState,
+  { label: string; dotClass: string; pulse: boolean; textClass: string }
+> = {
+  working: {
+    label: "Working",
+    dotClass: "bg-info",
+    pulse: true,
+    textClass: "text-info",
+  },
+  waiting: {
+    label: "Waiting for you",
+    dotClass: "bg-warning",
+    pulse: true,
+    textClass: "text-warning",
+  },
+  paused: {
+    label: "Paused",
+    dotClass: "bg-warning",
+    pulse: false,
+    textClass: "text-warning",
+  },
+  idle: {
+    label: "Idle",
+    dotClass: "bg-muted-foreground/50",
+    pulse: false,
+    textClass: "text-muted-foreground",
+  },
+};
+
+function StatusDot({ state }: { state: AgentState }) {
+  const meta = STATE_META[state];
+  return (
+    <span className="relative flex h-2.5 w-2.5 shrink-0">
+      {meta.pulse && (
+        <span
+          className={`animate-ping absolute inline-flex h-full w-full rounded-full opacity-60 ${meta.dotClass}`}
+        />
+      )}
+      <span
+        className={`relative inline-flex rounded-full h-2.5 w-2.5 ${meta.dotClass}`}
+      />
+    </span>
+  );
+}
+
+/** Current one-line narration for a running session: the active step plus its
+ *  freshest running substep. */
+function sessionNarration(session: AgentSession): string | null {
+  const step = session.steps.find(
+    (s) => s.status === "active" || s.status === "waiting_user",
+  );
+  if (!step) return null;
+  const running = [...(step.substeps ?? [])]
+    .reverse()
+    .find((s) => s.status === "running");
+  if (running) {
+    return `${step.label} — ${running.detail ?? running.label}`;
+  }
+  return `${step.label} — ${step.description}`;
+}
+
+export function QaAgentHeader({
+  repositoryName,
+  session,
+  awaitingReview,
+  workingTask,
+  externalActivity,
+  progress,
+  loading,
+  setupOpen,
+  canStartRun,
+  onToggleSetup,
+  onPause,
+  onResume,
+  onCancel,
+}: {
+  repositoryName: string;
+  /** The live (active/paused) session, or null when the agent is idle. */
+  session: AgentSession | null;
+  awaitingReview: boolean;
+  /** Task from the direction queue the agent is currently working, if any. */
+  workingTask: QaTask | null;
+  /** Most recent activity from ANOTHER agent (MCP, quickstart…) on this repo,
+   *  shown so the header reflects external agents driving the platform. */
+  externalActivity: { summary: string; sourceLabel: string } | null;
+  progress: number;
+  loading: boolean;
+  setupOpen: boolean;
+  canStartRun: boolean;
+  onToggleSetup: () => void;
+  onPause: () => void;
+  onResume: () => void;
+  onCancel: () => void;
+}) {
+  const isRunning = session?.status === "active";
+  const isPaused = session?.status === "paused";
+  const state: AgentState = isRunning
+    ? "working"
+    : awaitingReview
+      ? "waiting"
+      : isPaused
+        ? "paused"
+        : "idle";
+  const meta = STATE_META[state];
+
+  const narration = session
+    ? awaitingReview
+      ? "The test plan is ready — review it below"
+      : (sessionNarration(session) ?? "Starting up…")
+    : "Ready — start a run, or drop a task in the queue below";
+
+  return (
+    <Card>
+      <CardContent className="pt-4 space-y-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 shrink-0">
+            <Bot className="h-5 w-5 text-primary" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 font-medium">
+              QA agent
+              <span
+                className={`flex items-center gap-1.5 text-xs font-medium ${meta.textClass}`}
+              >
+                <StatusDot state={state} />
+                {meta.label}
+              </span>
+              {session?.metadata.qaMode &&
+                session.metadata.qaMode !== "full" && (
+                  <Badge variant="outline" className="text-[10px] px-1.5">
+                    {session.metadata.qaMode === "refresh_spec"
+                      ? "spec refresh"
+                      : "fill gaps"}
+                  </Badge>
+                )}
+              {workingTask && (
+                <Badge
+                  variant="outline"
+                  className="text-[10px] px-1.5 gap-1 bg-primary/5 border-primary/30 max-w-56"
+                  title={workingTask.title}
+                >
+                  <ListTodo className="h-3 w-3 shrink-0" />
+                  <span className="truncate">{workingTask.title}</span>
+                </Badge>
+              )}
+            </div>
+            <div
+              className="text-xs text-muted-foreground truncate"
+              title={narration}
+            >
+              {narration}
+              {session?.metadata.qaTargetUrl && (
+                <span className="opacity-70">
+                  {" "}
+                  · {repositoryName} → {session.metadata.qaTargetUrl}
+                </span>
+              )}
+            </div>
+            {externalActivity && (
+              <div className="mt-0.5 flex items-center gap-1 text-[11px] text-info truncate">
+                <Plug className="h-3 w-3 shrink-0" />
+                <span className="truncate">
+                  {externalActivity.sourceLabel}: {externalActivity.summary}
+                </span>
+              </div>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            {isRunning && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={onPause}
+                disabled={loading}
+              >
+                <Pause className="h-3.5 w-3.5" />
+                Pause
+              </Button>
+            )}
+            {isPaused && !awaitingReview && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={onResume}
+                disabled={loading}
+              >
+                <Play className="h-3.5 w-3.5" />
+                Resume
+              </Button>
+            )}
+            {(isRunning || isPaused) && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={onCancel}
+                disabled={loading}
+              >
+                <Ban className="h-3.5 w-3.5" />
+                Cancel
+              </Button>
+            )}
+            {!session && canStartRun && (
+              <Button size="sm" variant="outline" onClick={onToggleSetup}>
+                {setupOpen ? (
+                  <ChevronUp className="h-3.5 w-3.5" />
+                ) : (
+                  <Plus className="h-3.5 w-3.5" />
+                )}
+                New run
+                {!setupOpen && <ChevronDown className="h-3.5 w-3.5" />}
+              </Button>
+            )}
+          </div>
+        </div>
+        {(isRunning || isPaused) && (
+          <Progress value={progress} className="h-1.5" />
+        )}
+        <div className="text-[11px] text-muted-foreground">
+          Triggers: manual runs · task queue · re-runs — PR and schedule
+          triggers are coming next
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/qa-agent/qa-agent-upgrade-gate.tsx
+++ b/src/components/qa-agent/qa-agent-upgrade-gate.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import type { TeamPlan } from "@/lib/db/schema";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";

--- a/src/components/qa-agent/qa-agent-upgrade-gate.tsx
+++ b/src/components/qa-agent/qa-agent-upgrade-gate.tsx
@@ -1,0 +1,357 @@
+import Link from "next/link";
+import type { TeamPlan } from "@/lib/db/schema";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Bot,
+  CheckCircle2,
+  FileCode,
+  LayoutDashboard,
+  Loader2,
+  Lock,
+  Sparkles,
+  Zap,
+} from "lucide-react";
+
+// Locked view shown on /qa-agent to teams below the required plan. It sells the
+// feature by previewing exactly what a run looks like — the live agent flow and
+// the coverage dashboard it produces — rendered as a static, non-interactive
+// snapshot behind the upgrade CTA. The real UI lives in qa-agent-client.tsx;
+// this mirrors its visual language so the preview reads as the genuine article.
+
+const AGENT_BADGE_STYLES: Record<string, string> = {
+  orchestrator: "bg-primary/10 text-primary border-primary/30",
+  planner: "bg-info/10 text-info border-info/30",
+  scout: "bg-success/10 text-success border-success/30",
+  ranger: "bg-success/10 text-success border-success/30",
+  generator: "bg-warning/10 text-warning border-warning/30",
+  healer: "bg-destructive/10 text-destructive border-destructive/30",
+};
+
+type PreviewState = "completed" | "active" | "pending";
+
+const PREVIEW_PHASES: Array<{
+  label: string;
+  state: PreviewState;
+  lock?: boolean;
+}> = [
+  { label: "Preflight", state: "completed" },
+  { label: "Login", state: "completed", lock: true },
+  { label: "Discover", state: "completed" },
+  { label: "Plan", state: "completed" },
+  { label: "Review", state: "completed" },
+  { label: "Generate", state: "active" },
+  { label: "Execute", state: "pending" },
+  { label: "Heal", state: "pending" },
+  { label: "Summary", state: "pending" },
+];
+
+const PREVIEW_SUBSTEPS: Array<{
+  agent: string;
+  label: string;
+  detail: string;
+  state: "done" | "running";
+}> = [
+  {
+    agent: "scout",
+    label: "Static route scan",
+    detail: "42 routes (Next.js) · branch main",
+    state: "done",
+  },
+  {
+    agent: "ranger",
+    label: "Live crawl",
+    detail: "6 pages mapped, 18 API calls observed, logged in",
+    state: "done",
+  },
+  {
+    agent: "planner",
+    label: "Test plan designed",
+    detail: "5 journeys, 24 test items across 6 groups",
+    state: "done",
+  },
+  {
+    agent: "generator",
+    label: "Generating “Checkout — place order” smoke test…",
+    detail: "18 of 24 items generated",
+    state: "running",
+  },
+];
+
+const PREVIEW_STATS: Array<{ label: string; value: number }> = [
+  { label: "Planned", value: 24 },
+  { label: "Covered", value: 5 },
+  { label: "Generated", value: 19 },
+  { label: "Passing", value: 17 },
+  { label: "Gaps", value: 0 },
+];
+
+const PREVIEW_GROUPS: Array<{ label: string; detail: string }> = [
+  { label: "Business journeys", detail: "4/4 generated · 4 passing" },
+  { label: "Smoke", detail: "6/6 generated · 6 passing" },
+  { label: "UI", detail: "5/5 generated · 4 passing" },
+  { label: "API", detail: "3/3 generated · 3 passing" },
+  { label: "Accessibility", detail: "2 covered · 1/1 generated" },
+];
+
+const PREVIEW_TESTS: Array<{ name: string; status: "passed" | "generated" }> = [
+  { name: "Sign up → onboard → reach dashboard", status: "passed" },
+  { name: "Checkout — place order end to end", status: "passed" },
+  { name: "Invite teammate and accept invite", status: "generated" },
+];
+
+function PreviewDot({ state }: { state: PreviewState }) {
+  if (state === "completed")
+    return <CheckCircle2 className="h-4 w-4 text-success" />;
+  if (state === "active")
+    return <Loader2 className="h-4 w-4 text-info animate-spin" />;
+  return (
+    <span className="block h-4 w-4 rounded-full border border-muted-foreground/30" />
+  );
+}
+
+/** Static replica of the live agent flow (PhaseTimeline). */
+function FlowPreview() {
+  return (
+    <Card>
+      <CardContent className="space-y-4 pt-4">
+        <div className="flex items-start gap-0 overflow-x-auto pb-1">
+          {PREVIEW_PHASES.map((phase, i) => (
+            <div key={phase.label} className="flex min-w-0 items-start">
+              {i > 0 && (
+                <div
+                  className={`mt-2 h-px w-5 shrink-0 sm:w-8 ${
+                    phase.state === "pending" ? "bg-border" : "bg-success/50"
+                  }`}
+                />
+              )}
+              <div className="flex min-w-14 flex-col items-center gap-1 px-1">
+                <PreviewDot state={phase.state} />
+                <span
+                  className={`text-center text-[11px] leading-tight ${
+                    phase.state === "active"
+                      ? "font-medium text-foreground"
+                      : "text-muted-foreground"
+                  }`}
+                >
+                  {phase.lock && (
+                    <Lock className="mr-0.5 inline h-3 w-3 align-[-1px]" />
+                  )}
+                  {phase.label}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="space-y-1 rounded-md border bg-muted/30 p-3">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <Loader2 className="h-4 w-4 animate-spin text-info" />
+            Generate
+            <span className="text-xs font-normal text-muted-foreground">
+              Generate tests per plan item with live selector verification
+            </span>
+          </div>
+          <div>
+            {PREVIEW_SUBSTEPS.map((substep) => (
+              <div
+                key={substep.label}
+                className="flex items-start gap-2 py-0.5 text-sm"
+              >
+                <span className="mt-0.5 shrink-0">
+                  {substep.state === "running" ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin text-info" />
+                  ) : (
+                    <CheckCircle2 className="h-3.5 w-3.5 text-success" />
+                  )}
+                </span>
+                <Badge
+                  variant="outline"
+                  className={`shrink-0 px-1.5 text-[10px] ${AGENT_BADGE_STYLES[substep.agent] ?? ""}`}
+                >
+                  {substep.agent}
+                </Badge>
+                <span className="min-w-0">
+                  <span className="truncate">{substep.label}</span>
+                  <span className="block truncate text-xs text-muted-foreground">
+                    {substep.detail}
+                  </span>
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/** Static replica of the finished-run coverage dashboard (QaSummaryPanel). */
+function DoneScreenPreview() {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <LayoutDashboard className="h-4 w-4" />
+          Coverage dashboard
+          <span className="text-xs font-normal text-muted-foreground">
+            — what a completed run leaves behind
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+          {PREVIEW_STATS.map((stat) => (
+            <div key={stat.label} className="rounded-md border p-3 text-center">
+              <div className="text-2xl font-semibold">{stat.value}</div>
+              <div className="text-xs text-muted-foreground">{stat.label}</div>
+            </div>
+          ))}
+        </div>
+
+        <div className="space-y-1">
+          <h4 className="text-sm font-medium">By group</h4>
+          <div className="divide-y rounded-md border">
+            {PREVIEW_GROUPS.map((group) => (
+              <div
+                key={group.label}
+                className="flex items-center justify-between px-3 py-1.5 text-sm"
+              >
+                <span>{group.label}</span>
+                <span className="text-xs text-muted-foreground">
+                  {group.detail}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <h4 className="flex items-center gap-2 text-sm font-medium">
+            <FileCode className="h-4 w-4" />
+            Generated tests
+          </h4>
+          <div className="space-y-1">
+            {PREVIEW_TESTS.map((test) => (
+              <div
+                key={test.name}
+                className="flex items-center gap-2 rounded-md border px-2.5 py-1.5 text-sm"
+              >
+                <Badge
+                  variant="outline"
+                  className={`shrink-0 gap-1 px-1.5 text-[10px] ${
+                    test.status === "passed"
+                      ? "border-success/30 bg-success/10 text-success"
+                      : "border-border bg-muted text-muted-foreground"
+                  }`}
+                >
+                  {test.status === "passed" ? (
+                    <CheckCircle2 className="h-3 w-3" />
+                  ) : (
+                    <FileCode className="h-3 w-3" />
+                  )}
+                  {test.status === "passed" ? "Passed" : "Generated"}
+                </Badge>
+                <span className="flex-1 truncate">{test.name}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function QaAgentUpgradeGate({
+  currentPlanName,
+  requiredPlanName,
+}: {
+  /** Display name of the team's current plan (e.g. "Free"). */
+  currentPlanName: string;
+  /** Display name of the plan required to unlock (e.g. "Pro"). */
+  requiredPlanName: string;
+}) {
+  return (
+    <div className="flex-1 overflow-auto p-6">
+      <div className="mx-auto max-w-5xl space-y-6">
+        <header className="space-y-1">
+          <h1 className="flex items-center gap-2 text-2xl font-semibold">
+            <Bot className="h-6 w-6" />
+            QA Agent
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            An orchestrated agent team — scout, planner, generator, healer —
+            that discovers your app, plans coverage against testing best
+            practices, and builds a complete E2E suite you can watch and steer.
+          </p>
+        </header>
+
+        {/* Upgrade CTA */}
+        <Card className="overflow-hidden border-primary/30">
+          <CardContent className="flex flex-col gap-5 p-6 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-3">
+              <Badge
+                variant="outline"
+                className="gap-1.5 border-primary/30 bg-primary/10 text-primary"
+              >
+                <Sparkles className="h-3.5 w-3.5" />
+                {requiredPlanName} feature
+              </Badge>
+              <div className="space-y-1">
+                <h2 className="text-xl font-semibold">
+                  Unlock the QA Agent with {requiredPlanName}
+                </h2>
+                <p className="max-w-xl text-sm text-muted-foreground">
+                  Your team is on the {currentPlanName} plan. Upgrade to{" "}
+                  {requiredPlanName} to let the agent crawl your app, design a
+                  best-practices test plan, and generate, run, and heal a full
+                  E2E suite — all from a single target URL.
+                </p>
+              </div>
+              <ul className="grid gap-1.5 text-sm text-muted-foreground sm:grid-cols-2">
+                {[
+                  "Auto-discovers pages, forms & API endpoints",
+                  "Risk-prioritized plan you approve before it builds",
+                  "Generates journey, smoke, UI, API & a11y tests",
+                  "Runs the suite and self-heals failing tests",
+                ].map((feature) => (
+                  <li key={feature} className="flex items-start gap-2">
+                    <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-success" />
+                    {feature}
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="flex shrink-0 flex-col gap-2 sm:w-48">
+              <Button asChild size="lg" className="w-full">
+                <Link href="/settings/billing">
+                  <Zap className="h-4 w-4" />
+                  Upgrade to {requiredPlanName}
+                </Link>
+              </Button>
+              <Button asChild variant="ghost" size="sm" className="w-full">
+                <Link href="/settings/billing">Compare all plans</Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Preview of the real experience */}
+        <div aria-hidden className="pointer-events-none select-none space-y-4">
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Preview
+            </span>
+            <span className="h-px flex-1 bg-border" />
+            <span className="text-xs text-muted-foreground">
+              A sample run — not your data
+            </span>
+          </div>
+          <FlowPreview />
+          <DoneScreenPreview />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/qa-agent/qa-phase-timeline.tsx
+++ b/src/components/qa-agent/qa-phase-timeline.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import type { AgentSession, AgentStepState } from "@/lib/db/schema";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Circle,
+  CircleDashed,
+  Loader2,
+  Lock,
+  SkipForward,
+  UserRound,
+  XCircle,
+} from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Phase timeline (shared by the active-run view and expanded history rows)
+// ---------------------------------------------------------------------------
+
+export function StepDot({ step }: { step: AgentStepState }) {
+  switch (step.status) {
+    case "completed":
+      return <CheckCircle2 className="h-4 w-4 text-success" />;
+    case "active":
+      return <Loader2 className="h-4 w-4 text-info animate-spin" />;
+    case "waiting_user":
+      return <UserRound className="h-4 w-4 text-warning" />;
+    case "failed":
+      return <XCircle className="h-4 w-4 text-destructive" />;
+    case "skipped":
+      return <SkipForward className="h-4 w-4 text-muted-foreground" />;
+    default:
+      return <Circle className="h-4 w-4 text-muted-foreground/40" />;
+  }
+}
+
+export const AGENT_BADGE_STYLES: Record<string, string> = {
+  orchestrator: "bg-primary/10 text-primary border-primary/30",
+  planner: "bg-info/10 text-info border-info/30",
+  scout: "bg-success/10 text-success border-success/30",
+  ranger: "bg-success/10 text-success border-success/30",
+  generator: "bg-warning/10 text-warning border-warning/30",
+  healer: "bg-destructive/10 text-destructive border-destructive/30",
+};
+
+function SubstepRow({
+  substep,
+}: {
+  substep: NonNullable<AgentStepState["substeps"]>[number];
+}) {
+  return (
+    <div className="flex items-start gap-2 text-sm py-0.5">
+      <span className="mt-0.5 shrink-0">
+        {substep.status === "running" ? (
+          <Loader2 className="h-3.5 w-3.5 text-info animate-spin" />
+        ) : substep.status === "done" ? (
+          <CheckCircle2 className="h-3.5 w-3.5 text-success" />
+        ) : substep.status === "error" ? (
+          <XCircle className="h-3.5 w-3.5 text-destructive" />
+        ) : (
+          <CircleDashed className="h-3.5 w-3.5 text-muted-foreground/50" />
+        )}
+      </span>
+      {substep.agent && (
+        <Badge
+          variant="outline"
+          className={`text-[10px] px-1.5 shrink-0 ${AGENT_BADGE_STYLES[substep.agent] ?? ""}`}
+        >
+          {substep.agent}
+        </Badge>
+      )}
+      <span className="min-w-0">
+        <span className="truncate">{substep.label}</span>
+        {substep.detail && (
+          <span className="block text-xs text-muted-foreground truncate">
+            {substep.detail}
+          </span>
+        )}
+      </span>
+      {substep.durationMs !== undefined && (
+        <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+          {(substep.durationMs / 1000).toFixed(1)}s
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function PhaseTimeline({
+  session,
+  bare = false,
+}: {
+  session: AgentSession;
+  /** Render without the Card wrapper (inside an expanded history row). */
+  bare?: boolean;
+}) {
+  const activeStep = session.steps.find(
+    (s) =>
+      s.status === "active" ||
+      s.status === "waiting_user" ||
+      s.status === "failed",
+  );
+  const body = (
+    <>
+      <div className="flex items-start gap-0 overflow-x-auto pb-1">
+        {session.steps.map((step, i) => (
+          <div key={step.id} className="flex items-start min-w-0">
+            {i > 0 && (
+              <div
+                className={`h-px w-5 sm:w-8 mt-2 shrink-0 ${
+                  step.status === "pending" ? "bg-border" : "bg-success/50"
+                }`}
+              />
+            )}
+            <div
+              className="flex flex-col items-center gap-1 px-1 min-w-14"
+              title={step.description}
+            >
+              <StepDot step={step} />
+              <span
+                className={`text-[11px] leading-tight text-center ${
+                  step.status === "active" || step.status === "waiting_user"
+                    ? "text-foreground font-medium"
+                    : "text-muted-foreground"
+                }`}
+              >
+                {step.id === "qa_login" && (
+                  <Lock className="inline h-3 w-3 mr-0.5 align-[-1px]" />
+                )}
+                {step.label}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {activeStep && (
+        <div className="rounded-md border bg-muted/30 p-3 space-y-1">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <StepDot step={activeStep} />
+            {activeStep.label}
+            <span className="font-normal text-muted-foreground text-xs">
+              {activeStep.description}
+            </span>
+          </div>
+          {activeStep.error && (
+            <div className="flex items-start gap-1.5 text-sm text-destructive">
+              <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+              {activeStep.error}
+            </div>
+          )}
+          {activeStep.result?.manual === true && (
+            <div className="mt-2 space-y-2 rounded-md border border-warning/40 bg-warning/5 p-2">
+              <div className="text-xs font-medium">Proceed manually</div>
+              {typeof activeStep.result.manualHint === "string" && (
+                <p className="text-xs text-muted-foreground">
+                  {activeStep.result.manualHint}
+                </p>
+              )}
+              {typeof activeStep.result.rawOutput === "string" && (
+                <div className="space-y-1">
+                  <div className="text-[11px] font-medium text-muted-foreground">
+                    Raw planner output
+                  </div>
+                  <pre className="max-h-64 overflow-auto rounded bg-muted/50 p-2 text-[11px] leading-snug whitespace-pre-wrap break-words">
+                    {activeStep.result.rawOutput}
+                  </pre>
+                </div>
+              )}
+            </div>
+          )}
+          {(activeStep.substeps?.length ?? 0) > 0 && (
+            <div className="max-h-56 overflow-y-auto">
+              {activeStep.substeps!.map((substep, i) => (
+                <SubstepRow key={`${substep.label}-${i}`} substep={substep} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+
+  if (bare) return <div className="space-y-4">{body}</div>;
+  return (
+    <Card>
+      <CardContent className="pt-4 space-y-4">{body}</CardContent>
+    </Card>
+  );
+}

--- a/src/components/qa-agent/qa-plan-review.tsx
+++ b/src/components/qa-agent/qa-plan-review.tsx
@@ -1,12 +1,22 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import type { QaTestPlan } from "@/lib/db/schema";
+import type {
+  QaPlanItem,
+  QaPlanJourney,
+  QaTestGroup,
+  QaTestPlan,
+} from "@/lib/db/schema";
 import { itemGroups, QA_GROUPS } from "@/lib/qa-agent/plan";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
 import { Textarea } from "@/components/ui/textarea";
 import {
   Check,
@@ -32,6 +42,88 @@ function PriorityBadge({ priority }: { priority: string }) {
     >
       {priority}
     </Badge>
+  );
+}
+
+const groupLabel = (id: QaTestGroup) =>
+  QA_GROUPS.find((g) => g.id === id)?.label ?? id;
+
+/** Full plan-item details shown on hover over a matrix row's title. */
+function ItemDetailCard({
+  item,
+  groups,
+  journey,
+}: {
+  item: QaPlanItem;
+  groups: QaTestGroup[];
+  journey?: QaPlanJourney;
+}) {
+  return (
+    <div className="space-y-2 text-xs">
+      <div className="flex flex-wrap items-center gap-1.5">
+        <PriorityBadge priority={item.priority} />
+        <span className="text-sm font-medium">{item.title}</span>
+      </div>
+      <div className="flex flex-wrap items-center gap-1">
+        {groups.map((g) => (
+          <Badge key={g} variant="secondary" className="text-[10px] px-1.5">
+            {groupLabel(g)}
+          </Badge>
+        ))}
+        {item.pagePath && (
+          <code className="text-[10px] text-muted-foreground">
+            {item.pagePath}
+          </code>
+        )}
+      </div>
+      <div>
+        <div className="font-medium text-muted-foreground">Scenario</div>
+        <div className="whitespace-pre-line">{item.scenario}</div>
+      </div>
+      {item.rationale && (
+        <div>
+          <div className="font-medium text-muted-foreground">Rationale</div>
+          <div>{item.rationale}</div>
+        </div>
+      )}
+      {item.api && (
+        <div>
+          <div className="font-medium text-muted-foreground">API</div>
+          <code className="text-[11px]">
+            {item.api.method} {item.api.path}
+            {item.api.expectedStatus ? ` → ${item.api.expectedStatus}` : ""}
+          </code>
+        </div>
+      )}
+      {journey && (
+        <div>
+          <div className="font-medium text-muted-foreground">
+            Journey: {journey.title}
+          </div>
+          <div>
+            {journey.businessOutcome}
+            <span className="text-muted-foreground">
+              {" "}
+              · verified by: {journey.endStateVerification}
+            </span>
+          </div>
+        </div>
+      )}
+      {item.selectorHints && item.selectorHints.length > 0 && (
+        <div>
+          <div className="font-medium text-muted-foreground">
+            Verified selectors
+          </div>
+          <div className="space-y-0.5">
+            {item.selectorHints.map((s) => (
+              <code key={s} className="block text-[11px] break-all">
+                {s}
+              </code>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -159,14 +251,16 @@ export function QaPlanReview({
               <thead>
                 <tr className="border-b bg-muted/40">
                   {!readOnly && <th className="w-8 px-2 py-1.5" />}
-                  <th className="text-left px-3 py-1.5 font-medium">Test</th>
+                  <th className="w-full text-left px-3 py-1.5 font-medium">
+                    Test
+                  </th>
                   {presentGroups.map((g) => (
                     <th
                       key={g.id}
-                      className="text-center px-2 py-1.5 font-medium whitespace-nowrap"
-                      title={g.description}
+                      className="w-12 text-center px-1.5 py-1.5 font-medium text-xs whitespace-nowrap"
+                      title={`${g.label} — ${g.description}`}
                     >
-                      {g.label}
+                      {g.short}
                     </th>
                   ))}
                 </tr>
@@ -193,10 +287,33 @@ export function QaPlanReview({
                           />
                         </td>
                       )}
-                      <td className="px-3 py-2 min-w-64">
-                        <div className="flex items-center gap-2">
+                      <td className="w-full min-w-72 px-3 py-2">
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
                           <PriorityBadge priority={item.priority} />
-                          <span className="font-medium">{item.title}</span>
+                          <HoverCard openDelay={150} closeDelay={100}>
+                            <HoverCardTrigger asChild>
+                              <span className="font-medium cursor-help underline-offset-4 decoration-dotted decoration-muted-foreground/60 hover:underline">
+                                {item.title}
+                              </span>
+                            </HoverCardTrigger>
+                            <HoverCardContent
+                              align="start"
+                              className="w-96 max-h-96 overflow-y-auto"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <ItemDetailCard
+                                item={item}
+                                groups={groups}
+                                journey={
+                                  item.journeyId
+                                    ? plan.journeys.find(
+                                        (j) => j.id === item.journeyId,
+                                      )
+                                    : undefined
+                                }
+                              />
+                            </HoverCardContent>
+                          </HoverCard>
                           {item.businessArea && (
                             <Badge
                               variant="outline"
@@ -221,7 +338,7 @@ export function QaPlanReview({
                         return (
                           <td
                             key={g.id}
-                            className="text-center px-2 py-2 align-middle"
+                            className="text-center px-1.5 py-2 align-middle"
                             title={
                               covers
                                 ? `${g.label}${primary ? " (primary)" : ""}`

--- a/src/components/qa-agent/qa-plan-review.tsx
+++ b/src/components/qa-agent/qa-plan-review.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { QaTestGroup, QaTestPlan } from "@/lib/db/schema";
+import { QA_GROUPS } from "@/lib/qa-agent/plan";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  CheckCircle2,
+  ClipboardList,
+  Loader2,
+  MessageSquareWarning,
+  Route,
+  Target,
+} from "lucide-react";
+
+const PRIORITY_STYLES: Record<string, string> = {
+  P1: "bg-destructive/10 text-destructive border-destructive/30",
+  P2: "bg-warning/10 text-warning border-warning/30",
+  P3: "bg-muted text-muted-foreground border-border",
+};
+
+function PriorityBadge({ priority }: { priority: string }) {
+  return (
+    <Badge
+      variant="outline"
+      className={`text-[10px] px-1.5 ${PRIORITY_STYLES[priority] ?? ""}`}
+    >
+      {priority}
+    </Badge>
+  );
+}
+
+export function QaPlanReview({
+  plan,
+  readOnly,
+  loading,
+  onApprove,
+  onRequestChanges,
+}: {
+  plan: QaTestPlan;
+  /** True when the plan is shown outside the review gate (no actions). */
+  readOnly?: boolean;
+  loading?: boolean;
+  onApprove?: (disabledItemIds: string[]) => void;
+  onRequestChanges?: (feedback: string) => void;
+}) {
+  const [disabled, setDisabled] = useState<Set<string>>(
+    () =>
+      new Set(plan.items.filter((i) => i.enabled === false).map((i) => i.id)),
+  );
+  const [feedback, setFeedback] = useState("");
+  const [showFeedback, setShowFeedback] = useState(false);
+
+  const items = plan.items;
+  const itemsByGroup = useMemo(() => {
+    const map = new Map<QaTestGroup, typeof items>();
+    for (const item of items) {
+      const list = map.get(item.group) ?? [];
+      list.push(item);
+      map.set(item.group, list);
+    }
+    return map;
+  }, [items]);
+
+  const enabledCount = plan.items.length - disabled.size;
+
+  const toggle = (id: string) => {
+    setDisabled((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <ClipboardList className="h-4 w-4" />
+          Test plan
+          {!readOnly && (
+            <span className="text-xs font-normal text-muted-foreground">
+              — review, adjust, then approve
+            </span>
+          )}
+        </CardTitle>
+        <p className="text-sm text-muted-foreground">
+          {plan.appProfile.summary}
+          {plan.appProfile.primaryOutcome && (
+            <>
+              {" "}
+              <span className="text-foreground">
+                Primary outcome: {plan.appProfile.primaryOutcome}
+              </span>
+            </>
+          )}
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {plan.journeys.length > 0 && (
+          <div className="space-y-2">
+            <h4 className="text-sm font-medium flex items-center gap-1.5">
+              <Route className="h-3.5 w-3.5" />
+              Critical user journeys
+            </h4>
+            <div className="space-y-2">
+              {plan.journeys.map((journey) => (
+                <div
+                  key={journey.id}
+                  className="rounded-md border p-3 text-sm space-y-1"
+                >
+                  <div className="flex items-center gap-2">
+                    <PriorityBadge priority={journey.priority} />
+                    <span className="font-medium">{journey.title}</span>
+                  </div>
+                  <div className="text-muted-foreground text-xs">
+                    {journey.steps.join(" → ")}
+                  </div>
+                  <div className="flex items-start gap-1.5 text-xs">
+                    <Target className="h-3.5 w-3.5 mt-0.5 shrink-0 text-success" />
+                    <span>
+                      <span className="font-medium">Outcome:</span>{" "}
+                      {journey.businessOutcome}
+                      <span className="text-muted-foreground">
+                        {" "}
+                        · verified by: {journey.endStateVerification}
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-3">
+          {QA_GROUPS.filter((g) => itemsByGroup.has(g.id)).map((group) => (
+            <div key={group.id} className="space-y-1.5">
+              <h4 className="text-sm font-medium">
+                {group.label}{" "}
+                <span className="text-xs font-normal text-muted-foreground">
+                  ({itemsByGroup.get(group.id)!.length})
+                </span>
+              </h4>
+              <div className="space-y-1">
+                {itemsByGroup.get(group.id)!.map((item) => {
+                  const isDisabled = disabled.has(item.id);
+                  return (
+                    <label
+                      key={item.id}
+                      className={`flex items-start gap-2.5 rounded-md border p-2.5 text-sm ${
+                        readOnly ? "" : "cursor-pointer hover:bg-muted/50"
+                      } ${isDisabled ? "opacity-50" : ""}`}
+                    >
+                      {!readOnly && (
+                        <Checkbox
+                          checked={!isDisabled}
+                          onCheckedChange={() => toggle(item.id)}
+                          className="mt-0.5"
+                        />
+                      )}
+                      <div className="min-w-0 flex-1 space-y-0.5">
+                        <div className="flex items-center gap-2">
+                          <PriorityBadge priority={item.priority} />
+                          <span className="font-medium truncate">
+                            {item.title}
+                          </span>
+                          {item.pagePath && (
+                            <code className="text-[10px] text-muted-foreground">
+                              {item.pagePath}
+                            </code>
+                          )}
+                        </div>
+                        <div className="text-xs text-muted-foreground line-clamp-2 whitespace-pre-line">
+                          {item.scenario}
+                        </div>
+                      </div>
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {!readOnly && (
+          <div className="space-y-3 border-t pt-4">
+            {showFeedback ? (
+              <div className="space-y-2">
+                <Textarea
+                  placeholder="What should the planner change? (e.g. cover the transfer form, drop the P3 items, add logout coverage)"
+                  value={feedback}
+                  onChange={(e) => setFeedback(e.target.value)}
+                  rows={3}
+                />
+                <div className="flex gap-2">
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    disabled={loading || !feedback.trim()}
+                    onClick={() => onRequestChanges?.(feedback.trim())}
+                  >
+                    {loading ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <MessageSquareWarning className="h-3.5 w-3.5" />
+                    )}
+                    Send to planner
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => setShowFeedback(false)}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2">
+                <Button
+                  size="sm"
+                  disabled={loading || enabledCount === 0}
+                  onClick={() => onApprove?.([...disabled])}
+                >
+                  {loading ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <CheckCircle2 className="h-3.5 w-3.5" />
+                  )}
+                  Approve {enabledCount} test{enabledCount === 1 ? "" : "s"}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={loading}
+                  onClick={() => setShowFeedback(true)}
+                >
+                  <MessageSquareWarning className="h-3.5 w-3.5" />
+                  Request changes
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/qa-agent/qa-plan-review.tsx
+++ b/src/components/qa-agent/qa-plan-review.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import type {
+  QaDiscovery,
   QaPlanItem,
   QaPlanJourney,
   QaTestGroup,
@@ -22,6 +24,8 @@ import {
   Check,
   CheckCircle2,
   ClipboardList,
+  ExternalLink,
+  FileCheck,
   GitBranch,
   Loader2,
   MessageSquareWarning,
@@ -139,12 +143,60 @@ function ItemDetailCard({
           </div>
         </div>
       )}
+      {item.existingTestId && (
+        <div>
+          <div className="font-medium text-muted-foreground">
+            Already covered by existing test
+          </div>
+          <Link
+            href={`/tests/${item.existingTestId}`}
+            className="text-info hover:underline"
+          >
+            {item.existingTestName ?? "Open test"}
+          </Link>
+        </div>
+      )}
     </div>
+  );
+}
+
+/** Which code the discovery analyzed — branch, base, and the PR-diff facts
+ *  (or the reason there is no diff). Answers "what was this plan based on". */
+function AnalyzedCodeLine({ discovery }: { discovery: QaDiscovery }) {
+  if (!discovery.githubConnected || !discovery.branch) return null;
+  const pr = discovery.prChanges;
+  const onBase =
+    !discovery.baseBranch || discovery.branch === discovery.baseBranch;
+  return (
+    <p className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+      <GitBranch className="h-3.5 w-3.5" />
+      Code analyzed from branch <code>{discovery.branch}</code>
+      {pr ? (
+        <>
+          {" "}
+          — diff vs <code>{pr.baseBranch}</code>: {pr.files.length} files,{" "}
+          {pr.symbols.length} functions, {pr.endpoints.length} endpoints to
+          cover
+        </>
+      ) : onBase ? (
+        <>
+          {" "}
+          — this is the base branch, so there is no PR diff to target (pick a
+          feature branch in the repo settings to get PR-focused coverage)
+        </>
+      ) : (
+        <>
+          {" "}
+          — no diff vs <code>{discovery.baseBranch}</code> was available
+        </>
+      )}
+    </p>
   );
 }
 
 export function QaPlanReview({
   plan,
+  discovery,
   readOnly,
   loading,
   onApprove,
@@ -152,6 +204,8 @@ export function QaPlanReview({
   onAddJourneys,
 }: {
   plan: QaTestPlan;
+  /** Discovery the plan was based on — shows branch/diff provenance. */
+  discovery?: QaDiscovery;
   /** True when the plan is shown outside the review gate (no actions). */
   readOnly?: boolean;
   loading?: boolean;
@@ -200,6 +254,7 @@ export function QaPlanReview({
   );
 
   const enabledCount = plan.items.length - disabled.size;
+  const existingCount = items.filter((i) => i.existingTestId).length;
 
   const toggle = (id: string) => {
     setDisabled((prev) => {
@@ -233,6 +288,7 @@ export function QaPlanReview({
             </>
           )}
         </p>
+        {discovery && <AnalyzedCodeLine discovery={discovery} />}
       </CardHeader>
       <CardContent className="space-y-5">
         {plan.journeys.length > 0 && (
@@ -276,6 +332,8 @@ export function QaPlanReview({
             Coverage matrix{" "}
             <span className="text-xs font-normal text-muted-foreground">
               — one test can cover several groups in a single execution
+              {existingCount > 0 &&
+                ` · ${existingCount} of ${items.length} already covered by existing tests (marked "exists" — approving reuses them instead of generating duplicates)`}
             </span>
           </h4>
           <div className="rounded-md border overflow-x-auto">
@@ -363,6 +421,23 @@ export function QaPlanReview({
                               <GitBranch className="h-3 w-3" />
                               PR change
                             </Badge>
+                          )}
+                          {item.existingTestId && (
+                            <Link
+                              href={`/tests/${item.existingTestId}`}
+                              onClick={(e) => e.stopPropagation()}
+                              className="shrink-0"
+                              title={`Already covered by existing test: ${item.existingTestName ?? item.existingTestId}`}
+                            >
+                              <Badge
+                                variant="outline"
+                                className="text-[10px] px-1.5 gap-1 bg-success/10 text-success border-success/30"
+                              >
+                                <FileCheck className="h-3 w-3" />
+                                exists
+                                <ExternalLink className="h-2.5 w-2.5" />
+                              </Badge>
+                            </Link>
                           )}
                           {item.pagePath && (
                             <code className="text-[10px] text-muted-foreground">

--- a/src/components/qa-agent/qa-plan-review.tsx
+++ b/src/components/qa-agent/qa-plan-review.tsx
@@ -170,6 +170,14 @@ export function QaPlanReview({
                           <span className="font-medium truncate">
                             {item.title}
                           </span>
+                          {item.businessArea && (
+                            <Badge
+                              variant="outline"
+                              className="text-[10px] px-1.5 text-muted-foreground shrink-0"
+                            >
+                              {item.businessArea}
+                            </Badge>
+                          )}
                           {item.pagePath && (
                             <code className="text-[10px] text-muted-foreground">
                               {item.pagePath}

--- a/src/components/qa-agent/qa-plan-review.tsx
+++ b/src/components/qa-agent/qa-plan-review.tsx
@@ -22,6 +22,7 @@ import {
   Check,
   CheckCircle2,
   ClipboardList,
+  GitBranch,
   Loader2,
   MessageSquareWarning,
   Route,
@@ -119,6 +120,20 @@ function ItemDetailCard({
             {item.selectorHints.map((s) => (
               <code key={s} className="block text-[11px] break-all">
                 {s}
+              </code>
+            ))}
+          </div>
+        </div>
+      )}
+      {item.changeRefs && item.changeRefs.length > 0 && (
+        <div>
+          <div className="font-medium text-muted-foreground">
+            Covers branch changes
+          </div>
+          <div className="space-y-0.5">
+            {item.changeRefs.map((r) => (
+              <code key={r} className="block text-[11px] break-all">
+                {r}
               </code>
             ))}
           </div>
@@ -337,6 +352,16 @@ export function QaPlanReview({
                               className="text-[10px] px-1.5 text-muted-foreground shrink-0"
                             >
                               {item.businessArea}
+                            </Badge>
+                          )}
+                          {item.changeRefs && item.changeRefs.length > 0 && (
+                            <Badge
+                              variant="outline"
+                              className="text-[10px] px-1.5 shrink-0 gap-1 bg-info/10 text-info border-info/30"
+                              title={`Covers branch changes: ${item.changeRefs.join(", ")}`}
+                            >
+                              <GitBranch className="h-3 w-3" />
+                              PR change
                             </Badge>
                           )}
                           {item.pagePath && (

--- a/src/components/qa-agent/qa-plan-review.tsx
+++ b/src/components/qa-agent/qa-plan-review.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import type { QaTestGroup, QaTestPlan } from "@/lib/db/schema";
-import { QA_GROUPS } from "@/lib/qa-agent/plan";
+import type { QaTestPlan } from "@/lib/db/schema";
+import { itemGroups, QA_GROUPS } from "@/lib/qa-agent/plan";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Textarea } from "@/components/ui/textarea";
 import {
+  Check,
   CheckCircle2,
   ClipboardList,
   Loader2,
@@ -56,15 +57,23 @@ export function QaPlanReview({
   const [showFeedback, setShowFeedback] = useState(false);
 
   const items = plan.items;
-  const itemsByGroup = useMemo(() => {
-    const map = new Map<QaTestGroup, typeof items>();
-    for (const item of items) {
-      const list = map.get(item.group) ?? [];
-      list.push(item);
-      map.set(item.group, list);
-    }
-    return map;
-  }, [items]);
+  // Matrix axes: only groups that at least one item is tagged with become
+  // columns; rows are items sorted by business area then priority.
+  const presentGroups = useMemo(
+    () =>
+      QA_GROUPS.filter((g) => items.some((i) => itemGroups(i).includes(g.id))),
+    [items],
+  );
+  const sortedItems = useMemo(
+    () =>
+      [...items].sort((a, b) => {
+        const areaA = a.businessArea?.trim() || "General";
+        const areaB = b.businessArea?.trim() || "General";
+        if (areaA !== areaB) return areaA.localeCompare(areaB);
+        return a.priority.localeCompare(b.priority);
+      }),
+    [items],
+  );
 
   const enabledCount = plan.items.length - disabled.size;
 
@@ -138,38 +147,56 @@ export function QaPlanReview({
           </div>
         )}
 
-        <div className="space-y-3">
-          {QA_GROUPS.filter((g) => itemsByGroup.has(g.id)).map((group) => (
-            <div key={group.id} className="space-y-1.5">
-              <h4 className="text-sm font-medium">
-                {group.label}{" "}
-                <span className="text-xs font-normal text-muted-foreground">
-                  ({itemsByGroup.get(group.id)!.length})
-                </span>
-              </h4>
-              <div className="space-y-1">
-                {itemsByGroup.get(group.id)!.map((item) => {
+        <div className="space-y-1">
+          <h4 className="text-sm font-medium">
+            Coverage matrix{" "}
+            <span className="text-xs font-normal text-muted-foreground">
+              — one test can cover several groups in a single execution
+            </span>
+          </h4>
+          <div className="rounded-md border overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted/40">
+                  {!readOnly && <th className="w-8 px-2 py-1.5" />}
+                  <th className="text-left px-3 py-1.5 font-medium">Test</th>
+                  {presentGroups.map((g) => (
+                    <th
+                      key={g.id}
+                      className="text-center px-2 py-1.5 font-medium whitespace-nowrap"
+                      title={g.description}
+                    >
+                      {g.label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {sortedItems.map((item) => {
                   const isDisabled = disabled.has(item.id);
+                  const groups = itemGroups(item);
                   return (
-                    <label
+                    <tr
                       key={item.id}
-                      className={`flex items-start gap-2.5 rounded-md border p-2.5 text-sm ${
-                        readOnly ? "" : "cursor-pointer hover:bg-muted/50"
-                      } ${isDisabled ? "opacity-50" : ""}`}
+                      className={`${readOnly ? "" : "cursor-pointer hover:bg-muted/50"} ${
+                        isDisabled ? "opacity-50" : ""
+                      }`}
+                      onClick={readOnly ? undefined : () => toggle(item.id)}
                     >
                       {!readOnly && (
-                        <Checkbox
-                          checked={!isDisabled}
-                          onCheckedChange={() => toggle(item.id)}
-                          className="mt-0.5"
-                        />
+                        <td className="px-2 py-2 align-top">
+                          <Checkbox
+                            checked={!isDisabled}
+                            onCheckedChange={() => toggle(item.id)}
+                            onClick={(e) => e.stopPropagation()}
+                            className="mt-0.5"
+                          />
+                        </td>
                       )}
-                      <div className="min-w-0 flex-1 space-y-0.5">
+                      <td className="px-3 py-2 min-w-64">
                         <div className="flex items-center gap-2">
                           <PriorityBadge priority={item.priority} />
-                          <span className="font-medium truncate">
-                            {item.title}
-                          </span>
+                          <span className="font-medium">{item.title}</span>
                           {item.businessArea && (
                             <Badge
                               variant="outline"
@@ -187,13 +214,40 @@ export function QaPlanReview({
                         <div className="text-xs text-muted-foreground line-clamp-2 whitespace-pre-line">
                           {item.scenario}
                         </div>
-                      </div>
-                    </label>
+                      </td>
+                      {presentGroups.map((g) => {
+                        const covers = groups.includes(g.id);
+                        const primary = item.group === g.id;
+                        return (
+                          <td
+                            key={g.id}
+                            className="text-center px-2 py-2 align-middle"
+                            title={
+                              covers
+                                ? `${g.label}${primary ? " (primary)" : ""}`
+                                : undefined
+                            }
+                          >
+                            {covers ? (
+                              <Check
+                                className={`h-4 w-4 inline ${
+                                  primary ? "text-success" : "text-success/50"
+                                }`}
+                              />
+                            ) : (
+                              <span className="text-muted-foreground/40">
+                                —
+                              </span>
+                            )}
+                          </td>
+                        );
+                      })}
+                    </tr>
                   );
                 })}
-              </div>
-            </div>
-          ))}
+              </tbody>
+            </table>
+          </div>
         </div>
 
         {!readOnly && (

--- a/src/components/qa-agent/qa-plan-review.tsx
+++ b/src/components/qa-agent/qa-plan-review.tsx
@@ -25,6 +25,7 @@ import {
   Loader2,
   MessageSquareWarning,
   Route,
+  Sparkles,
   Target,
 } from "lucide-react";
 
@@ -133,6 +134,7 @@ export function QaPlanReview({
   loading,
   onApprove,
   onRequestChanges,
+  onAddJourneys,
 }: {
   plan: QaTestPlan;
   /** True when the plan is shown outside the review gate (no actions). */
@@ -140,6 +142,9 @@ export function QaPlanReview({
   loading?: boolean;
   onApprove?: (disabledItemIds: string[]) => void;
   onRequestChanges?: (feedback: string) => void;
+  /** Refine the reviewer's own plain-language journeys and merge them in.
+   *  Resolves true when the merge succeeded (drives the panel reset). */
+  onAddJourneys?: (journeysText: string) => Promise<boolean>;
 }) {
   const [disabled, setDisabled] = useState<Set<string>>(
     () =>
@@ -147,6 +152,18 @@ export function QaPlanReview({
   );
   const [feedback, setFeedback] = useState("");
   const [showFeedback, setShowFeedback] = useState(false);
+  const [journeysText, setJourneysText] = useState("");
+  const [showJourneys, setShowJourneys] = useState(false);
+
+  // Refine + merge the reviewer's journeys, then collapse/clear the panel only
+  // when the merge succeeded (on failure the text is kept so they can retry).
+  const submitJourneys = async () => {
+    const ok = await onAddJourneys?.(journeysText.trim());
+    if (ok) {
+      setShowJourneys(false);
+      setJourneysText("");
+    }
+  };
 
   const items = plan.items;
   // Matrix axes: only groups that at least one item is tagged with become
@@ -400,8 +417,46 @@ export function QaPlanReview({
                   </Button>
                 </div>
               </div>
+            ) : showJourneys ? (
+              <div className="space-y-2">
+                <p className="text-xs text-muted-foreground">
+                  Describe the user journeys you care about, one per line. The
+                  AI refines each into a grounded test and adds it to the plan
+                  above — your existing tests and choices are kept.
+                </p>
+                <Textarea
+                  placeholder={
+                    "One journey per line, e.g.\nA user records a flow and sees the diff approved\nAn admin invites a teammate who then signs in\nA user creates a test suite and runs it"
+                  }
+                  value={journeysText}
+                  onChange={(e) => setJourneysText(e.target.value)}
+                  rows={4}
+                />
+                <div className="flex gap-2">
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    disabled={loading || !journeysText.trim()}
+                    onClick={submitJourneys}
+                  >
+                    {loading ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <Sparkles className="h-3.5 w-3.5" />
+                    )}
+                    Refine &amp; add
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => setShowJourneys(false)}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
             ) : (
-              <div className="flex items-center gap-2">
+              <div className="flex flex-wrap items-center gap-2">
                 <Button
                   size="sm"
                   disabled={loading || enabledCount === 0}
@@ -414,6 +469,17 @@ export function QaPlanReview({
                   )}
                   Approve {enabledCount} test{enabledCount === 1 ? "" : "s"}
                 </Button>
+                {onAddJourneys && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={loading}
+                    onClick={() => setShowJourneys(true)}
+                  >
+                    <Sparkles className="h-3.5 w-3.5" />
+                    Add journeys
+                  </Button>
+                )}
                 <Button
                   size="sm"
                   variant="outline"

--- a/src/components/qa-agent/qa-results-panel.tsx
+++ b/src/components/qa-agent/qa-results-panel.tsx
@@ -182,7 +182,8 @@ export function QaSummaryPanel({
               Coverage matrix{" "}
               <span className="text-xs font-normal text-muted-foreground">
                 — business area × test group (covered+generated / planned, ✓
-                passing this run)
+                passing this run; a multi-group test counts in every column it
+                covers)
               </span>
             </h4>
             <div className="rounded-md border overflow-x-auto">

--- a/src/components/qa-agent/qa-results-panel.tsx
+++ b/src/components/qa-agent/qa-results-panel.tsx
@@ -450,20 +450,64 @@ export function QaSummaryPanel({
 
         {groupRows.length > 0 && (
           <div className="space-y-1">
-            <h4 className="text-sm font-medium">By group</h4>
+            <h4 className="text-sm font-medium">
+              By group{" "}
+              <span className="text-xs font-normal text-muted-foreground">
+                — covered+generated / planned (a multi-group test counts in
+                every group it covers, so these rows sum higher than the totals
+                above)
+              </span>
+            </h4>
             <div className="rounded-md border divide-y">
               {groupRows.map((group) => {
                 const row = summary.byGroup[group.id]!;
+                const covered = row.covered ?? 0;
+                const done = covered + row.generated;
+                const gap = Math.max(0, row.planned - done);
+                const complete = gap === 0;
+                const composition = [
+                  covered > 0 && `${covered} existing`,
+                  row.generated > 0 && `${row.generated} new`,
+                  row.passed > 0 && `${row.passed} passing`,
+                ]
+                  .filter(Boolean)
+                  .join(" · ");
                 return (
                   <div
                     key={group.id}
-                    className="flex items-center justify-between px-3 py-1.5 text-sm"
+                    className="flex items-center justify-between gap-2 px-3 py-1.5 text-sm"
                   >
                     <span>{group.label}</span>
-                    <span className="text-muted-foreground text-xs">
-                      {(row.covered ?? 0) > 0 && `${row.covered} covered · `}
-                      {row.generated}/{row.planned} generated · {row.passed}{" "}
-                      passing
+                    <span className="flex items-center gap-2 text-xs">
+                      {composition && (
+                        <span className="text-muted-foreground">
+                          {composition}
+                        </span>
+                      )}
+                      <span
+                        className={`font-medium ${
+                          complete ? "text-success" : "text-warning"
+                        }`}
+                        title={
+                          complete
+                            ? "Fully covered — existing tests satisfy the rest, so nothing needed generating"
+                            : `${gap} planned ${gap === 1 ? "test" : "tests"} not yet covered or generated`
+                        }
+                      >
+                        {done}/{row.planned}
+                      </span>
+                      {gap > 0 && onRequestCoverage && (
+                        <button
+                          type="button"
+                          className="inline-flex items-center gap-1 rounded border border-warning/40 px-1.5 py-0.5 text-warning hover:bg-warning/10 disabled:opacity-50"
+                          title={`Plan & generate ${gap} more ${gap === 1 ? "test" : "tests"} to complete ${group.label} coverage`}
+                          disabled={requestPending}
+                          onClick={() => onRequestCoverage({ group: group.id })}
+                        >
+                          <Plus className="h-3 w-3" />
+                          Plan &amp; generate
+                        </button>
+                      )}
                     </span>
                   </div>
                 );

--- a/src/components/qa-agent/qa-results-panel.tsx
+++ b/src/components/qa-agent/qa-results-panel.tsx
@@ -13,6 +13,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   CheckCircle2,
   ExternalLink,
+  FileCheck,
   FileCode,
   Loader2,
   Wrench,
@@ -37,6 +38,11 @@ const STATUS_META: Record<
     label: "Gen failed",
     className: "bg-destructive/10 text-destructive border-destructive/30",
     icon: XCircle,
+  },
+  covered: {
+    label: "Covered",
+    className: "bg-info/10 text-info border-info/30",
+    icon: FileCheck,
   },
   passed: {
     label: "Passed",
@@ -149,12 +155,19 @@ export function QaSummaryPanel({
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
           {[
             { label: "Planned", value: summary.planned },
+            { label: "Covered", value: summary.covered ?? 0 },
             { label: "Generated", value: summary.generated },
             { label: "Passing", value: summary.passed },
-            { label: "Healed", value: summary.healed },
+            {
+              label: "Gaps",
+              value: Math.max(
+                0,
+                summary.planned - (summary.covered ?? 0) - summary.generated,
+              ),
+            },
           ].map((stat) => (
             <div key={stat.label} className="rounded-md border p-3 text-center">
               <div className="text-2xl font-semibold">{stat.value}</div>
@@ -176,6 +189,7 @@ export function QaSummaryPanel({
                   >
                     <span>{group.label}</span>
                     <span className="text-muted-foreground text-xs">
+                      {(row.covered ?? 0) > 0 && `${row.covered} covered · `}
                       {row.generated}/{row.planned} generated · {row.passed}{" "}
                       passing
                     </span>

--- a/src/components/qa-agent/qa-results-panel.tsx
+++ b/src/components/qa-agent/qa-results-panel.tsx
@@ -9,7 +9,9 @@ import type {
   QaTestPlan,
 } from "@/lib/db/schema";
 import { QA_GROUPS } from "@/lib/qa-agent/plan";
+import { timeAgo } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   CheckCircle2,
@@ -18,10 +20,20 @@ import {
   FileCheck,
   FileCode,
   GitBranch,
+  LayoutDashboard,
   Loader2,
+  Plus,
+  TrendingUp,
   Wrench,
   XCircle,
 } from "lucide-react";
+
+/** Hint passed to the "ask the agent to increase coverage" CTAs — a specific
+ *  matrix gap (area × group) or blank for a general fill-gaps request. */
+export interface CoverageRequestHint {
+  area?: string;
+  group?: QaTestGroup;
+}
 
 const STATUS_META: Record<
   QaGeneratedTest["status"],
@@ -258,17 +270,59 @@ function QaPrCoverageSection({
 export function QaSummaryPanel({
   summary,
   plan,
+  persistent = false,
+  updatedAt,
+  onRequestCoverage,
+  requestPending = false,
 }: {
   summary: QaSummaryData;
   plan: QaTestPlan | undefined;
+  /** Render as the always-current coverage dashboard (vs a per-run summary). */
+  persistent?: boolean;
+  /** When the summary was produced (persistent framing). */
+  updatedAt?: Date | string | null;
+  /** Queue an "increase coverage" task for the agent — header button and
+   *  per-gap-cell CTAs render only when provided. */
+  onRequestCoverage?: (hint: CoverageRequestHint) => void;
+  requestPending?: boolean;
 }) {
   const groupRows = QA_GROUPS.filter((g) => summary.byGroup[g.id]);
+  const gaps = Math.max(
+    0,
+    summary.planned - (summary.covered ?? 0) - summary.generated,
+  );
   return (
     <Card>
       <CardHeader className="pb-3">
         <CardTitle className="flex items-center gap-2 text-base">
-          <CheckCircle2 className="h-4 w-4" />
-          Coverage summary
+          {persistent ? (
+            <LayoutDashboard className="h-4 w-4" />
+          ) : (
+            <CheckCircle2 className="h-4 w-4" />
+          )}
+          {persistent ? "Coverage dashboard" : "Coverage summary"}
+          {persistent && updatedAt && (
+            <span className="text-xs font-normal text-muted-foreground">
+              — updated {timeAgo(new Date(updatedAt))}
+            </span>
+          )}
+          {onRequestCoverage && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="ml-auto"
+              disabled={requestPending}
+              title={
+                gaps > 0
+                  ? `Queue a task to close the ${gaps} remaining gap${gaps === 1 ? "" : "s"}`
+                  : "Queue a task to broaden coverage"
+              }
+              onClick={() => onRequestCoverage({})}
+            >
+              <TrendingUp className="h-3.5 w-3.5" />
+              Increase coverage
+            </Button>
+          )}
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -369,6 +423,19 @@ export function QaSummaryPanel({
                                 {" "}
                                 {cell.passed}✓
                               </span>
+                            )}
+                            {hasGap && onRequestCoverage && (
+                              <button
+                                type="button"
+                                className="ml-1 inline-flex align-[-2px] rounded border border-warning/40 text-warning hover:bg-warning/10 disabled:opacity-50"
+                                title={`Ask the agent to cover the ${area} × ${g.label} gap`}
+                                disabled={requestPending}
+                                onClick={() =>
+                                  onRequestCoverage({ area, group: g.id })
+                                }
+                              >
+                                <Plus className="h-3 w-3" />
+                              </button>
                             )}
                           </td>
                         );

--- a/src/components/qa-agent/qa-results-panel.tsx
+++ b/src/components/qa-agent/qa-results-panel.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import Link from "next/link";
+import type {
+  QaGeneratedTest,
+  QaSummaryData,
+  QaTestGroup,
+  QaTestPlan,
+} from "@/lib/db/schema";
+import { QA_GROUPS } from "@/lib/qa-agent/plan";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  CheckCircle2,
+  ExternalLink,
+  FileCode,
+  Loader2,
+  Wrench,
+  XCircle,
+} from "lucide-react";
+
+const STATUS_META: Record<
+  QaGeneratedTest["status"],
+  { label: string; className: string; icon: typeof CheckCircle2 }
+> = {
+  generating: {
+    label: "Generating",
+    className: "bg-info/10 text-info border-info/30",
+    icon: Loader2,
+  },
+  generated: {
+    label: "Generated",
+    className: "bg-muted text-muted-foreground border-border",
+    icon: FileCode,
+  },
+  generation_failed: {
+    label: "Gen failed",
+    className: "bg-destructive/10 text-destructive border-destructive/30",
+    icon: XCircle,
+  },
+  passed: {
+    label: "Passed",
+    className: "bg-success/10 text-success border-success/30",
+    icon: CheckCircle2,
+  },
+  failed: {
+    label: "Failed",
+    className: "bg-destructive/10 text-destructive border-destructive/30",
+    icon: XCircle,
+  },
+  healed: {
+    label: "Healed",
+    className: "bg-success/10 text-success border-success/30",
+    icon: Wrench,
+  },
+};
+
+export function QaGeneratedTestsPanel({
+  generated,
+}: {
+  generated: QaGeneratedTest[];
+}) {
+  if (generated.length === 0) return null;
+  const byGroup = new Map<QaTestGroup, QaGeneratedTest[]>();
+  for (const test of generated) {
+    const list = byGroup.get(test.group) ?? [];
+    list.push(test);
+    byGroup.set(test.group, list);
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <FileCode className="h-4 w-4" />
+          Generated tests
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {QA_GROUPS.filter((g) => byGroup.has(g.id)).map((group) => (
+          <div key={group.id} className="space-y-1.5">
+            <h4 className="text-sm font-medium">
+              {group.label}{" "}
+              <span className="text-xs font-normal text-muted-foreground">
+                ({byGroup.get(group.id)!.length})
+              </span>
+            </h4>
+            <div className="space-y-1">
+              {byGroup.get(group.id)!.map((test) => {
+                const meta = STATUS_META[test.status];
+                const Icon = meta.icon;
+                return (
+                  <div
+                    key={test.planItemId}
+                    className="flex items-center gap-2 rounded-md border px-2.5 py-1.5 text-sm"
+                  >
+                    <Badge
+                      variant="outline"
+                      className={`text-[10px] px-1.5 shrink-0 gap-1 ${meta.className}`}
+                    >
+                      <Icon
+                        className={`h-3 w-3 ${test.status === "generating" ? "animate-spin" : ""}`}
+                      />
+                      {meta.label}
+                    </Badge>
+                    <span className="truncate flex-1">{test.name}</span>
+                    {test.error && (
+                      <span
+                        className="text-xs text-destructive truncate max-w-[200px]"
+                        title={test.error}
+                      >
+                        {test.error}
+                      </span>
+                    )}
+                    {test.testId && (
+                      <Link
+                        href={`/tests/${test.testId}`}
+                        className="text-muted-foreground hover:text-foreground shrink-0"
+                        title="Open test"
+                      >
+                        <ExternalLink className="h-3.5 w-3.5" />
+                      </Link>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function QaSummaryPanel({
+  summary,
+  plan,
+}: {
+  summary: QaSummaryData;
+  plan: QaTestPlan | undefined;
+}) {
+  const groupRows = QA_GROUPS.filter((g) => summary.byGroup[g.id]);
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <CheckCircle2 className="h-4 w-4" />
+          Coverage summary
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          {[
+            { label: "Planned", value: summary.planned },
+            { label: "Generated", value: summary.generated },
+            { label: "Passing", value: summary.passed },
+            { label: "Healed", value: summary.healed },
+          ].map((stat) => (
+            <div key={stat.label} className="rounded-md border p-3 text-center">
+              <div className="text-2xl font-semibold">{stat.value}</div>
+              <div className="text-xs text-muted-foreground">{stat.label}</div>
+            </div>
+          ))}
+        </div>
+
+        {groupRows.length > 0 && (
+          <div className="space-y-1">
+            <h4 className="text-sm font-medium">By group</h4>
+            <div className="rounded-md border divide-y">
+              {groupRows.map((group) => {
+                const row = summary.byGroup[group.id]!;
+                return (
+                  <div
+                    key={group.id}
+                    className="flex items-center justify-between px-3 py-1.5 text-sm"
+                  >
+                    <span>{group.label}</span>
+                    <span className="text-muted-foreground text-xs">
+                      {row.generated}/{row.planned} generated · {row.passed}{" "}
+                      passing
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {plan && plan.journeys.length > 0 && (
+          <div className="space-y-1">
+            <h4 className="text-sm font-medium">Journey traceability</h4>
+            <div className="rounded-md border divide-y">
+              {plan.journeys.map((journey) => {
+                const testIds = summary.journeyCoverage[journey.id] ?? [];
+                return (
+                  <div
+                    key={journey.id}
+                    className="flex items-center justify-between px-3 py-1.5 text-sm gap-2"
+                  >
+                    <span className="truncate">{journey.title}</span>
+                    <span
+                      className={`text-xs shrink-0 ${testIds.length > 0 ? "text-success" : "text-warning"}`}
+                    >
+                      {testIds.length > 0
+                        ? `${testIds.length} test${testIds.length === 1 ? "" : "s"}`
+                        : "uncovered"}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/qa-agent/qa-results-panel.tsx
+++ b/src/components/qa-agent/qa-results-panel.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import type {
   QaGeneratedTest,
+  QaPrCoverageEntry,
   QaSummaryData,
   QaTestGroup,
   QaTestPlan,
@@ -12,9 +13,11 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   CheckCircle2,
+  CircleDashed,
   ExternalLink,
   FileCheck,
   FileCode,
+  GitBranch,
   Loader2,
   Wrench,
   XCircle,
@@ -138,6 +141,120 @@ export function QaGeneratedTestsPanel({
   );
 }
 
+const PR_STATUS_META: Record<
+  QaPrCoverageEntry["status"],
+  { label: string; className: string; icon: typeof CheckCircle2 }
+> = {
+  passed: {
+    label: "Passing",
+    className: "bg-success/10 text-success border-success/30",
+    icon: CheckCircle2,
+  },
+  covered: {
+    label: "Covered",
+    className: "bg-info/10 text-info border-info/30",
+    icon: FileCheck,
+  },
+  generated: {
+    label: "Test created",
+    className: "bg-info/10 text-info border-info/30",
+    icon: FileCode,
+  },
+  planned: {
+    label: "Planned only",
+    className: "bg-warning/10 text-warning border-warning/30",
+    icon: CircleDashed,
+  },
+  uncovered: {
+    label: "Uncovered",
+    className: "bg-destructive/10 text-destructive border-destructive/30",
+    icon: XCircle,
+  },
+};
+
+const PR_CHANGE_LABEL: Record<QaPrCoverageEntry["change"], string> = {
+  added: "new",
+  modified: "changed",
+  removed: "removed",
+};
+
+/** Per-change coverage of the branch diff — which functions/endpoints the
+ *  working branch touched and whether a test now exercises each one. */
+function QaPrCoverageSection({
+  prCoverage,
+}: {
+  prCoverage: NonNullable<QaSummaryData["prCoverage"]>;
+}) {
+  if (prCoverage.entries.length === 0) return null;
+  const total = prCoverage.entries.length;
+  return (
+    <div className="space-y-1">
+      <h4 className="flex items-center gap-1.5 text-sm font-medium">
+        <GitBranch className="h-3.5 w-3.5" />
+        Branch changes coverage{" "}
+        <span className="text-xs font-normal text-muted-foreground">
+          — <code>{prCoverage.headBranch}</code> vs{" "}
+          <code>{prCoverage.baseBranch}</code>:{" "}
+          <span
+            className={
+              prCoverage.coveredCount === total
+                ? "text-success"
+                : "text-warning"
+            }
+          >
+            {prCoverage.coveredCount}/{total}
+          </span>{" "}
+          changed functions & endpoints have tests
+        </span>
+      </h4>
+      <div className="rounded-md border divide-y">
+        {prCoverage.entries.map((entry) => {
+          const meta = PR_STATUS_META[entry.status];
+          const Icon = meta.icon;
+          return (
+            <div
+              key={`${entry.kind}:${entry.ref}`}
+              className="flex items-center gap-2 px-3 py-1.5 text-sm"
+            >
+              <Badge
+                variant="outline"
+                className={`text-[10px] px-1.5 shrink-0 gap-1 ${meta.className}`}
+              >
+                <Icon className="h-3 w-3" />
+                {meta.label}
+              </Badge>
+              <code className="truncate text-xs">{entry.ref}</code>
+              <span className="text-[10px] text-muted-foreground shrink-0">
+                {PR_CHANGE_LABEL[entry.change]}{" "}
+                {entry.kind === "endpoint" ? "endpoint" : "function"}
+              </span>
+              <span
+                className="ml-auto truncate text-[10px] text-muted-foreground max-w-[220px]"
+                title={entry.file}
+              >
+                {entry.file}
+              </span>
+              {entry.testIds[0] && (
+                <Link
+                  href={`/tests/${entry.testIds[0]}`}
+                  className="text-muted-foreground hover:text-foreground shrink-0"
+                  title={
+                    entry.testIds.length > 1
+                      ? `Open test (1 of ${entry.testIds.length})`
+                      : "Open test"
+                  }
+                >
+                  <ExternalLink className="h-3.5 w-3.5" />
+                </Link>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 export function QaSummaryPanel({
   summary,
   plan,
@@ -175,6 +292,10 @@ export function QaSummaryPanel({
             </div>
           ))}
         </div>
+
+        {summary.prCoverage && (
+          <QaPrCoverageSection prCoverage={summary.prCoverage} />
+        )}
 
         {summary.matrix && Object.keys(summary.matrix).length > 0 && (
           <div className="space-y-1">

--- a/src/components/qa-agent/qa-results-panel.tsx
+++ b/src/components/qa-agent/qa-results-panel.tsx
@@ -176,6 +176,89 @@ export function QaSummaryPanel({
           ))}
         </div>
 
+        {summary.matrix && Object.keys(summary.matrix).length > 0 && (
+          <div className="space-y-1">
+            <h4 className="text-sm font-medium">
+              Coverage matrix{" "}
+              <span className="text-xs font-normal text-muted-foreground">
+                — business area × test group (covered+generated / planned, ✓
+                passing this run)
+              </span>
+            </h4>
+            <div className="rounded-md border overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b bg-muted/40">
+                    <th className="text-left px-3 py-1.5 font-medium">
+                      Business area
+                    </th>
+                    {QA_GROUPS.filter((g) =>
+                      Object.values(summary.matrix!).some((row) => row[g.id]),
+                    ).map((g) => (
+                      <th
+                        key={g.id}
+                        className="text-center px-2 py-1.5 font-medium whitespace-nowrap"
+                        title={g.description}
+                      >
+                        {g.label}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className="divide-y">
+                  {Object.entries(summary.matrix).map(([area, row]) => (
+                    <tr key={area}>
+                      <td className="px-3 py-1.5 font-medium whitespace-nowrap">
+                        {area}
+                      </td>
+                      {QA_GROUPS.filter((g) =>
+                        Object.values(summary.matrix!).some((r) => r[g.id]),
+                      ).map((g) => {
+                        const cell = row[g.id];
+                        if (!cell || cell.planned === 0) {
+                          return (
+                            <td
+                              key={g.id}
+                              className="text-center px-2 py-1.5 text-muted-foreground/40"
+                            >
+                              —
+                            </td>
+                          );
+                        }
+                        const done = cell.covered + cell.generated;
+                        const complete =
+                          cell.covered + cell.passed === cell.planned;
+                        const hasGap = done < cell.planned;
+                        return (
+                          <td
+                            key={g.id}
+                            className={`text-center px-2 py-1.5 whitespace-nowrap ${
+                              complete
+                                ? "text-success"
+                                : hasGap
+                                  ? "text-warning"
+                                  : ""
+                            }`}
+                            title={`planned ${cell.planned} · covered ${cell.covered} · generated ${cell.generated} · passing ${cell.passed}`}
+                          >
+                            {done}/{cell.planned}
+                            {cell.passed > 0 && (
+                              <span className="text-xs text-success">
+                                {" "}
+                                {cell.passed}✓
+                              </span>
+                            )}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
         {groupRows.length > 0 && (
           <div className="space-y-1">
             <h4 className="text-sm font-medium">By group</h4>

--- a/src/components/qa-agent/qa-results-panel.tsx
+++ b/src/components/qa-agent/qa-results-panel.tsx
@@ -190,7 +190,7 @@ export function QaSummaryPanel({
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b bg-muted/40">
-                    <th className="text-left px-3 py-1.5 font-medium">
+                    <th className="w-full text-left px-3 py-1.5 font-medium">
                       Business area
                     </th>
                     {QA_GROUPS.filter((g) =>
@@ -198,10 +198,10 @@ export function QaSummaryPanel({
                     ).map((g) => (
                       <th
                         key={g.id}
-                        className="text-center px-2 py-1.5 font-medium whitespace-nowrap"
-                        title={g.description}
+                        className="w-14 text-center px-1.5 py-1.5 font-medium text-xs whitespace-nowrap"
+                        title={`${g.label} — ${g.description}`}
                       >
-                        {g.label}
+                        {g.short}
                       </th>
                     ))}
                   </tr>

--- a/src/components/qa-agent/qa-run-history.tsx
+++ b/src/components/qa-agent/qa-run-history.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useState } from "react";
+import type { AgentSession, QaSessionTrigger } from "@/lib/db/schema";
+import { timeAgo } from "@/lib/utils";
+import { PhaseTimeline } from "./qa-phase-timeline";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Ban,
+  Bot,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  History,
+  ListTodo,
+  Loader2,
+  Play,
+  Plug,
+  RotateCcw,
+  UserRound,
+  XCircle,
+} from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Run history — every run collapsed to a headline, expandable, re-runnable
+// ---------------------------------------------------------------------------
+
+const STATUS_ICON: Record<
+  AgentSession["status"],
+  { icon: typeof CheckCircle2; className: string; spin?: boolean }
+> = {
+  active: { icon: Loader2, className: "text-info", spin: true },
+  paused: { icon: UserRound, className: "text-warning" },
+  completed: { icon: CheckCircle2, className: "text-success" },
+  failed: { icon: XCircle, className: "text-destructive" },
+  cancelled: { icon: Ban, className: "text-muted-foreground" },
+};
+
+const TRIGGER_META: Record<
+  QaSessionTrigger,
+  { label: string; icon: typeof UserRound }
+> = {
+  manual: { label: "manual", icon: UserRound },
+  task: { label: "task", icon: ListTodo },
+  rerun: { label: "re-run", icon: RotateCcw },
+  schedule: { label: "schedule", icon: History },
+  pr: { label: "PR", icon: Play },
+  mcp: { label: "via MCP", icon: Plug },
+};
+
+const MODE_LABEL: Record<string, string> = {
+  full: "full",
+  refresh_spec: "spec refresh",
+  fill_gaps: "fill gaps",
+};
+
+/** One-line outcome for a collapsed run row. */
+function headline(session: AgentSession): string {
+  const s = session.metadata.qaSummary;
+  if (session.status === "completed" && s) {
+    const parts = [`${s.planned} planned`];
+    if (s.covered > 0) parts.push(`${s.covered} covered`);
+    if (s.generated > 0) parts.push(`${s.generated} generated`);
+    parts.push(`${s.passed} passing`);
+    return parts.join(" · ");
+  }
+  if (session.status === "completed") return "Completed";
+  if (session.status === "cancelled") return "Cancelled";
+  if (session.status === "failed") {
+    const step = session.steps.find((st) => st.status === "failed");
+    return step ? `Failed at ${step.label}` : "Failed";
+  }
+  const current = session.steps.find(
+    (st) => st.status === "active" || st.status === "waiting_user",
+  );
+  return current ? `Running — ${current.label}` : "Running";
+}
+
+function durationOf(session: AgentSession): string | null {
+  if (!session.createdAt || !session.completedAt) return null;
+  const ms =
+    new Date(session.completedAt).getTime() -
+    new Date(session.createdAt).getTime();
+  if (ms <= 0) return null;
+  const mins = Math.round(ms / 60000);
+  if (mins < 1) return "<1m";
+  if (mins < 60) return `${mins}m`;
+  return `${Math.floor(mins / 60)}h ${mins % 60}m`;
+}
+
+function RunRow({
+  session,
+  isLive,
+  loading,
+  onRerun,
+}: {
+  session: AgentSession;
+  /** This row is the currently-running session (shown expanded above). */
+  isLive: boolean;
+  loading: boolean;
+  onRerun: (sessionId: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const status = STATUS_ICON[session.status];
+  const StatusIcon = status.icon;
+  const trigger = TRIGGER_META[session.metadata.qaTrigger ?? "manual"];
+  const TriggerIcon = trigger.icon;
+  const duration = durationOf(session);
+
+  return (
+    <div className="text-sm">
+      <div className="flex items-center gap-2 px-3 py-2">
+        <button
+          type="button"
+          className="flex items-center gap-2 min-w-0 flex-1 text-left group"
+          onClick={() => setExpanded((v) => !v)}
+        >
+          {expanded ? (
+            <ChevronDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          )}
+          <StatusIcon
+            className={`h-4 w-4 shrink-0 ${status.className} ${status.spin ? "animate-spin" : ""}`}
+          />
+          <span className="min-w-0 truncate group-hover:underline underline-offset-2">
+            {headline(session)}
+          </span>
+        </button>
+        <Badge variant="outline" className="text-[10px] px-1.5 shrink-0">
+          {MODE_LABEL[session.metadata.qaMode ?? "full"]}
+        </Badge>
+        <Badge
+          variant="outline"
+          className="text-[10px] px-1.5 gap-1 shrink-0 text-muted-foreground"
+          title={`Triggered by ${trigger.label}`}
+        >
+          <TriggerIcon className="h-3 w-3" />
+          {trigger.label}
+        </Badge>
+        {isLive && (
+          <Badge className="text-[10px] px-1.5 shrink-0 bg-info/15 text-info border-info/30">
+            live
+          </Badge>
+        )}
+        <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
+          {duration && `${duration} · `}
+          {timeAgo(session.createdAt)}
+        </span>
+        {!isLive && (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 px-2 shrink-0"
+            title="Re-run with the same configuration"
+            disabled={loading}
+            onClick={() => onRerun(session.id)}
+          >
+            <RotateCcw className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+      {expanded && (
+        <div className="px-3 pb-3 animate-in fade-in slide-in-from-top-1 duration-200">
+          <div className="rounded-md border bg-muted/20 p-3 space-y-2">
+            <div className="text-xs text-muted-foreground truncate flex items-center gap-1.5">
+              <Bot className="h-3.5 w-3.5 shrink-0" />
+              {session.metadata.qaTargetUrl}
+              {(session.metadata.qaDocs?.length ?? 0) > 0 &&
+                ` · ${session.metadata.qaDocs!.length} doc${
+                  session.metadata.qaDocs!.length === 1 ? "" : "s"
+                }`}
+            </div>
+            <PhaseTimeline session={session} bare />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function QaRunHistory({
+  sessions,
+  liveSessionId,
+  loading,
+  onRerun,
+}: {
+  sessions: AgentSession[];
+  liveSessionId: string | null;
+  loading: boolean;
+  onRerun: (sessionId: string) => void;
+}) {
+  if (sessions.length === 0) return null;
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <History className="h-4 w-4" />
+          Runs
+          <span className="text-xs font-normal text-muted-foreground">
+            — every run collapses to a headline; expand for the step trail, or
+            re-run it with the same configuration
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <div className="rounded-md border divide-y">
+          {sessions.map((session) => (
+            <RunRow
+              key={session.id}
+              session={session}
+              isLive={session.id === liveSessionId}
+              loading={loading}
+              onRerun={onRerun}
+            />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/qa-agent/qa-task-board.tsx
+++ b/src/components/qa-agent/qa-task-board.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useState } from "react";
+import type { QaTask, QaTaskStatus } from "@/lib/db/schema";
+import { timeAgo } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  AlertTriangle,
+  Bot,
+  CheckCircle2,
+  CircleDashed,
+  Crosshair,
+  ListTodo,
+  Loader2,
+  Plug,
+  Plus,
+  RotateCcw,
+  UserRound,
+  X,
+} from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Direction queue — drop ideas for the agent; it replies when done
+// ---------------------------------------------------------------------------
+
+type ColumnId = "queued" | "working" | "needs_input" | "done";
+
+const COLUMNS: Array<{
+  id: ColumnId;
+  label: string;
+  icon: typeof ListTodo;
+  statuses: QaTaskStatus[];
+}> = [
+  { id: "queued", label: "Queued", icon: CircleDashed, statuses: ["queued"] },
+  { id: "working", label: "Working", icon: Loader2, statuses: ["working"] },
+  {
+    id: "needs_input",
+    label: "Waiting on you",
+    icon: UserRound,
+    statuses: ["needs_input"],
+  },
+  {
+    id: "done",
+    label: "Done",
+    icon: CheckCircle2,
+    statuses: ["done", "cancelled"],
+  },
+];
+
+function SourceChip({ task }: { task: QaTask }) {
+  if (task.source === "coverage_gap") {
+    return (
+      <Badge
+        variant="outline"
+        className="text-[10px] px-1.5 gap-1 bg-warning/10 text-warning border-warning/30"
+      >
+        <Crosshair className="h-3 w-3" />
+        coverage
+      </Badge>
+    );
+  }
+  if (task.source === "mcp") {
+    return (
+      <Badge
+        variant="outline"
+        className="text-[10px] px-1.5 gap-1 bg-info/10 text-info border-info/30"
+        title={task.createdByName ?? undefined}
+      >
+        <Plug className="h-3 w-3" />
+        via MCP
+      </Badge>
+    );
+  }
+  return (
+    <Badge
+      variant="outline"
+      className="text-[10px] px-1.5 gap-1 text-muted-foreground"
+      title={task.createdByName ?? undefined}
+    >
+      <UserRound className="h-3 w-3" />
+      {task.createdByName?.split(/[@\s]/)[0] ?? "you"}
+    </Badge>
+  );
+}
+
+function TaskCard({
+  task,
+  pending,
+  onRetry,
+  onDrop,
+}: {
+  task: QaTask;
+  pending: boolean;
+  onRetry: (id: string) => void;
+  onDrop: (id: string) => void;
+}) {
+  const cancelled = task.status === "cancelled";
+  return (
+    <div
+      className={`rounded-md border bg-card p-2.5 space-y-1.5 text-sm animate-in fade-in slide-in-from-bottom-2 duration-300 ${
+        cancelled ? "opacity-60" : ""
+      } ${task.status === "working" ? "border-info/40 shadow-sm" : ""}`}
+    >
+      <div className="flex items-start gap-2">
+        <span className={`min-w-0 flex-1 ${cancelled ? "line-through" : ""}`}>
+          {task.title}
+        </span>
+        {(task.status === "queued" ||
+          task.status === "working" ||
+          task.status === "needs_input") && (
+          <button
+            type="button"
+            className="text-muted-foreground hover:text-destructive shrink-0"
+            title={
+              task.status === "working"
+                ? "Cancel this task and its run"
+                : "Cancel task"
+            }
+            disabled={pending}
+            onClick={() => onDrop(task.id)}
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+      {task.description && (
+        <p className="text-xs text-muted-foreground line-clamp-3">
+          {task.description}
+        </p>
+      )}
+      <div className="flex items-center gap-1.5 flex-wrap">
+        <SourceChip task={task} />
+        {task.status === "working" && (
+          <span className="flex items-center gap-1 text-[11px] text-info">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            agent working…
+          </span>
+        )}
+        <span className="ml-auto text-[10px] text-muted-foreground">
+          {timeAgo(
+            task.status === "done" || task.status === "cancelled"
+              ? (task.completedAt ?? task.createdAt)
+              : task.createdAt,
+          )}
+        </span>
+      </div>
+      {task.agentReply && (
+        <div className="flex items-start gap-1.5 rounded border bg-muted/40 p-1.5 text-xs animate-in fade-in duration-500">
+          <Bot className="h-3.5 w-3.5 mt-0.5 shrink-0 text-primary" />
+          <span className="min-w-0">{task.agentReply}</span>
+        </div>
+      )}
+      {task.status === "needs_input" && (
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-7 text-xs"
+          disabled={pending}
+          onClick={() => onRetry(task.id)}
+        >
+          <RotateCcw className="h-3 w-3" />
+          Retry
+        </Button>
+      )}
+    </div>
+  );
+}
+
+export function QaTaskBoard({
+  tasks,
+  pending,
+  error,
+  onAdd,
+  onRetry,
+  onDrop,
+}: {
+  tasks: QaTask[];
+  pending: boolean;
+  error: string | null;
+  onAdd: (
+    title: string,
+    opts?: { source?: "user" | "coverage_gap" },
+  ) => Promise<boolean>;
+  onRetry: (id: string) => void;
+  onDrop: (id: string) => void;
+}) {
+  const [draft, setDraft] = useState("");
+
+  const submit = async () => {
+    const title = draft.trim();
+    if (!title) return;
+    if (await onAdd(title)) setDraft("");
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <ListTodo className="h-4 w-4" />
+          Direct the agent
+          <span className="text-xs font-normal text-muted-foreground">
+            — drop an idea; the agent picks it up, works it with the right
+            protocol, and replies here
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex gap-2">
+          <Input
+            placeholder='e.g. "Cover the billing flow with an expired card" or "Add negative tests for signup"'
+            value={draft}
+            disabled={pending}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void submit();
+            }}
+          />
+          <Button
+            disabled={pending || !draft.trim()}
+            onClick={() => void submit()}
+          >
+            {pending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Plus className="h-4 w-4" />
+            )}
+            Queue task
+          </Button>
+        </div>
+        {error && (
+          <div className="flex items-start gap-1.5 text-sm text-destructive">
+            <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+            {error}
+          </div>
+        )}
+
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {COLUMNS.map((col) => {
+            const Icon = col.icon;
+            const items = tasks.filter((t) => col.statuses.includes(t.status));
+            return (
+              <div
+                key={col.id}
+                className="rounded-md border bg-muted/20 p-2 space-y-2 min-h-28"
+              >
+                <div className="flex items-center gap-1.5 px-0.5 text-xs font-medium text-muted-foreground">
+                  <Icon
+                    className={`h-3.5 w-3.5 ${
+                      col.id === "working" && items.length > 0
+                        ? "animate-spin text-info"
+                        : ""
+                    }`}
+                  />
+                  {col.label}
+                  <span className="ml-auto tabular-nums">{items.length}</span>
+                </div>
+                {items.length === 0 ? (
+                  <div className="flex items-center justify-center py-4 text-[11px] text-muted-foreground/60">
+                    {col.id === "queued" ? "Nothing queued" : "—"}
+                  </div>
+                ) : (
+                  items.map((task) => (
+                    // Keyed by id+status so a column move remounts the card
+                    // and replays the entry animation.
+                    <TaskCard
+                      key={`${task.id}-${task.status}`}
+                      task={task}
+                      pending={pending}
+                      onRetry={onRetry}
+                      onDrop={onDrop}
+                    />
+                  ))
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/qa-agent/qa-trigger-config.tsx
+++ b/src/components/qa-agent/qa-trigger-config.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import type { QaAgentTrigger, QaRunMode } from "@/lib/db/schema";
+import { updateQaTriggerConfig } from "@/server/actions/qa-agent";
+import { timeAgo } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import {
+  AlertTriangle,
+  CalendarClock,
+  GitPullRequest,
+  Loader2,
+  Save,
+} from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Automation triggers — cron schedule + PR webhook config
+// ---------------------------------------------------------------------------
+
+const CRON_PRESETS: Array<{ cron: string; label: string }> = [
+  { cron: "0 3 * * *", label: "Daily at 3:00 AM" },
+  { cron: "0 0 * * *", label: "Daily at midnight" },
+  { cron: "0 */6 * * *", label: "Every 6 hours" },
+  { cron: "0 3 * * 1", label: "Weekly on Monday at 3:00 AM" },
+  { cron: "custom", label: "Custom cron…" },
+];
+
+const MODE_OPTIONS: Array<{ id: QaRunMode; label: string }> = [
+  { id: "fill_gaps", label: "Fill coverage gaps" },
+  { id: "refresh_spec", label: "Refresh specification" },
+  { id: "full", label: "Full run" },
+];
+
+export interface QaTriggerState {
+  scheduleEnabled: boolean;
+  cronExpression: string;
+  scheduleMode: QaRunMode;
+  prEnabled: boolean;
+  prMode: QaRunMode;
+  nextRunAt: Date | string | null;
+}
+
+export function triggerStateFrom(
+  config: QaAgentTrigger | null,
+): QaTriggerState {
+  return {
+    scheduleEnabled: config?.scheduleEnabled ?? false,
+    cronExpression: config?.cronExpression ?? "0 3 * * *",
+    scheduleMode: config?.scheduleMode ?? "fill_gaps",
+    prEnabled: config?.prEnabled ?? false,
+    prMode: config?.prMode ?? "refresh_spec",
+    nextRunAt: config?.nextRunAt ?? null,
+  };
+}
+
+/** One-line trigger summary for the agent header. */
+export function describeTriggers(state: QaTriggerState): string {
+  const parts = ["manual runs", "task queue"];
+  if (state.prEnabled) parts.push("on PR");
+  if (state.scheduleEnabled && state.cronExpression) {
+    const preset = CRON_PRESETS.find((p) => p.cron === state.cronExpression);
+    parts.push((preset?.label ?? `cron ${state.cronExpression}`).toLowerCase());
+  }
+  return parts.join(" · ");
+}
+
+export function QaTriggerConfig({
+  repositoryId,
+  githubConnected,
+  state,
+  onSaved,
+}: {
+  repositoryId: string;
+  githubConnected: boolean;
+  state: QaTriggerState;
+  onSaved: (next: QaTriggerState) => void;
+}) {
+  const [draft, setDraft] = useState<QaTriggerState>(state);
+  const [preset, setPreset] = useState(() =>
+    CRON_PRESETS.some((p) => p.cron === state.cronExpression)
+      ? state.cronExpression
+      : "custom",
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const dirty =
+    draft.scheduleEnabled !== state.scheduleEnabled ||
+    draft.cronExpression !== state.cronExpression ||
+    draft.scheduleMode !== state.scheduleMode ||
+    draft.prEnabled !== state.prEnabled ||
+    draft.prMode !== state.prMode;
+
+  const save = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const row = await updateQaTriggerConfig(repositoryId, {
+        scheduleEnabled: draft.scheduleEnabled,
+        cronExpression: draft.cronExpression || null,
+        scheduleMode: draft.scheduleMode,
+        prEnabled: draft.prEnabled,
+        prMode: draft.prMode,
+      });
+      const next = triggerStateFrom(row);
+      setDraft(next);
+      onSaved(next);
+      toast.success("Agent triggers saved");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <CalendarClock className="h-4 w-4" />
+          Automation triggers
+          <span className="text-xs font-normal text-muted-foreground">
+            — let the agent run itself on a schedule or on every PR
+          </span>
+          {dirty && (
+            <Button
+              size="sm"
+              className="ml-auto"
+              disabled={saving}
+              onClick={() => void save()}
+            >
+              {saving ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Save className="h-3.5 w-3.5" />
+              )}
+              Save
+            </Button>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="grid gap-3 sm:grid-cols-2">
+          {/* PR trigger */}
+          <div className="rounded-md border p-3 space-y-2.5">
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-1.5 text-sm font-medium">
+                <GitPullRequest className="h-3.5 w-3.5" />
+                Run on pull requests
+              </div>
+              <Switch
+                checked={draft.prEnabled}
+                onCheckedChange={(v) =>
+                  setDraft((d) => ({ ...d, prEnabled: v }))
+                }
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Fires on PR opened/updated webhooks (GitHub). The agent
+              re-discovers the branch and reports coverage of the changed
+              functions and endpoints.
+            </p>
+            {!githubConnected && (
+              <p className="text-xs text-warning">
+                GitHub is not connected — PR events won&apos;t arrive until it
+                is.
+              </p>
+            )}
+            <div className="space-y-1">
+              <Label className="text-xs">Run mode</Label>
+              <Select
+                value={draft.prMode}
+                onValueChange={(v) =>
+                  setDraft((d) => ({ ...d, prMode: v as QaRunMode }))
+                }
+              >
+                <SelectTrigger className="h-8 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {MODE_OPTIONS.map((m) => (
+                    <SelectItem key={m.id} value={m.id} className="text-xs">
+                      {m.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {/* Cron schedule */}
+          <div className="rounded-md border p-3 space-y-2.5">
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-1.5 text-sm font-medium">
+                <CalendarClock className="h-3.5 w-3.5" />
+                Run on a schedule
+              </div>
+              <Switch
+                checked={draft.scheduleEnabled}
+                onCheckedChange={(v) =>
+                  setDraft((d) => ({ ...d, scheduleEnabled: v }))
+                }
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">When</Label>
+              <Select
+                value={preset}
+                onValueChange={(v) => {
+                  setPreset(v);
+                  if (v !== "custom") {
+                    setDraft((d) => ({ ...d, cronExpression: v }));
+                  }
+                }}
+              >
+                <SelectTrigger className="h-8 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {CRON_PRESETS.map((p) => (
+                    <SelectItem key={p.cron} value={p.cron} className="text-xs">
+                      {p.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {preset === "custom" && (
+                <Input
+                  className="h-8 text-xs font-mono"
+                  placeholder="0 3 * * * (min hour day month weekday, UTC)"
+                  value={draft.cronExpression}
+                  onChange={(e) =>
+                    setDraft((d) => ({ ...d, cronExpression: e.target.value }))
+                  }
+                />
+              )}
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Run mode</Label>
+              <Select
+                value={draft.scheduleMode}
+                onValueChange={(v) =>
+                  setDraft((d) => ({ ...d, scheduleMode: v as QaRunMode }))
+                }
+              >
+                <SelectTrigger className="h-8 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {MODE_OPTIONS.map((m) => (
+                    <SelectItem key={m.id} value={m.id} className="text-xs">
+                      {m.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            {state.scheduleEnabled && state.nextRunAt && !dirty && (
+              <p className="text-xs text-muted-foreground">
+                Next run{" "}
+                {new Date(state.nextRunAt) > new Date()
+                  ? `at ${new Date(state.nextRunAt).toLocaleString()}`
+                  : timeAgo(new Date(state.nextRunAt))}
+              </p>
+            )}
+          </div>
+        </div>
+        {error && (
+          <div className="flex items-start gap-1.5 text-sm text-destructive">
+            <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+            {error}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/qa-agent/use-qa-agent.ts
+++ b/src/components/qa-agent/use-qa-agent.ts
@@ -6,6 +6,7 @@ import {
   startQaAgent,
   approveQaPlan,
   rerunQaPlanner,
+  rerunQaSession,
   addQaUserJourneys,
   pauseQaAgent,
   resumeQaAgent,
@@ -139,6 +140,33 @@ export function useQaAgent(
     [repositoryId, storageKey, startPolling],
   );
 
+  /** Re-run a prior session with its stored configuration (history rows). */
+  const rerun = useCallback(
+    async (sourceSessionId: string) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await rerunQaSession(sourceSessionId);
+        if (storageKey) localStorage.setItem(storageKey, result.sessionId);
+        startPolling(result.sessionId);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to re-run");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [storageKey, startPolling],
+  );
+
+  /** Attach to a session started elsewhere (e.g. the task dispatcher). */
+  const attach = useCallback(
+    (sid: string) => {
+      if (storageKey) localStorage.setItem(storageKey, sid);
+      startPolling(sid);
+    },
+    [storageKey, startPolling],
+  );
+
   const approve = useCallback(
     (disabledItemIds: string[]) =>
       session
@@ -239,6 +267,8 @@ export function useQaAgent(
     isTerminal,
     progress,
     start,
+    rerun,
+    attach,
     approve,
     requestChanges,
     addJourneys,

--- a/src/components/qa-agent/use-qa-agent.ts
+++ b/src/components/qa-agent/use-qa-agent.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import type { AgentSession, QaTestGroup } from "@/lib/db/schema";
+import type { AgentSession, QaRunMode, QaTestGroup } from "@/lib/db/schema";
 import {
   startQaAgent,
   approveQaPlan,
@@ -16,6 +16,7 @@ const POLL_INTERVAL = 2000;
 
 export interface StartQaOptions {
   targetUrl: string;
+  mode?: QaRunMode;
   groups: QaTestGroup[];
   email?: string;
   password?: string;

--- a/src/components/qa-agent/use-qa-agent.ts
+++ b/src/components/qa-agent/use-qa-agent.ts
@@ -21,6 +21,7 @@ export interface StartQaOptions {
   email?: string;
   password?: string;
   autoApprove?: boolean;
+  allowRegistration?: boolean;
 }
 
 /**
@@ -196,7 +197,7 @@ export function useQaAgent(
     session?.steps.filter(
       (s) => s.status === "completed" || s.status === "skipped",
     ).length ?? 0;
-  const totalSteps = session?.steps.length ?? 8;
+  const totalSteps = session?.steps.length ?? 9;
   const progress =
     totalSteps > 0 ? Math.round((completedSteps / totalSteps) * 100) : 0;
 

--- a/src/components/qa-agent/use-qa-agent.ts
+++ b/src/components/qa-agent/use-qa-agent.ts
@@ -6,6 +6,7 @@ import {
   startQaAgent,
   approveQaPlan,
   rerunQaPlanner,
+  addQaUserJourneys,
   pauseQaAgent,
   resumeQaAgent,
   cancelQaAgent,
@@ -155,6 +156,32 @@ export function useQaAgent(
     [session, runAction],
   );
 
+  // Refine the reviewer's own journeys and merge them into the plan. Unlike the
+  // other actions this returns a {success,error} result instead of throwing, so
+  // surface the error inline; poll on success to pick up the augmented plan.
+  const addJourneys = useCallback(
+    async (journeysText: string): Promise<boolean> => {
+      if (!session) return false;
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await addQaUserJourneys(session.id, journeysText);
+        if (res.success) {
+          startPolling(session.id);
+          return true;
+        }
+        setError(res.error ?? "Could not add those journeys");
+        return false;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Action failed");
+        return false;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [session, startPolling],
+  );
+
   const pause = useCallback(
     () =>
       session
@@ -212,6 +239,7 @@ export function useQaAgent(
     start,
     approve,
     requestChanges,
+    addJourneys,
     pause,
     resume,
     cancel,

--- a/src/components/qa-agent/use-qa-agent.ts
+++ b/src/components/qa-agent/use-qa-agent.ts
@@ -1,0 +1,218 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import type { AgentSession, QaTestGroup } from "@/lib/db/schema";
+import {
+  startQaAgent,
+  approveQaPlan,
+  rerunQaPlanner,
+  pauseQaAgent,
+  resumeQaAgent,
+  cancelQaAgent,
+  type StartQaAgentInput,
+} from "@/server/actions/qa-agent";
+
+const POLL_INTERVAL = 2000;
+
+export interface StartQaOptions {
+  targetUrl: string;
+  groups: QaTestGroup[];
+  email?: string;
+  password?: string;
+  autoApprove?: boolean;
+}
+
+/**
+ * Client driver for a QA agent session: starts/controls it via server actions
+ * and polls /api/qa-agent/[sessionId] for live state, mirroring usePlayAgent.
+ * The session id is remembered per-repo so a page reload re-attaches.
+ */
+export function useQaAgent(
+  repositoryId: string | null | undefined,
+  initialSession: AgentSession | null,
+) {
+  const [session, setSession] = useState<AgentSession | null>(initialSession);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const storageKey = repositoryId ? `qa-agent-session-${repositoryId}` : null;
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const poll = useCallback(
+    async (sid: string) => {
+      try {
+        const res = await fetch(`/api/qa-agent/${sid}`, {
+          cache: "no-store",
+        });
+        if (!res.ok) {
+          if (res.status === 404 && storageKey) {
+            localStorage.removeItem(storageKey);
+            setSession(null);
+          }
+          return;
+        }
+        const data: AgentSession = await res.json();
+        setSession(data);
+        if (data.status !== "active") {
+          // paused (review gate) and terminal states don't need a 2s cadence;
+          // paused keeps a slow poll via the effect below re-arming on action.
+          if (data.status !== "paused") stopPolling();
+        }
+      } catch {
+        // Transient network errors are ignored; next tick retries.
+      }
+    },
+    [storageKey, stopPolling],
+  );
+
+  const startPolling = useCallback(
+    (sid: string) => {
+      stopPolling();
+      pollRef.current = setInterval(() => poll(sid), POLL_INTERVAL);
+      void poll(sid);
+    },
+    [poll, stopPolling],
+  );
+
+  // Re-attach on mount: prefer the server-provided session, else localStorage.
+  useEffect(() => {
+    const sid =
+      initialSession?.id ??
+      (storageKey ? localStorage.getItem(storageKey) : null);
+    if (!sid) return;
+    if (
+      initialSession &&
+      initialSession.status !== "active" &&
+      initialSession.status !== "paused"
+    ) {
+      return; // terminal snapshot from the server — nothing to poll
+    }
+    startPolling(sid);
+    return stopPolling;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [repositoryId]);
+
+  const runAction = useCallback(
+    async (fn: () => Promise<unknown>, sid?: string) => {
+      setLoading(true);
+      setError(null);
+      try {
+        await fn();
+        if (sid) startPolling(sid);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Action failed");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [startPolling],
+  );
+
+  const start = useCallback(
+    async (options: StartQaOptions) => {
+      if (!repositoryId) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const input: StartQaAgentInput = { repositoryId, ...options };
+        const result = await startQaAgent(input);
+        if (storageKey) localStorage.setItem(storageKey, result.sessionId);
+        startPolling(result.sessionId);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to start");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [repositoryId, storageKey, startPolling],
+  );
+
+  const approve = useCallback(
+    (disabledItemIds: string[]) =>
+      session
+        ? runAction(
+            () => approveQaPlan(session.id, { disabledItemIds }),
+            session.id,
+          )
+        : Promise.resolve(),
+    [session, runAction],
+  );
+
+  const requestChanges = useCallback(
+    (feedback: string) =>
+      session
+        ? runAction(() => rerunQaPlanner(session.id, feedback), session.id)
+        : Promise.resolve(),
+    [session, runAction],
+  );
+
+  const pause = useCallback(
+    () =>
+      session
+        ? runAction(() => pauseQaAgent(session.id), session.id)
+        : Promise.resolve(),
+    [session, runAction],
+  );
+
+  const resume = useCallback(
+    () =>
+      session
+        ? runAction(() => resumeQaAgent(session.id), session.id)
+        : Promise.resolve(),
+    [session, runAction],
+  );
+
+  const cancel = useCallback(
+    () =>
+      session
+        ? runAction(() => cancelQaAgent(session.id), session.id)
+        : Promise.resolve(),
+    [session, runAction],
+  );
+
+  /** Forget the current (terminal) session so the setup form shows again. */
+  const dismiss = useCallback(() => {
+    stopPolling();
+    if (storageKey) localStorage.removeItem(storageKey);
+    setSession(null);
+  }, [storageKey, stopPolling]);
+
+  const isRunning = session?.status === "active";
+  const isPaused = session?.status === "paused";
+  const isTerminal =
+    session?.status === "completed" ||
+    session?.status === "failed" ||
+    session?.status === "cancelled";
+
+  const completedSteps =
+    session?.steps.filter(
+      (s) => s.status === "completed" || s.status === "skipped",
+    ).length ?? 0;
+  const totalSteps = session?.steps.length ?? 8;
+  const progress =
+    totalSteps > 0 ? Math.round((completedSteps / totalSteps) * 100) : 0;
+
+  return {
+    session,
+    loading,
+    error,
+    isRunning,
+    isPaused,
+    isTerminal,
+    progress,
+    start,
+    approve,
+    requestChanges,
+    pause,
+    resume,
+    cancel,
+    dismiss,
+  };
+}

--- a/src/components/qa-agent/use-qa-agent.ts
+++ b/src/components/qa-agent/use-qa-agent.ts
@@ -23,6 +23,8 @@ export interface StartQaOptions {
   password?: string;
   autoApprove?: boolean;
   allowRegistration?: boolean;
+  /** Uploaded product docs, base64-encoded (.md/.txt/.pdf/.docx). */
+  docs?: Array<{ name: string; contentBase64: string }>;
 }
 
 /**

--- a/src/components/qa-agent/use-qa-tasks.ts
+++ b/src/components/qa-agent/use-qa-tasks.ts
@@ -1,0 +1,99 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { QaTask, QaTaskSource } from "@/lib/db/schema";
+import {
+  addQaTask,
+  dropQaTask,
+  listQaTasks,
+  retryQaTask,
+} from "@/server/actions/qa-agent";
+
+const ACTIVE_POLL_MS = 5000;
+const IDLE_POLL_MS = 20000;
+
+/**
+ * Client driver for the QA agent direction queue: polls the board state
+ * (fast while something is queued/working, slow otherwise) and wraps the
+ * task server actions.
+ */
+export function useQaTasks(repositoryId: string, initialTasks: QaTask[]) {
+  const [tasks, setTasks] = useState<QaTask[]>(initialTasks);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setTasks(await listQaTasks(repositoryId));
+    } catch {
+      // Transient — next poll retries.
+    }
+  }, [repositoryId]);
+
+  const hasOpenWork = useMemo(
+    () => tasks.some((t) => t.status === "queued" || t.status === "working"),
+    [tasks],
+  );
+
+  useEffect(() => {
+    const interval = setInterval(
+      () => void refresh(),
+      hasOpenWork ? ACTIVE_POLL_MS : IDLE_POLL_MS,
+    );
+    return () => clearInterval(interval);
+  }, [refresh, hasOpenWork]);
+
+  const run = useCallback(
+    async (fn: () => Promise<unknown>) => {
+      setPending(true);
+      setError(null);
+      try {
+        await fn();
+        await refresh();
+        return true;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Action failed");
+        return false;
+      } finally {
+        setPending(false);
+      }
+    },
+    [refresh],
+  );
+
+  const add = useCallback(
+    (
+      title: string,
+      opts?: {
+        description?: string;
+        source?: Extract<QaTaskSource, "user" | "coverage_gap">;
+      },
+    ) =>
+      run(() =>
+        addQaTask({
+          repositoryId,
+          title,
+          description: opts?.description,
+          source: opts?.source,
+        }),
+      ),
+    [repositoryId, run],
+  );
+
+  const retry = useCallback(
+    (taskId: string) => run(() => retryQaTask(taskId)),
+    [run],
+  );
+
+  const drop = useCallback(
+    (taskId: string) => run(() => dropQaTask(taskId)),
+    [run],
+  );
+
+  const workingTask = useMemo(
+    () => tasks.find((t) => t.status === "working") ?? null,
+    [tasks],
+  );
+
+  return { tasks, workingTask, pending, error, add, retry, drop, refresh };
+}

--- a/src/lib/ai/claude-agent-sdk.ts
+++ b/src/lib/ai/claude-agent-sdk.ts
@@ -71,7 +71,14 @@ export class ClaudeAgentSDKProvider implements AIProvider {
       ? abortControllerFromSignal(signal)
       : undefined;
 
-    const messages: string[] = [];
+    // The SDK emits the model's final turn twice: once as an `assistant`
+    // message text block, and again as the terminal `result` (subtype
+    // "success") whose `.result` is that same text verbatim. Appending both
+    // yields a doubled reply (e.g. `{json}\n{json}`) that then fails
+    // JSON.parse. Keep the two sources separate and prefer the authoritative
+    // `result`; fall back to the assistant text only if no result arrives.
+    const assistantChunks: string[] = [];
+    let resultText: string | null = null;
     const stderrChunks: string[] = [];
 
     try {
@@ -100,14 +107,14 @@ export class ClaudeAgentSDKProvider implements AIProvider {
         if (message.type === "assistant" && message.message?.content) {
           for (const block of message.message.content) {
             if (block.type === "text") {
-              messages.push(block.text);
+              assistantChunks.push(block.text);
             }
           }
         }
-        // Also collect result messages (success only)
+        // The terminal success result — the authoritative final answer.
         if (message.type === "result" && message.subtype === "success") {
           if (message.result) {
-            messages.push(message.result);
+            resultText = message.result;
           }
         }
         // Capture error results with more detail
@@ -123,17 +130,15 @@ export class ClaudeAgentSDKProvider implements AIProvider {
         }
       }
 
-      return messages.join("\n").trim();
+      return (resultText ?? assistantChunks.join("\n")).trim();
     } catch (error) {
       const stderr = stderrChunks.join("").trim();
       if (error instanceof Error) {
         if (error.message === "Aborted") throw error;
         const parts = [`Claude Agent SDK error: ${error.message}`];
         if (stderr) parts.push(`stderr: ${stderr.slice(0, 1000)}`);
-        if (messages.length > 0)
-          parts.push(
-            `last output: ${messages.slice(-2).join("\n").slice(0, 500)}`,
-          );
+        const lastOutput = resultText ?? assistantChunks.slice(-2).join("\n");
+        if (lastOutput) parts.push(`last output: ${lastOutput.slice(0, 500)}`);
         throw new Error(parts.join(" | "));
       }
       throw error;
@@ -159,6 +164,11 @@ export class ClaudeAgentSDKProvider implements AIProvider {
       : undefined;
 
     let fullText = "";
+    // Tracks whether any assistant text was already streamed this turn. The
+    // SDK's terminal success `result` repeats that same final text, so we only
+    // emit it as a fallback when no assistant text arrived — otherwise the
+    // stream (and fullText) would be doubled. See generate() for the details.
+    let streamedAssistant = false;
     const stderrChunks: string[] = [];
 
     try {
@@ -187,15 +197,18 @@ export class ClaudeAgentSDKProvider implements AIProvider {
           for (const block of message.message.content) {
             if (block.type === "text") {
               fullText += block.text;
+              streamedAssistant = true;
               callbacks.onToken?.(block.text);
             }
           }
         }
-        // Also handle result messages (success only)
+        // Terminal success result — only use it if no assistant text streamed,
+        // since it otherwise duplicates the already-streamed final turn.
         if (
           message.type === "result" &&
           message.subtype === "success" &&
-          message.result
+          message.result &&
+          !streamedAssistant
         ) {
           fullText += message.result;
           callbacks.onToken?.(message.result);

--- a/src/lib/ai/claude-cli.ts
+++ b/src/lib/ai/claude-cli.ts
@@ -8,6 +8,14 @@ function getExtendedEnv(): NodeJS.ProcessEnv {
   return { ...process.env, PATH: extendedPath };
 }
 
+// Per-call wall-clock cap. Agent-scale prompts (QA planner with a discovery
+// digest + existing-coverage section) legitimately run past the old 120s cap,
+// so the default is 4 minutes; override with CLAUDE_CLI_TIMEOUT_MS.
+function cliTimeoutMs(): number {
+  const raw = Number(process.env.CLAUDE_CLI_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 240_000;
+}
+
 export class ClaudeCLIProvider implements AIProvider {
   async generate(options: GenerateOptions): Promise<string> {
     const { prompt, systemPrompt, signal } = options;
@@ -43,7 +51,18 @@ export class ClaudeCLIProvider implements AIProvider {
         stderr += data.toString();
       });
 
+      const timeoutMs = cliTimeoutMs();
+      const timer = setTimeout(() => {
+        child.kill("SIGTERM");
+        reject(
+          new Error(
+            `Claude CLI error: timed out after ${Math.round(timeoutMs / 1000)}s`,
+          ),
+        );
+      }, timeoutMs);
+
       child.on("close", (code) => {
+        clearTimeout(timer);
         signal?.removeEventListener("abort", onAbort);
         if (code === 0) {
           resolve(stdout.trim());
@@ -57,15 +76,10 @@ export class ClaudeCLIProvider implements AIProvider {
       });
 
       child.on("error", (error) => {
+        clearTimeout(timer);
         signal?.removeEventListener("abort", onAbort);
         reject(new Error(`Claude CLI error: ${error.message}`));
       });
-
-      // 2 minute timeout
-      setTimeout(() => {
-        child.kill("SIGTERM");
-        reject(new Error("Claude CLI error: timed out after 120s"));
-      }, 120000);
 
       // Write prompt via stdin to avoid E2BIG on large prompts
       child.stdin.write(fullPrompt);

--- a/src/lib/ai/json-parse.test.ts
+++ b/src/lib/ai/json-parse.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { parseAiJson } from "./json-parse";
+
+interface Plan {
+  appProfile: { summary: string };
+  items: unknown[];
+}
+
+function isPlan(v: unknown): v is Plan {
+  if (!v || typeof v !== "object") return false;
+  const p = v as Record<string, unknown>;
+  const profile = p.appProfile as Record<string, unknown> | undefined;
+  return (
+    !!profile &&
+    typeof profile.summary === "string" &&
+    Array.isArray(p.items) &&
+    p.items.length > 0
+  );
+}
+
+const VALID = '{"appProfile":{"summary":"x"},"items":[1]}';
+
+describe("parseAiJson", () => {
+  it("parses a clean JSON object", () => {
+    expect(parseAiJson(VALID, isPlan)).toEqual({
+      appProfile: { summary: "x" },
+      items: [1],
+    });
+  });
+
+  it("strips markdown fences", () => {
+    expect(parseAiJson("```json\n" + VALID + "\n```", isPlan)).toEqual({
+      appProfile: { summary: "x" },
+      items: [1],
+    });
+  });
+
+  it("recovers the first object when the model emits it twice concatenated", () => {
+    // Reproduces the claude-agent-sdk double-emission that failed the QA
+    // planner: two identical objects joined by a newline. A plain JSON.parse
+    // throws "Unexpected non-whitespace character after JSON".
+    const doubled = VALID + "\n" + VALID;
+    expect(() => JSON.parse(doubled)).toThrow();
+    expect(parseAiJson(doubled, isPlan)).toEqual({
+      appProfile: { summary: "x" },
+      items: [1],
+    });
+  });
+
+  it("recovers a JSON object wrapped in surrounding prose", () => {
+    const noisy = `Sure, here is the plan:\n${VALID}\nLet me know if you want changes.`;
+    expect(parseAiJson(noisy, isPlan)).toEqual({
+      appProfile: { summary: "x" },
+      items: [1],
+    });
+  });
+
+  it("does not mistake braces inside string values for structure", () => {
+    const withBraces =
+      '{"appProfile":{"summary":"a } b { c"},"items":[1]} trailing';
+    expect(parseAiJson(withBraces, isPlan)).toEqual({
+      appProfile: { summary: "a } b { c" },
+      items: [1],
+    });
+  });
+
+  it("returns null on unrecoverable garbage", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(parseAiJson("not json at all", isPlan)).toBeNull();
+    expect(parseAiJson("", isPlan)).toBeNull();
+  });
+
+  it("returns null when the recovered value fails the shape predicate", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    // Parses fine but items is empty → predicate rejects.
+    expect(
+      parseAiJson('{"appProfile":{"summary":"x"},"items":[]}', isPlan),
+    ).toBeNull();
+  });
+});

--- a/src/lib/ai/json-parse.ts
+++ b/src/lib/ai/json-parse.ts
@@ -25,6 +25,40 @@ function stripFences(raw: string): string {
   return raw.trim();
 }
 
+/**
+ * Extract the first balanced JSON object/array from `s` by depth-scanning from
+ * the first `{`/`[`, respecting string literals and escapes. Recovers a single
+ * valid value when the model wraps it in prose or — as some providers do —
+ * emits the object more than once concatenated (`{…}\n{…}`), which trips a
+ * plain JSON.parse with "Unexpected non-whitespace character after JSON".
+ * Returns null when no balanced value is found.
+ */
+function extractFirstJsonValue(s: string): string | null {
+  const start = s.search(/[{[]/);
+  if (start === -1) return null;
+  const open = s[start]!;
+  const close = open === "{" ? "}" : "]";
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < s.length; i++) {
+    const ch = s[i]!;
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === open) depth++;
+    else if (ch === close) {
+      depth--;
+      if (depth === 0) return s.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
 export function parseAiJson<T>(
   raw: string,
   isValid: (value: unknown) => value is T,
@@ -36,10 +70,24 @@ export function parseAiJson<T>(
   try {
     parsed = JSON.parse(cleaned);
   } catch (err) {
-    if (opts.source) {
-      console.warn(`[ai-json] ${opts.source}: JSON.parse failed —`, err);
+    // Fallback: recover the first balanced JSON value (handles trailing prose
+    // or a duplicated/concatenated object that defeats a whole-string parse).
+    const extracted = extractFirstJsonValue(cleaned);
+    if (extracted && extracted !== cleaned) {
+      try {
+        parsed = JSON.parse(extracted);
+      } catch {
+        if (opts.source) {
+          console.warn(`[ai-json] ${opts.source}: JSON.parse failed —`, err);
+        }
+        return null;
+      }
+    } else {
+      if (opts.source) {
+        console.warn(`[ai-json] ${opts.source}: JSON.parse failed —`, err);
+      }
+      return null;
     }
-    return null;
   }
   if (!isValid(parsed)) {
     if (opts.source) {

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -129,6 +129,12 @@ export interface TestGenerationContext {
   functionalAreaId?: string;
   testName?: string;
   baseUrl?: string;
+  /** The caller has already applied an authenticated session to the exploration
+   *  browser (e.g. QA agent injected a storage state over CDP). When set, the
+   *  generator is told to assume it is logged in and NOT to script a login,
+   *  overriding the repo-default seed auth heuristic — the two auth stories must
+   *  not contradict. */
+  preAuthenticated?: boolean;
 }
 
 export interface GeneratedTest {

--- a/src/lib/billing/feature-access.ts
+++ b/src/lib/billing/feature-access.ts
@@ -1,0 +1,43 @@
+/**
+ * Per-feature plan gating.
+ *
+ * Tier identity lives in `plans.ts`; this module maps individual product
+ * features to the minimum plan that unlocks them. Keep the checks here so the
+ * page (which renders the upgrade screen) and the server actions (which enforce
+ * it) share one source of truth — a feature can't be gated in the UI but left
+ * open in the action, or vice-versa.
+ */
+import type { TeamPlan } from "@/lib/db/schema";
+import { planConfig, planRank } from "./plans";
+
+/**
+ * QA Agent is a paid, high-cost feature (multi-agent orchestration + EB time),
+ * gated to the top tier. There is no dedicated "enterprise" tier today — `pro`
+ * is the ceiling — so this is effectively Pro-only. Using a rank comparison
+ * (rather than an equality check) means any future higher tier inherits access
+ * automatically.
+ */
+export const QA_AGENT_MIN_PLAN: TeamPlan = "pro";
+
+/** True when the team's plan unlocks the QA Agent. */
+export function hasQaAgentAccess(plan: TeamPlan): boolean {
+  return planRank(plan) >= planRank(QA_AGENT_MIN_PLAN);
+}
+
+/** Human-readable name of the tier required for the QA Agent (e.g. "Pro"). */
+export function qaAgentMinPlanName(): string {
+  return planConfig(QA_AGENT_MIN_PLAN).name;
+}
+
+/**
+ * Throw a user-facing error when a team without QA Agent access reaches a
+ * QA-agent server action directly (the page renders an upgrade screen, but the
+ * actions must not rely on the UI to gate access).
+ */
+export function assertQaAgentAccess(plan: TeamPlan): void {
+  if (!hasQaAgentAccess(plan)) {
+    throw new Error(
+      `The QA Agent requires the ${qaAgentMinPlanName()} plan. Upgrade under Settings → Billing to unlock it.`,
+    );
+  }
+}

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -42,3 +42,4 @@ export * from "./queries/launch";
 export * from "./queries/playground";
 export * from "./queries/billing";
 export * from "./queries/qa-tasks";
+export * from "./queries/qa-agent-triggers";

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -41,3 +41,4 @@ export * from "./queries/awards";
 export * from "./queries/launch";
 export * from "./queries/playground";
 export * from "./queries/billing";
+export * from "./queries/qa-tasks";

--- a/src/lib/db/queries/integrations.ts
+++ b/src/lib/db/queries/integrations.ts
@@ -17,6 +17,7 @@ import type {
   NewGoogleSheetsDataSource,
   NewComposeConfig,
   NewAgentSession,
+  AgentSessionKind,
   AgentSessionStatus,
   AgentStepState,
   AgentStepId,
@@ -380,7 +381,7 @@ export async function getAgentSession(id: string) {
 
 export async function getActiveAgentSession(
   repositoryId: string,
-  kind: "play" | "quickstart" = "play",
+  kind: AgentSessionKind = "play",
 ) {
   // Opportunistic sweep so a stale "active" row doesn't keep the activity
   // feed spinning forever. Cheap when there's nothing to do.
@@ -402,6 +403,26 @@ export async function getActiveAgentSession(
       ),
     )
     .orderBy(desc(agentSessions.createdAt));
+  return row ? decryptAgentSessionRow(row) : row;
+}
+
+/** Most recent session of a kind for a repo, regardless of status. Used by
+ *  the QA Agent page to show the last run's summary after completion. */
+export async function getLatestAgentSession(
+  repositoryId: string,
+  kind: AgentSessionKind,
+) {
+  const [row] = await db
+    .select()
+    .from(agentSessions)
+    .where(
+      and(
+        eq(agentSessions.repositoryId, repositoryId),
+        eq(agentSessions.kind, kind),
+      ),
+    )
+    .orderBy(desc(agentSessions.createdAt))
+    .limit(1);
   return row ? decryptAgentSessionRow(row) : row;
 }
 

--- a/src/lib/db/queries/integrations.ts
+++ b/src/lib/db/queries/integrations.ts
@@ -426,6 +426,27 @@ export async function getLatestAgentSession(
   return row ? decryptAgentSessionRow(row) : row;
 }
 
+/** Recent sessions of a kind for a repo, newest first (any status). Used by
+ *  the QA agent's segmented modes to locate the latest stored plan. */
+export async function getRecentAgentSessions(
+  repositoryId: string,
+  kind: AgentSessionKind,
+  limit = 10,
+) {
+  const rows = await db
+    .select()
+    .from(agentSessions)
+    .where(
+      and(
+        eq(agentSessions.repositoryId, repositoryId),
+        eq(agentSessions.kind, kind),
+      ),
+    )
+    .orderBy(desc(agentSessions.createdAt))
+    .limit(limit);
+  return rows.map(decryptAgentSessionRow);
+}
+
 export async function updateAgentSession(
   id: string,
   data: {

--- a/src/lib/db/queries/qa-agent-triggers.ts
+++ b/src/lib/db/queries/qa-agent-triggers.ts
@@ -1,0 +1,81 @@
+import { db } from "../index";
+import { qaAgentTriggers } from "../schema";
+import type { QaAgentTrigger } from "../schema";
+import { eq, and, lte } from "drizzle-orm";
+
+/**
+ * QA agent automation config — one row per repo holding the cron schedule and
+ * PR-trigger switches. The build scheduler tick fires due schedules; the
+ * GitHub webhook checks prEnabled on PR opened/synchronize.
+ */
+
+export async function getQaAgentTrigger(
+  repositoryId: string,
+): Promise<QaAgentTrigger | undefined> {
+  const [row] = await db
+    .select()
+    .from(qaAgentTriggers)
+    .where(eq(qaAgentTriggers.repositoryId, repositoryId));
+  return row;
+}
+
+export async function upsertQaAgentTrigger(
+  repositoryId: string,
+  teamId: string,
+  patch: Partial<{
+    scheduleEnabled: boolean;
+    cronExpression: string | null;
+    scheduleMode: QaAgentTrigger["scheduleMode"];
+    prEnabled: boolean;
+    prMode: QaAgentTrigger["prMode"];
+    nextRunAt: Date | null;
+  }>,
+): Promise<QaAgentTrigger> {
+  const existing = await getQaAgentTrigger(repositoryId);
+  const now = new Date();
+  if (existing) {
+    const [row] = await db
+      .update(qaAgentTriggers)
+      .set({ ...patch, updatedAt: now })
+      .where(eq(qaAgentTriggers.id, existing.id))
+      .returning();
+    return row;
+  }
+  const [row] = await db
+    .insert(qaAgentTriggers)
+    .values({
+      id: crypto.randomUUID(),
+      repositoryId,
+      teamId,
+      ...patch,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+  return row;
+}
+
+/** Enabled cron triggers whose nextRunAt has passed — the scheduler's pick. */
+export async function getDueQaAgentTriggers(
+  now: Date = new Date(),
+): Promise<QaAgentTrigger[]> {
+  return db
+    .select()
+    .from(qaAgentTriggers)
+    .where(
+      and(
+        eq(qaAgentTriggers.scheduleEnabled, true),
+        lte(qaAgentTriggers.nextRunAt, now),
+      ),
+    );
+}
+
+export async function markQaAgentTriggerFired(
+  id: string,
+  data: { nextRunAt: Date | null; lastRunAt?: Date; lastSessionId?: string },
+): Promise<void> {
+  await db
+    .update(qaAgentTriggers)
+    .set({ ...data, updatedAt: new Date() })
+    .where(eq(qaAgentTriggers.id, id));
+}

--- a/src/lib/db/queries/qa-tasks.ts
+++ b/src/lib/db/queries/qa-tasks.ts
@@ -1,0 +1,109 @@
+import { db } from "../index";
+import { qaTasks } from "../schema";
+import type { NewQaTask, QaTask, QaTaskStatus } from "../schema";
+import { eq, desc, and, asc, inArray } from "drizzle-orm";
+
+/**
+ * QA agent direction queue — tasks the team (or an external agent via MCP)
+ * drops for the QA agent. The dispatcher in server/actions/qa-agent.ts claims
+ * queued tasks oldest-first whenever no QA session is active.
+ */
+
+export async function createQaTask(
+  data: Omit<NewQaTask, "id" | "createdAt" | "updatedAt">,
+): Promise<QaTask> {
+  const now = new Date();
+  const [row] = await db
+    .insert(qaTasks)
+    .values({
+      ...data,
+      id: crypto.randomUUID(),
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+  return row;
+}
+
+export async function getQaTask(id: string): Promise<QaTask | undefined> {
+  const [row] = await db.select().from(qaTasks).where(eq(qaTasks.id, id));
+  return row;
+}
+
+/** All tasks for a repo, newest first — the board slots them into columns
+ *  client-side. Terminal tasks (done/cancelled) are capped so the Done column
+ *  stays a recent-history strip, not an archive. */
+export async function getQaTasksByRepo(
+  repositoryId: string,
+  opts: { terminalLimit?: number } = {},
+): Promise<QaTask[]> {
+  const { terminalLimit = 25 } = opts;
+  const [open, terminal] = await Promise.all([
+    db
+      .select()
+      .from(qaTasks)
+      .where(
+        and(
+          eq(qaTasks.repositoryId, repositoryId),
+          inArray(qaTasks.status, ["queued", "working", "needs_input"]),
+        ),
+      )
+      .orderBy(desc(qaTasks.createdAt)),
+    db
+      .select()
+      .from(qaTasks)
+      .where(
+        and(
+          eq(qaTasks.repositoryId, repositoryId),
+          inArray(qaTasks.status, ["done", "cancelled"]),
+        ),
+      )
+      .orderBy(desc(qaTasks.completedAt))
+      .limit(terminalLimit),
+  ]);
+  return [...open, ...terminal];
+}
+
+/** Oldest queued task for a repo — what the dispatcher picks up next. */
+export async function getNextQueuedQaTask(
+  repositoryId: string,
+): Promise<QaTask | undefined> {
+  const [row] = await db
+    .select()
+    .from(qaTasks)
+    .where(
+      and(eq(qaTasks.repositoryId, repositoryId), eq(qaTasks.status, "queued")),
+    )
+    .orderBy(asc(qaTasks.createdAt))
+    .limit(1);
+  return row;
+}
+
+export async function updateQaTask(
+  id: string,
+  data: Partial<{
+    status: QaTaskStatus;
+    sessionId: string | null;
+    agentReply: string | null;
+    startedAt: Date | null;
+    completedAt: Date | null;
+  }>,
+): Promise<void> {
+  await db
+    .update(qaTasks)
+    .set({ ...data, updatedAt: new Date() })
+    .where(eq(qaTasks.id, id));
+}
+
+/** The task a session is working, if any (session → task back-reference). */
+export async function getQaTaskBySession(
+  sessionId: string,
+): Promise<QaTask | undefined> {
+  const [row] = await db
+    .select()
+    .from(qaTasks)
+    .where(eq(qaTasks.sessionId, sessionId))
+    .orderBy(desc(qaTasks.createdAt))
+    .limit(1);
+  return row;
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -2837,6 +2837,8 @@ export interface QaPlanJourney {
   priority: QaPriority;
   /** Ordered user-visible steps of the journey. */
   steps: string[];
+  /** Business/functional domain of the journey (matrix axis). */
+  businessArea?: string;
   /** The business outcome this journey must produce (e.g. "order placed"). */
   businessOutcome: string;
   /** How the outcome is proven beyond UI toasts (end-state via API/data/UI). */
@@ -2853,6 +2855,10 @@ export interface QaPlanItem {
   priority: QaPriority;
   /** Traceability link to the journey this test covers, when applicable. */
   journeyId?: string;
+  /** Business/functional domain this item exercises (e.g. "Authentication",
+   *  "Checkout") — one axis of the coverage matrix. Missing values roll up
+   *  under "General". */
+  businessArea?: string;
   /** Route/page under test, relative to the target base URL. */
   pagePath?: string;
   rationale?: string;
@@ -2946,6 +2952,17 @@ export interface QaGeneratedTest {
   error?: string;
 }
 
+/** One cell of the business-area × test-group coverage matrix. */
+export interface QaMatrixCell {
+  planned: number;
+  /** Plan items satisfied by pre-existing tests. */
+  covered: number;
+  generated: number;
+  /** Passing among covered+generated is not knowable for covered (they run
+   *  in normal builds) — `passed` counts this run's passing tests only. */
+  passed: number;
+}
+
 export interface QaSummaryData {
   planned: number;
   generated: number;
@@ -2960,6 +2977,9 @@ export interface QaSummaryData {
       { planned: number; generated: number; covered: number; passed: number }
     >
   >;
+  /** Coverage matrix: business area → test group → cell. Areas come from
+   *  QaPlanItem.businessArea ("General" when unset). */
+  matrix?: Record<string, Partial<Record<QaTestGroup, QaMatrixCell>>>;
   /** journeyId → testIds covering it (traceability matrix). */
   journeyCoverage: Record<string, string[]>;
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -2850,7 +2850,12 @@ export interface QaPlanJourney {
  *  ApiTestDefinition instead of a browser test. */
 export interface QaPlanItem {
   id: string;
+  /** Primary group — drives functional-area assignment and legacy plans. */
   group: QaTestGroup;
+  /** All coverage groups this single test satisfies (primary first). One
+   *  test execution runs every check layer, so a page visit can serve
+   *  smoke+ui+a11y+perf at once. Absent = [group] (legacy plans). */
+  groups?: QaTestGroup[];
   title: string;
   priority: QaPriority;
   /** Traceability link to the journey this test covers, when applicable. */
@@ -2945,6 +2950,8 @@ export type QaGeneratedTestStatus =
 export interface QaGeneratedTest {
   planItemId: string;
   group: QaTestGroup;
+  /** All coverage groups of the source plan item (primary first). */
+  groups?: QaTestGroup[];
   /** Absent when generation failed before a test row was created. */
   testId?: string;
   name: string;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -3111,6 +3111,10 @@ export interface AgentSessionMetadata {
   qaPlan?: QaTestPlan;
   /** User feedback captured on "request changes" — fed to the planner rerun. */
   qaPlannerFeedback?: string;
+  /** Plain-language journeys the user added at the review gate. Refined by AI
+   *  into structured journeys + covering items and merged into qaPlan; kept for
+   *  provenance and so refresh/rerun paths preserve human-supplied intent. */
+  qaUserJourneys?: string[];
   /** Per-plan-item generation/execution status ledger. */
   qaGeneratedTests?: QaGeneratedTest[];
   /** Test-run ids started by the execute/heal phases. */

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -3305,6 +3305,39 @@ export const qaTasks = pgTable(
 export type QaTask = typeof qaTasks.$inferSelect;
 export type NewQaTask = typeof qaTasks.$inferInsert;
 
+/** Per-repo automation config for the QA agent: an optional cron schedule and
+ *  an optional PR-webhook trigger. One row per repository; both triggers start
+ *  autonomous sessions (review gate auto-approved) and are skipped with an
+ *  activity event when a session is already running. */
+export const qaAgentTriggers = pgTable("qa_agent_triggers", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  repositoryId: text("repository_id")
+    .references(() => repositories.id, { onDelete: "cascade" })
+    .notNull()
+    .unique(),
+  teamId: text("team_id").notNull(),
+  /** Cron schedule (5-field expression, UTC). */
+  scheduleEnabled: boolean("schedule_enabled").notNull().default(false),
+  cronExpression: text("cron_expression"),
+  scheduleMode: text("schedule_mode")
+    .$type<QaRunMode>()
+    .notNull()
+    .default("fill_gaps"),
+  /** Run on PR opened/synchronize webhooks. */
+  prEnabled: boolean("pr_enabled").notNull().default(false),
+  prMode: text("pr_mode").$type<QaRunMode>().notNull().default("refresh_spec"),
+  nextRunAt: timestamp("next_run_at"),
+  lastRunAt: timestamp("last_run_at"),
+  lastSessionId: text("last_session_id"),
+  createdAt: timestamp("created_at").$defaultFn(() => new Date()),
+  updatedAt: timestamp("updated_at").$defaultFn(() => new Date()),
+});
+
+export type QaAgentTrigger = typeof qaAgentTriggers.$inferSelect;
+export type NewQaAgentTrigger = typeof qaAgentTriggers.$inferInsert;
+
 // ── Bug Reports ──────────────────────────────────────────────────────────────
 
 export type BugReportSeverity = "low" | "medium" | "high";

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -2905,6 +2905,9 @@ export interface QaPlanItem {
   scenario: string;
   /** Verified selectors from discovery the generator should prefer. */
   selectorHints?: string[];
+  /** Exact ref strings from the branch-diff digest this item covers (symbol
+   *  names, "METHOD /path" endpoints, file paths) — drives PR coverage. */
+  changeRefs?: string[];
   api?: {
     method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
     path: string;
@@ -2960,6 +2963,63 @@ export interface QaPageSnapshot {
   consoleErrors?: string[];
 }
 
+/** One file changed on the working branch vs the base branch. */
+export interface QaPrChangedFile {
+  path: string;
+  status: "added" | "modified" | "removed" | "renamed";
+  additions: number;
+  deletions: number;
+  previousPath?: string;
+}
+
+/** A function/class/component the branch diff added or modified — extracted
+ *  deterministically from diff hunks (src/lib/qa-agent/pr-check). */
+export interface QaPrSymbol {
+  name: string;
+  kind: "function" | "component" | "class" | "endpoint";
+  file: string;
+  change: "added" | "modified";
+}
+
+/** An API endpoint whose route file the branch diff touched. */
+export interface QaPrEndpoint {
+  method: string;
+  path: string;
+  file: string;
+  change: "added" | "modified" | "removed";
+}
+
+/** Branch/PR diff facts (head vs base) feeding the planner + coverage report. */
+export interface QaPrChanges {
+  baseBranch: string;
+  headBranch: string;
+  files: QaPrChangedFile[];
+  symbols: QaPrSymbol[];
+  endpoints: QaPrEndpoint[];
+  /** True when file/symbol caps dropped part of the diff. */
+  truncated?: boolean;
+}
+
+/** Coverage verdict for one branch change (symbol/endpoint) in the summary. */
+export interface QaPrCoverageEntry {
+  /** Ref string as listed in the digest ("createInvoice", "POST /api/x"). */
+  ref: string;
+  kind: "symbol" | "endpoint";
+  file: string;
+  change: "added" | "modified" | "removed";
+  planItemIds: string[];
+  testIds: string[];
+  status: "passed" | "covered" | "generated" | "planned" | "uncovered";
+}
+
+export interface QaPrCoverage {
+  baseBranch: string;
+  headBranch: string;
+  /** Entries with a live test (passed/covered/generated). */
+  coveredCount: number;
+  entries: QaPrCoverageEntry[];
+}
+
 export interface QaDiscovery {
   targetUrl: string;
   crawledPages: QaPageSnapshot[];
@@ -2977,6 +3037,10 @@ export interface QaDiscovery {
     testingNotes: string[];
     declaredEndpoints: Array<{ method: string; path: string; file: string }>;
   };
+  /** Branch diff vs the base branch (repo-aware mode, head ≠ base): the
+   *  functions/endpoints this branch adds or changes. Feeds the planner
+   *  ("cover these") and the summary's PR coverage report. */
+  prChanges?: QaPrChanges;
 }
 
 /** How a QA session runs. `full` is the complete pipeline; `refresh_spec`
@@ -3038,6 +3102,8 @@ export interface QaSummaryData {
   matrix?: Record<string, Partial<Record<QaTestGroup, QaMatrixCell>>>;
   /** journeyId → testIds covering it (traceability matrix). */
   journeyCoverage: Record<string, string[]>;
+  /** Per-change coverage of the branch diff (repo-aware runs on a branch). */
+  prCoverage?: QaPrCoverage;
 }
 
 export interface AgentSessionMetadata {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -2919,10 +2919,19 @@ export interface QaDiscovery {
   githubConnected: boolean;
 }
 
+/** How a QA session runs. `full` is the complete pipeline; `refresh_spec`
+ *  re-discovers the app and re-plans against existing coverage (no
+ *  generation); `fill_gaps` takes the latest plan and generates only the
+ *  items not already covered by a live test. */
+export type QaRunMode = "full" | "refresh_spec" | "fill_gaps";
+
 export type QaGeneratedTestStatus =
   | "generating"
   | "generated"
   | "generation_failed"
+  /** Matched to a pre-existing test (from a prior run or manual authoring) —
+   *  generation skipped, `testId` points at that test. */
+  | "covered"
   | "passed"
   | "failed"
   | "healed";
@@ -2940,11 +2949,16 @@ export interface QaGeneratedTest {
 export interface QaSummaryData {
   planned: number;
   generated: number;
+  /** Plan items satisfied by pre-existing tests (no generation needed). */
+  covered: number;
   passed: number;
   failed: number;
   healed: number;
   byGroup: Partial<
-    Record<QaTestGroup, { planned: number; generated: number; passed: number }>
+    Record<
+      QaTestGroup,
+      { planned: number; generated: number; covered: number; passed: number }
+    >
   >;
   /** journeyId → testIds covering it (traceability matrix). */
   journeyCoverage: Record<string, string[]>;
@@ -3010,6 +3024,11 @@ export interface AgentSessionMetadata {
   // encryption-at-rest treatment from the agent-session query layer.
   /** Target app base URL under test. */
   qaTargetUrl?: string;
+  /** How this session runs (full | refresh_spec | fill_gaps). Absent on
+   *  sessions created before modes existed — treated as "full". */
+  qaMode?: QaRunMode;
+  /** For fill_gaps runs: the prior session whose plan/discovery was reused. */
+  qaPlanSourceSessionId?: string;
   /** Coverage groups selected for this run ("journey" is always included). */
   qaGroups?: QaTestGroup[];
   /** Skip the human plan-review gate and generate immediately. */

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -2908,6 +2908,10 @@ export interface QaPlanItem {
   /** Exact ref strings from the branch-diff digest this item covers (symbol
    *  names, "METHOD /path" endpoints, file paths) — drives PR coverage. */
   changeRefs?: string[];
+  /** Set at plan time when a pre-existing test already covers this item
+   *  (matchPlanToExistingTests) — the review UI shows what already exists. */
+  existingTestId?: string;
+  existingTestName?: string;
   api?: {
     method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
     path: string;
@@ -3027,6 +3031,12 @@ export interface QaDiscovery {
   staticRoutes?: Array<{ path: string; type: string }>;
   framework?: string;
   githubConnected: boolean;
+  /** Branch the static scan + code check analyzed (the repo's selected
+   *  branch, falling back to its default branch). */
+  branch?: string;
+  /** Base branch for the PR diff (the repo's default branch). branch ===
+   *  baseBranch means the run analyzed the base itself — no diff exists. */
+  baseBranch?: string;
   /** Code-check output (repo-aware mode): stack facts, testing implications,
    *  and API endpoints declared in code. Shape in src/lib/qa-agent/code-check. */
   codeCheck?: {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -2967,6 +2967,16 @@ export interface QaDiscovery {
   staticRoutes?: Array<{ path: string; type: string }>;
   framework?: string;
   githubConnected: boolean;
+  /** Code-check output (repo-aware mode): stack facts, testing implications,
+   *  and API endpoints declared in code. Shape in src/lib/qa-agent/code-check. */
+  codeCheck?: {
+    framework?: string;
+    authMechanism?: string;
+    apiLayer?: string;
+    projectDescription?: string;
+    testingNotes: string[];
+    declaredEndpoints: Array<{ method: string; path: string; file: string }>;
+  };
 }
 
 /** How a QA session runs. `full` is the complete pipeline; `refresh_spec`
@@ -3107,6 +3117,12 @@ export interface AgentSessionMetadata {
   qaAuth?: QaAuthState;
   /** Live + static discovery output feeding the planner. */
   qaDiscovery?: QaDiscovery;
+  /** Uploaded product docs (name + decoded size only — raw files are never
+   *  persisted). */
+  qaDocs?: Array<{ name: string; chars: number }>;
+  /** Condensed documentation text the planner treats as authoritative for
+   *  intended behavior. Capped (see src/lib/qa-agent/docs.ts). */
+  qaDocsDigest?: string;
   /** The structured test plan produced by the planner subagent. */
   qaPlan?: QaTestPlan;
   /** User feedback captured on "request changes" — fed to the planner rerun. */

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -2954,6 +2954,10 @@ export interface QaPageSnapshot {
   testIds: string[];
   candidateSelectors: string[];
   apiEndpoints: Array<{ method: string; path: string; status: number }>;
+  /** Console errors observed while this page loaded — surfaces third-party /
+   *  analytics noise so the planner can route-block it or downgrade the
+   *  console check layer (the executor reds on ANY console error otherwise). */
+  consoleErrors?: string[];
 }
 
 export interface QaDiscovery {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -3059,6 +3059,16 @@ export interface QaDiscovery {
  *  items not already covered by a live test. */
 export type QaRunMode = "full" | "refresh_spec" | "fill_gaps";
 
+/** What started a QA session. `schedule`/`pr`/`mcp` are reserved for the
+ *  trigger phases (cron, PR webhook, MCP control). */
+export type QaSessionTrigger =
+  | "manual"
+  | "task"
+  | "rerun"
+  | "schedule"
+  | "pr"
+  | "mcp";
+
 export type QaGeneratedTestStatus =
   | "generating"
   | "generated"
@@ -3213,6 +3223,11 @@ export interface AgentSessionMetadata {
   qaRunIds?: string[];
   /** Final coverage/traceability summary. */
   qaSummary?: QaSummaryData;
+  /** Task from the direction queue this session is working (dispatcher-run). */
+  qaTaskId?: string;
+  /** What started this session — powers the run-history provenance chip.
+   *  Absent on sessions created before triggers existed = "manual". */
+  qaTrigger?: QaSessionTrigger;
   [key: string]: unknown;
 }
 
@@ -3237,6 +3252,58 @@ export const agentSessions = pgTable("agent_sessions", {
 
 export type AgentSession = typeof agentSessions.$inferSelect;
 export type NewAgentSession = typeof agentSessions.$inferInsert;
+
+// ── QA Agent Tasks (direction queue for the ongoing QA agent) ───────────────
+
+export type QaTaskStatus =
+  | "queued"
+  | "working"
+  /** The agent finished abnormally (failed/cancelled run) and left a reply —
+   *  the human decides whether to retry (→ queued) or drop (→ cancelled). */
+  | "needs_input"
+  | "done"
+  | "cancelled";
+
+export type QaTaskSource = "user" | "mcp" | "coverage_gap";
+
+/** A directive dropped into the QA agent's queue ("test the billing flow",
+ *  "increase Dashboard a11y coverage"). The dispatcher picks tasks up oldest
+ *  first whenever no QA session is active, runs a task-scoped session, writes
+ *  the agent's reply back, and advances the status — the /qa-agent task board
+ *  renders these as kanban columns. */
+export const qaTasks = pgTable(
+  "qa_tasks",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    repositoryId: text("repository_id")
+      .references(() => repositories.id, { onDelete: "cascade" })
+      .notNull(),
+    teamId: text("team_id").notNull(),
+    title: text("title").notNull(),
+    description: text("description"),
+    status: text("status").$type<QaTaskStatus>().notNull().default("queued"),
+    source: text("source").$type<QaTaskSource>().notNull().default("user"),
+    /** Display name of who filed it (user name or MCP client name). */
+    createdByName: text("created_by_name"),
+    createdById: text("created_by_id"),
+    /** Agent session that is working (or worked) this task. */
+    sessionId: text("session_id"),
+    /** The agent's reply when it finishes — or why it needs input. */
+    agentReply: text("agent_reply"),
+    createdAt: timestamp("created_at").$defaultFn(() => new Date()),
+    updatedAt: timestamp("updated_at").$defaultFn(() => new Date()),
+    startedAt: timestamp("started_at"),
+    completedAt: timestamp("completed_at"),
+  },
+  (table) => [
+    index("idx_qa_tasks_repo_status").on(table.repositoryId, table.status),
+  ],
+);
+
+export type QaTask = typeof qaTasks.$inferSelect;
+export type NewQaTask = typeof qaTasks.$inferInsert;
 
 // ── Bug Reports ──────────────────────────────────────────────────────────────
 
@@ -3678,6 +3745,11 @@ export type ActivityEventType =
   | "step:error"
   | "step:waiting_user"
   | "substep:update"
+  // QA agent direction queue
+  | "task:created"
+  | "task:started"
+  | "task:completed"
+  | "task:failed"
   | "mcp:tool_call"
   | "mcp:tool_result"
   | "mcp:tool_error"

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -2607,6 +2607,7 @@ export type AgentStepId =
   | "ranger_browse"
   // QA Agent (dedicated comprehensive-suite builder, /qa-agent page)
   | "qa_setup"
+  | "qa_login"
   | "qa_discover"
   | "qa_plan"
   | "qa_plan_review"
@@ -2829,6 +2830,40 @@ export type QaTestGroup =
   | "journey";
 
 export type QaPriority = "P1" | "P2" | "P3";
+
+/** How the qa_login step resolved authentication for the run. */
+export type QaAuthStrategy =
+  /** Repo setup infrastructure reused (default setup steps / storage state). */
+  | "existing_setup"
+  /** User-provided credentials verified on the EB; storage state captured. */
+  | "user_creds"
+  /** The agent registered its own throwaway account and captured a session. */
+  | "self_registered"
+  /** Credentials exist but could not be verified — discovery tests them inline. */
+  | "creds_untested"
+  /** No auth resolvable — public surface only (discovery maps the auth pages). */
+  | "public_only";
+
+/** Outcome of the qa_login resolution cascade. Holds no secrets — registered
+ *  credentials go into quickstartEmail/quickstartPassword (encrypted at rest). */
+export interface QaAuthState {
+  strategy: QaAuthStrategy;
+  /** The authed heuristic was confirmed live on an EB (no password field,
+   *  final URL not an auth page). False = deferred to discovery/execution. */
+  validated: boolean;
+  storageStateId?: string;
+  /** Login/signup setup test created or found for reuse via setupOverrides. */
+  setupTestId?: string;
+  /** Repo default setup steps already cover auth — generated tests must NOT
+   *  add extraSteps (the executor applies defaults to every test already). */
+  defaultSetupInUse?: boolean;
+  /** Observed in the target app's DOM — never URL-guessed. */
+  loginUrl?: string;
+  /** Observed in the target app's DOM — never URL-guessed. */
+  signupUrl?: string;
+  registeredEmail?: string;
+  notes?: string;
+}
 
 /** A critical user journey with a verifiable business outcome. */
 export interface QaPlanJourney {
@@ -3060,6 +3095,12 @@ export interface AgentSessionMetadata {
   qaGroups?: QaTestGroup[];
   /** Skip the human plan-review gate and generate immediately. */
   qaAutoApprove?: boolean;
+  /** Allow the qa_login step to self-register a throwaway account when no
+   *  credentials/setup exist and a signup link is discovered in the DOM.
+   *  Absent = allowed (opt-out via the setup form). */
+  qaAllowRegistration?: boolean;
+  /** Resolved auth strategy for this run, decided by the qa_login step. */
+  qaAuth?: QaAuthState;
   /** Live + static discovery output feeding the planner. */
   qaDiscovery?: QaDiscovery;
   /** The structured test plan produced by the planner subagent. */

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1803,6 +1803,7 @@ export type AIActionType =
   | "agent_generate"
   | "agent_heal"
   | "agent_play"
+  | "qa_plan"
   | "triage"
   | "generate_var_value"
   | "suggest_app_fix";
@@ -2576,7 +2577,7 @@ export type AgentSessionStatus =
   | "failed"
   | "cancelled";
 
-export type AgentSessionKind = "play" | "quickstart" | "ranger";
+export type AgentSessionKind = "play" | "quickstart" | "ranger" | "qa";
 
 export type AgentStepId =
   | "settings_check"
@@ -2603,7 +2604,16 @@ export type AgentStepId =
   | "qs_publish_share"
   // Ranger (EB-backed live page scout, MCP-driven)
   | "ranger_provision"
-  | "ranger_browse";
+  | "ranger_browse"
+  // QA Agent (dedicated comprehensive-suite builder, /qa-agent page)
+  | "qa_setup"
+  | "qa_discover"
+  | "qa_plan"
+  | "qa_plan_review"
+  | "qa_generate"
+  | "qa_execute"
+  | "qa_heal"
+  | "qa_summary";
 
 export type AgentStepStatus =
   | "pending"
@@ -2801,6 +2811,145 @@ export interface QuickstartAuthSetupMeta {
   mode?: "login" | "signup";
 }
 
+// ── QA Agent (comprehensive suite builder) ──────────────────────────────────
+
+/** Coverage groups the QA agent plans and generates tests for. Mirrors the
+ *  industry-standard suite tiers (smoke/regression) and coverage angles
+ *  (a11y/perf/resilience/negative); `journey` is the business-outcome E2E
+ *  tier (e.g. "an order is actually placed") and is always planned. */
+export type QaTestGroup =
+  | "smoke"
+  | "api"
+  | "ui"
+  | "hybrid"
+  | "a11y"
+  | "perf"
+  | "resilience"
+  | "negative"
+  | "journey";
+
+export type QaPriority = "P1" | "P2" | "P3";
+
+/** A critical user journey with a verifiable business outcome. */
+export interface QaPlanJourney {
+  id: string;
+  title: string;
+  priority: QaPriority;
+  /** Ordered user-visible steps of the journey. */
+  steps: string[];
+  /** The business outcome this journey must produce (e.g. "order placed"). */
+  businessOutcome: string;
+  /** How the outcome is proven beyond UI toasts (end-state via API/data/UI). */
+  endStateVerification: string;
+}
+
+/** One planned test case. `scenario` is generator-ready prose (steps +
+ *  expected results); `api` is set for api-group items and drives a headless
+ *  ApiTestDefinition instead of a browser test. */
+export interface QaPlanItem {
+  id: string;
+  group: QaTestGroup;
+  title: string;
+  priority: QaPriority;
+  /** Traceability link to the journey this test covers, when applicable. */
+  journeyId?: string;
+  /** Route/page under test, relative to the target base URL. */
+  pagePath?: string;
+  rationale?: string;
+  scenario: string;
+  /** Verified selectors from discovery the generator should prefer. */
+  selectorHints?: string[];
+  api?: {
+    method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+    path: string;
+    expectedStatus?: number;
+    body?: unknown;
+    description?: string;
+  };
+  /** User can exclude items during plan review. Absent = enabled. */
+  enabled?: boolean;
+}
+
+export interface QaTestPlan {
+  appProfile: {
+    summary: string;
+    businessDomain?: string;
+    /** The single most valuable business outcome of the app. */
+    primaryOutcome?: string;
+  };
+  journeys: QaPlanJourney[];
+  items: QaPlanItem[];
+  entryCriteria?: string[];
+  exitCriteria?: string[];
+  risks?: string[];
+}
+
+/** One live-crawled page: rendered-DOM facts + same-origin API endpoints
+ *  observed while the page loaded. Fed (condensed) to the planner. */
+export interface QaPageSnapshot {
+  url: string;
+  finalUrl: string;
+  title: string | null;
+  headings: Array<{ level: number; text: string }>;
+  forms: Array<{
+    name: string | null;
+    action: string | null;
+    method: string;
+    inputs: Array<{
+      tag: string;
+      type: string | null;
+      name: string | null;
+      id: string | null;
+      label: string | null;
+    }>;
+  }>;
+  buttons: string[];
+  links: Array<{ text: string; href: string }>;
+  testIds: string[];
+  candidateSelectors: string[];
+  apiEndpoints: Array<{ method: string; path: string; status: number }>;
+}
+
+export interface QaDiscovery {
+  targetUrl: string;
+  crawledPages: QaPageSnapshot[];
+  /** Routes from the static GitHub-tree scan (repo-aware mode only). */
+  staticRoutes?: Array<{ path: string; type: string }>;
+  framework?: string;
+  githubConnected: boolean;
+}
+
+export type QaGeneratedTestStatus =
+  | "generating"
+  | "generated"
+  | "generation_failed"
+  | "passed"
+  | "failed"
+  | "healed";
+
+export interface QaGeneratedTest {
+  planItemId: string;
+  group: QaTestGroup;
+  /** Absent when generation failed before a test row was created. */
+  testId?: string;
+  name: string;
+  status: QaGeneratedTestStatus;
+  error?: string;
+}
+
+export interface QaSummaryData {
+  planned: number;
+  generated: number;
+  passed: number;
+  failed: number;
+  healed: number;
+  byGroup: Partial<
+    Record<QaTestGroup, { planned: number; generated: number; passed: number }>
+  >;
+  /** journeyId → testIds covering it (traceability matrix). */
+  journeyCoverage: Record<string, string[]>;
+}
+
 export interface AgentSessionMetadata {
   buildIds?: string[];
   fixAttempts?: Record<string, number>;
@@ -2856,6 +3005,27 @@ export interface AgentSessionMetadata {
   rangerUrl?: string;
   /** Deterministic rendered page map produced by the ranger EB browse. */
   rangerPageMap?: Record<string, unknown>;
+  // QA Agent fields (kind = "qa"). Credentials for the target app reuse
+  // quickstartEmail/quickstartPassword above so they get the same AES-256-GCM
+  // encryption-at-rest treatment from the agent-session query layer.
+  /** Target app base URL under test. */
+  qaTargetUrl?: string;
+  /** Coverage groups selected for this run ("journey" is always included). */
+  qaGroups?: QaTestGroup[];
+  /** Skip the human plan-review gate and generate immediately. */
+  qaAutoApprove?: boolean;
+  /** Live + static discovery output feeding the planner. */
+  qaDiscovery?: QaDiscovery;
+  /** The structured test plan produced by the planner subagent. */
+  qaPlan?: QaTestPlan;
+  /** User feedback captured on "request changes" — fed to the planner rerun. */
+  qaPlannerFeedback?: string;
+  /** Per-plan-item generation/execution status ledger. */
+  qaGeneratedTests?: QaGeneratedTest[];
+  /** Test-run ids started by the execute/heal phases. */
+  qaRunIds?: string[];
+  /** Final coverage/traceability summary. */
+  qaSummary?: QaSummaryData;
   [key: string]: unknown;
 }
 
@@ -3350,7 +3520,8 @@ export type ActivitySourceType =
   | "play_agent"
   | "mcp_server"
   | "generate_agent"
-  | "heal_agent";
+  | "heal_agent"
+  | "qa_agent";
 
 export type ActivityArtifactType =
   | "test"

--- a/src/lib/eb/inject-storage-state.ts
+++ b/src/lib/eb/inject-storage-state.ts
@@ -1,0 +1,84 @@
+import { chromium, type Browser } from "playwright";
+
+/**
+ * Inject a captured storage_state (cookies + localStorage) into the EB's default
+ * browser context over CDP, so the next agent phase starts already-signed-in.
+ * This removes LLM/deterministic login replays when a session was already
+ * captured moments earlier.
+ *
+ * Targets `browser.contexts()[0]` — the persistent default context that
+ * `@playwright/mcp --cdp-endpoint` reuses — NOT a fresh `newContext` (which MCP
+ * would never see). `browser.close()` over connectOverCDP only disconnects the
+ * CDP session; it does not terminate the EB's Chromium (mirrors play-agent.ts).
+ *
+ * Returns whether enough session material (cookies and/or localStorage) was
+ * injected to consider the browser pre-authenticated. IndexedDB-only captures
+ * (e.g. Firebase) inject nothing here → caller falls back to seed replay.
+ */
+export async function injectStorageStateIntoEb(
+  cdpUrl: string,
+  storageStateJson: string,
+): Promise<boolean> {
+  let browser: Browser | null = null;
+  try {
+    const parsed = JSON.parse(storageStateJson) as {
+      cookies?: Array<Record<string, unknown>>;
+      origins?: Array<{
+        origin?: string;
+        localStorage?: Array<{ name: string; value: string }>;
+      }>;
+    };
+    const cookies = Array.isArray(parsed.cookies) ? parsed.cookies : [];
+    const origins = Array.isArray(parsed.origins) ? parsed.origins : [];
+    const hasLocalStorage = origins.some(
+      (o) => Array.isArray(o.localStorage) && o.localStorage.length > 0,
+    );
+    // Nothing cookie/localStorage-shaped to inject (e.g. IndexedDB-only Firebase
+    // capture) — let the caller fall back to LLM seed replay.
+    if (cookies.length === 0 && !hasLocalStorage) return false;
+
+    browser = await chromium.connectOverCDP(cdpUrl);
+    const ctx = browser.contexts()[0];
+    if (!ctx) return false;
+
+    if (cookies.length > 0) {
+      // Cookies come straight from Playwright's own storageState() capture, so
+      // they already match addCookies' param shape — route through `unknown` to
+      // satisfy the structural check on the loosely-parsed JSON.
+      await ctx.addCookies(
+        cookies as unknown as Parameters<typeof ctx.addCookies>[0],
+      );
+    }
+    for (const o of origins) {
+      const ls = Array.isArray(o.localStorage) ? o.localStorage : [];
+      if (!o.origin || ls.length === 0) continue;
+      const page = await ctx.newPage();
+      try {
+        await page
+          .goto(o.origin, { waitUntil: "domcontentloaded", timeout: 10000 })
+          .catch(() => {});
+        await page.evaluate((items) => {
+          for (const it of items) {
+            try {
+              window.localStorage.setItem(it.name, it.value);
+            } catch {
+              /* quota / opaque origin — best effort */
+            }
+          }
+        }, ls);
+      } finally {
+        await page.close().catch(() => {});
+      }
+    }
+    return true;
+  } catch (err) {
+    console.warn(
+      `[EB storage-state] injection failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return false;
+  } finally {
+    if (browser) await browser.close().catch(() => {});
+  }
+}

--- a/src/lib/eb/inject-storage-state.ts
+++ b/src/lib/eb/inject-storage-state.ts
@@ -1,15 +1,35 @@
 import { chromium, type Browser } from "playwright";
 
+interface CapturedCookie {
+  name?: string;
+  value?: string;
+  domain?: string;
+  path?: string;
+  expires?: number;
+  httpOnly?: boolean;
+  secure?: boolean;
+  sameSite?: "Strict" | "Lax" | "None";
+}
+
 /**
- * Inject a captured storage_state (cookies + localStorage) into the EB's default
- * browser context over CDP, so the next agent phase starts already-signed-in.
- * This removes LLM/deterministic login replays when a session was already
- * captured moments earlier.
+ * Inject a captured storage_state (cookies + localStorage) into the EB's live
+ * page over CDP, so the next agent phase starts already-signed-in.
  *
- * Targets `browser.contexts()[0]` — the persistent default context that
- * `@playwright/mcp --cdp-endpoint` reuses — NOT a fresh `newContext` (which MCP
- * would never see). `browser.close()` over connectOverCDP only disconnects the
- * CDP session; it does not terminate the EB's Chromium (mirrors play-agent.ts).
+ * IMPORTANT: Playwright's `context.addCookies()` is the WRONG tool here. The
+ * EB's page lives in a non-default browser context (`browser.newContext()` in
+ * the EB service); over `connectOverCDP`, `addCookies` writes to a cookie
+ * store the page's network stack never reads — the cookie shows up in
+ * `context.cookies()` but Chromium NEVER SENDS it (verified against a live EB
+ * pod: `document.cookie` stays empty, requests carry no Cookie header).
+ * A page-level CDP `Network.setCookie` writes to the page's real store and
+ * authenticates immediately. Reads (`storageState()`) are unaffected.
+ *
+ * localStorage is set by driving the EB's OWN page to each origin — a
+ * `context.newPage()` can land in a different context with a separate
+ * storage bucket, same failure mode as the cookies.
+ *
+ * `browser.close()` over connectOverCDP only disconnects the CDP session; it
+ * does not terminate the EB's Chromium (mirrors play-agent.ts).
  *
  * Returns whether enough session material (cookies and/or localStorage) was
  * injected to consider the browser pre-authenticated. IndexedDB-only captures
@@ -22,7 +42,7 @@ export async function injectStorageStateIntoEb(
   let browser: Browser | null = null;
   try {
     const parsed = JSON.parse(storageStateJson) as {
-      cookies?: Array<Record<string, unknown>>;
+      cookies?: CapturedCookie[];
       origins?: Array<{
         origin?: string;
         localStorage?: Array<{ name: string; value: string }>;
@@ -40,23 +60,46 @@ export async function injectStorageStateIntoEb(
     browser = await chromium.connectOverCDP(cdpUrl);
     const ctx = browser.contexts()[0];
     if (!ctx) return false;
+    const page = ctx.pages()[0] ?? (await ctx.newPage());
 
+    let injected = false;
     if (cookies.length > 0) {
-      // Cookies come straight from Playwright's own storageState() capture, so
-      // they already match addCookies' param shape — route through `unknown` to
-      // satisfy the structural check on the loosely-parsed JSON.
-      await ctx.addCookies(
-        cookies as unknown as Parameters<typeof ctx.addCookies>[0],
-      );
+      const cdp = await ctx.newCDPSession(page);
+      try {
+        for (const c of cookies) {
+          if (!c.name || typeof c.value !== "string") continue;
+          const ok = await cdp
+            .send("Network.setCookie", {
+              name: c.name,
+              value: c.value,
+              domain: c.domain,
+              path: c.path ?? "/",
+              secure: c.secure,
+              httpOnly: c.httpOnly,
+              sameSite: c.sameSite,
+              // -1 marks a session cookie in Playwright captures — omit so
+              // CDP treats it as a session cookie instead of expired.
+              ...(typeof c.expires === "number" && c.expires > 0
+                ? { expires: Math.floor(c.expires) }
+                : {}),
+            })
+            .then((r) => (r as { success?: boolean }).success !== false)
+            .catch(() => false);
+          injected = injected || ok;
+        }
+      } finally {
+        await cdp.detach().catch(() => {});
+      }
     }
+
     for (const o of origins) {
       const ls = Array.isArray(o.localStorage) ? o.localStorage : [];
       if (!o.origin || ls.length === 0) continue;
-      const page = await ctx.newPage();
       try {
-        await page
-          .goto(o.origin, { waitUntil: "domcontentloaded", timeout: 10000 })
-          .catch(() => {});
+        await page.goto(o.origin, {
+          waitUntil: "domcontentloaded",
+          timeout: 10000,
+        });
         await page.evaluate((items) => {
           for (const it of items) {
             try {
@@ -66,11 +109,12 @@ export async function injectStorageStateIntoEb(
             }
           }
         }, ls);
-      } finally {
-        await page.close().catch(() => {});
+        injected = true;
+      } catch {
+        // Best-effort per origin — cookies may already be enough.
       }
     }
-    return true;
+    return injected;
   } catch (err) {
     console.warn(
       `[EB storage-state] injection failed: ${

--- a/src/lib/github/content.ts
+++ b/src/lib/github/content.ts
@@ -243,6 +243,10 @@ export interface CompareResult {
     additions: number;
     deletions: number;
     changes: number;
+    /** Unified-diff hunk text for this file (absent for binary/huge files). */
+    patch?: string;
+    /** Original path for renamed files. */
+    previousFilename?: string;
   }>;
   baseBranch: string;
   headBranch: string;
@@ -296,12 +300,16 @@ export async function compareBranches(
           additions: number;
           deletions: number;
           changes: number;
+          patch?: string;
+          previous_filename?: string;
         }) => ({
           filename: f.filename,
           status: f.status,
           additions: f.additions,
           deletions: f.deletions,
           changes: f.changes,
+          patch: f.patch,
+          previousFilename: f.previous_filename,
         }),
       ),
       baseBranch,

--- a/src/lib/launch/oauth-config.test.ts
+++ b/src/lib/launch/oauth-config.test.ts
@@ -3,7 +3,11 @@ import {
   isValidClientId,
   isAllowedRedirectUri,
   scopeIncludes,
+  scopeForClient,
   LAUNCH_CLIENT_ID,
+  LAUNCH_SCOPE,
+  PLAYGROUND_CLIENT_ID,
+  PLAYGROUND_SCOPE,
 } from "./oauth-config";
 
 describe("launch/oauth-config", () => {
@@ -12,10 +16,18 @@ describe("launch/oauth-config", () => {
     vi.unstubAllEnvs();
   });
 
-  it("only accepts the launch-www client id", () => {
+  it("only accepts registered client ids", () => {
     expect(isValidClientId(LAUNCH_CLIENT_ID)).toBe(true);
+    expect(isValidClientId(PLAYGROUND_CLIENT_ID)).toBe(true);
     expect(isValidClientId("something-else")).toBe(false);
     expect(isValidClientId(null)).toBe(false);
+  });
+
+  it("maps each client to its own scope", () => {
+    expect(scopeForClient(LAUNCH_CLIENT_ID)).toBe(LAUNCH_SCOPE);
+    expect(scopeForClient(PLAYGROUND_CLIENT_ID)).toBe(PLAYGROUND_SCOPE);
+    expect(scopeForClient("something-else")).toBe(null);
+    expect(scopeForClient(null)).toBe(null);
   });
 
   it("allows the production launch origin by default and localhost in dev", () => {

--- a/src/lib/launch/oauth-config.ts
+++ b/src/lib/launch/oauth-config.ts
@@ -1,14 +1,24 @@
 /**
- * Config for the implicit OAuth handoff that mints a launch-scoped token for
- * the launch.lastest.cloud frontend. The redirect-URI allowlist is the key
- * guard against open-redirect / token-leak: we only ever hand a token back to
- * an origin on this list.
+ * Config for the implicit OAuth handoff that mints scoped tokens for the
+ * static lastest-www frontends (launch board, playground leaderboard). The
+ * redirect-URI allowlist is the key guard against open-redirect / token-leak:
+ * we only ever hand a token back to an origin on this list.
  */
 
 import { DEFAULT_LAUNCH } from "@/lib/db/schema";
 
 export const LAUNCH_CLIENT_ID = "launch-www";
 export const LAUNCH_SCOPE = DEFAULT_LAUNCH.scope; // 'launch:vote launch:submit'
+
+export const PLAYGROUND_CLIENT_ID = "playground-www";
+export const PLAYGROUND_SCOPE = "playground:score";
+
+// clientId → the full scope string that client may be granted. Requested
+// scopes are intersected with this in /oauth/authorize.
+const CLIENT_SCOPES: Record<string, string> = {
+  [LAUNCH_CLIENT_ID]: LAUNCH_SCOPE,
+  [PLAYGROUND_CLIENT_ID]: PLAYGROUND_SCOPE,
+};
 
 /** Allowed origins a token may be returned to. Configurable via env for staging. */
 export function allowedRedirectOrigins(): string[] {
@@ -24,6 +34,7 @@ export function allowedRedirectOrigins(): string[] {
         .filter(Boolean)
     : [
         "https://launch.lastest.cloud",
+        "https://playground.lastest.cloud",
         "https://lastest.cloud",
         "https://www.lastest.cloud",
       ];
@@ -43,7 +54,12 @@ export function allowedRedirectOrigins(): string[] {
 }
 
 export function isValidClientId(clientId: string | null): boolean {
-  return clientId === LAUNCH_CLIENT_ID;
+  return clientId != null && clientId in CLIENT_SCOPES;
+}
+
+/** Full scope string a registered client may be granted (null if unknown). */
+export function scopeForClient(clientId: string | null): string | null {
+  return clientId != null ? (CLIENT_SCOPES[clientId] ?? null) : null;
 }
 
 export function isAllowedRedirectUri(redirectUri: string | null): boolean {

--- a/src/lib/playwright/generator-agent.ts
+++ b/src/lib/playwright/generator-agent.ts
@@ -148,8 +148,13 @@ export async function agentCreateTest(
 
     prompt += `\n\nTarget base URL: ${seed.baseUrl}`;
     prompt += `\nNavigate to the page, explore it using MCP tools, then generate the test code.`;
-    if (seed.hasLoginSetup) {
-      prompt += `\n\n**IMPORTANT: Do NOT include login/auth/setup steps in your generated test code. The seed fixture handles authentication during your MCP exploration, but at runtime a separate setup script logs in BEFORE the test runs. Your test should assume the user is already logged in — start directly on the page being tested.**`;
+    // The QA agent may have injected an authenticated session directly into the
+    // exploration browser (context.preAuthenticated) even when the repo has no
+    // login-bearing default setup step (seed.hasLoginSetup is false for a
+    // per-test storage_state override). Honor either signal so the generator's
+    // auth story matches the browser it is actually driving.
+    if (seed.hasLoginSetup || context.preAuthenticated) {
+      prompt += `\n\n**IMPORTANT: Do NOT include login/auth/setup steps in your generated test code. Authentication is applied automatically before the test runs (an injected session or a setup script), and your MCP exploration browser is already signed in. Your test should assume the user is already logged in — start directly on the page being tested. If exploration lands on a login page, the session lapsed: report it rather than scripting a manual login.**`;
     }
     prompt += `\n\n---\n\n${seed.seedPrompt}`;
 

--- a/src/lib/playwright/generator-agent.ts
+++ b/src/lib/playwright/generator-agent.ts
@@ -33,12 +33,13 @@ WORKFLOW:
 6. Identify the reliable selectors from the snapshots (role-based locators preferred)
 7. Generate the final test code using discovered selectors
 
-MULTI-SCENARIO TESTS:
-When given multiple scenarios, create ONE test function that covers all of them in sequence.
-After verifying each scenario, take a screenshot as a checkpoint using a unique filename:
-  await page.screenshot({ path: screenshotPath.replace('.png', '-scenario-1.png'), fullPage: true });
-The final screenshot should use the original screenshotPath.
+SCENARIO / CHECKPOINT STRUCTURE:
+You are usually given ONE scenario made of numbered steps. Take a screenshot checkpoint after each KEY state the scenario reaches — the initial page, and each state a later check layer needs to see (an opened dialog, an error/validation state, the post-submit confirmation). The platform runs axe / Core Web Vitals / visual diffing on EVERY captured state, so a state that is never screenshotted is never checked. Use a unique filename per checkpoint and the original screenshotPath for the final one:
+  await page.screenshot({ path: screenshotPath.replace('.png', '-step-1.png'), fullPage: true });
+If given multiple independent scenarios, cover them in one test function in sequence.
 Group related interactions (same page/route) together for efficiency — don't navigate away and back unnecessarily.
+
+OVERLAYS: If a cookie/consent banner, newsletter, or intro modal is present and would intercept clicks, dismiss it first (accept/close) via a verified selector before interacting with the page under test.
 
 OUTPUT FORMAT:
 Generate a single JavaScript function with this exact signature — NO imports, NO TypeScript:
@@ -70,6 +71,7 @@ CRITICAL RULES:
 - Use stepLogger.log() for step descriptions — prefix with "Scenario N:" for multi-scenario tests
 - ALWAYS use regex for URL checks: await expect(page).toHaveURL(/\\/path/)
 - Every variable must use const or let
+- UNIQUE TEST DATA: when the test creates a record (signup, new item, invite), build the uniqueness-constrained field at runtime with a unique suffix — e.g. const email = \`user-\${Date.now().toString(36)}@example.com\`. Never hardcode a value that a unique constraint will reject on the second run.
 - Output ONLY the code block, no explanations
 
 ${SELECTOR_ROBUSTNESS_RULES}`;

--- a/src/lib/playwright/healer-agent.ts
+++ b/src/lib/playwright/healer-agent.ts
@@ -61,6 +61,11 @@ CRITICAL RULES:
 - Output ONLY the fixed code block, no explanations
 - Do not add test.fixme() — always attempt a real fix
 
+PRESERVE THE TEST'S INTENT (do not "fix" a test by defeating its purpose):
+- NEVER delete or loosen an assertion just to make the test pass. Fix broken SELECTORS and TIMING; if an assertion is correct but the app genuinely misbehaves, leave that assertion failing — a real product bug is a valid test result, not something to heal away.
+- NEVER remove intentional failure injection (page.route(...).abort()/fulfill({ status: 500 })) or negative-input steps. Those tests are SUPPOSED to drive an error path; heal the assertion about the error UI, not the injection.
+- "Flexible matchers for dynamic data" means matching a stable pattern (e.g. a currency/number shape), NOT weakening a specific expected value into an always-true check (toBeVisible on the body, .toBeTruthy(), removing the assertion).
+
 ${SELECTOR_ROBUSTNESS_RULES}`;
 
 // ---------------------------------------------------------------------------
@@ -74,7 +79,14 @@ ${SELECTOR_ROBUSTNESS_RULES}`;
 export async function agentHealTestCore(
   repositoryId: string,
   testId: string,
-  options?: { cdpEndpoint?: string; signal?: AbortSignal },
+  options?: {
+    cdpEndpoint?: string;
+    signal?: AbortSignal;
+    /** Caller-supplied statement of what the test is meant to prove (QA agent
+     *  passes the plan item's coverage groups + end-state requirement) so the
+     *  healer preserves that intent instead of loosening assertions to pass. */
+    intent?: string;
+  },
 ): Promise<{ success: boolean; code?: string; error?: string }> {
   try {
     const test = await queries.getTest(testId);
@@ -82,9 +94,11 @@ export async function agentHealTestCore(
       return { success: false, error: "Test not found" };
     }
 
-    // Get latest error
+    // Get latest error. getTestResultsByTest is ordered newest-first, so the
+    // most recent failure is results[0] — NOT results.at(-1), which is the
+    // oldest run and would make the healer diagnose a stale error/DOM snapshot.
     const results = await queries.getTestResultsByTest(testId);
-    const latestResult = results[results.length - 1];
+    const latestResult = results[0];
     const errorMessage =
       latestResult?.errorMessage || "Test failed with unknown error";
 
@@ -122,7 +136,11 @@ ${test.code}
 \`\`\`
 ${errorMessage}
 \`\`\`
-${domDiffContext}
+${domDiffContext}${
+      options?.intent
+        ? `\n**What this test must prove (preserve this intent — do not weaken assertions to force a pass):**\n${options.intent}\n`
+        : ""
+    }
 **Base URL:** ${seed.baseUrl}
 
 Navigate to the relevant page using MCP tools, inspect the current UI state via browser_snapshot, diagnose why the test fails, and output the fixed test code.

--- a/src/lib/playwright/quickstart-templates.ts
+++ b/src/lib/playwright/quickstart-templates.ts
@@ -223,15 +223,35 @@ ${renderEbBootstrap()}
       return c && c.value && /session|auth|token|sid|jwt/i.test(c.name || '');
     });
   }
+  // A visible, non-empty error element = real rejection. Next.js renders an
+  // always-on 1px screen-reader route announcer with role="alert"
+  // (#__next-route-announcer__) — treating IT as a rejection made every
+  // signup on a Next app race its own redirect and false-fail.
+  async function visibleAuthError() {
+    const locs = page.locator('[role="alert"]:visible, .error:visible, [data-error]:visible');
+    const count = Math.min(await locs.count().catch(function () { return 0; }), 5);
+    for (let i = 0; i < count; i++) {
+      const el = locs.nth(i);
+      const id = (await el.getAttribute('id').catch(function () { return null; })) || '';
+      if (id === '__next-route-announcer__') continue;
+      const t = ((await el.textContent().catch(function () { return ''; })) || '').replace(/\\s+/g, ' ').trim();
+      if (t.length >= 4) return true;
+    }
+    return false;
+  }
   let authed = false;
   const authDeadline = Date.now() + 30000;
   while (Date.now() < authDeadline) {
     if (!AUTH_URL_RE.test(page.url()) || (await hasSessionCookie())) { authed = true; break; }
-    const rejected = await page.locator('[role="alert"]:visible, .error:visible, [data-error]:visible').first().isVisible().catch(function () { return false; });
-    if (rejected) break;
+    if (await visibleAuthError()) break;
     await page.waitForTimeout(500);
   }
   await settle();
+  // Success can land moments after the poll gives up (sign-up → consent
+  // server-action → hard navigation) — re-check both signals before judging.
+  if (!authed) {
+    authed = !AUTH_URL_RE.test(page.url()) || (await hasSessionCookie());
+  }
 
   stepLogger.log('Scenario 3: Post-signup landing');
   const verifyBanner = page.getByText(
@@ -419,7 +439,10 @@ ${renderEbBootstrap()}
     await submit.click().catch(function () {});
     await Promise.race([
       page.waitForURL(/dashboard|onboarding|welcome|home|app|projects|account/i, { timeout: 15000 }),
-      page.waitForSelector('[role="alert"]:visible, .error:visible, [data-error]:visible', { timeout: 15000 }),
+      // :not(#__next-route-announcer__) — Next's always-present sr-only alert
+      // must not short-circuit the wait (see visibleAuthError in the signup
+      // template).
+      page.waitForSelector('[role="alert"]:not(#__next-route-announcer__):visible, .error:visible, [data-error]:visible', { timeout: 15000 }),
     ]).catch(function () {});
   }
   await settle();
@@ -432,7 +455,7 @@ ${renderEbBootstrap()}
   if (onAuthUrl && (await stillSignInCta.isVisible().catch(() => false))) {
     await page.screenshot({ path: screenshotPath, fullPage: true });
     let errText = '';
-    const errLoc = page.locator('[role="alert"], [aria-live="polite"], [aria-live="assertive"], .error, .field-error, [class*="text-red"], [class*="text-destructive"]').first();
+    const errLoc = page.locator('[role="alert"]:not(#__next-route-announcer__), [aria-live="polite"], [aria-live="assertive"], .error, .field-error, [class*="text-red"], [class*="text-destructive"]').first();
     if (await errLoc.isVisible().catch(() => false)) {
       errText = ((await errLoc.textContent().catch(() => '')) || '').replace(/\\s+/g, ' ').trim().slice(0, 200);
     }

--- a/src/lib/qa-agent/auth-links.test.ts
+++ b/src/lib/qa-agent/auth-links.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { isAuthLink, looksLikeAuthUrl, matchAuthLinks } from "./auth-links";
+
+describe("isAuthLink", () => {
+  it("matches login/signin/signup/register in text or href", () => {
+    expect(isAuthLink("Log in", "/whatever")).toBe(true);
+    expect(isAuthLink("Sign In", "/x")).toBe(true);
+    expect(isAuthLink("Sign up free", "/x")).toBe(true);
+    expect(isAuthLink("Register", "/x")).toBe(true);
+    expect(isAuthLink("Create an account", "/x")).toBe(true);
+    expect(isAuthLink("", "/login")).toBe(true);
+    expect(isAuthLink("", "/auth/sign-in")).toBe(true);
+  });
+
+  it("does not match unrelated links", () => {
+    expect(isAuthLink("Pricing", "/pricing")).toBe(false);
+    expect(isAuthLink("Blog", "/blog/sign-language")).toBe(false);
+    expect(isAuthLink("Design tokens", "/design")).toBe(false);
+  });
+});
+
+describe("looksLikeAuthUrl", () => {
+  it("matches auth-page pathnames", () => {
+    expect(looksLikeAuthUrl("/login")).toBe(true);
+    expect(looksLikeAuthUrl("/sign-in")).toBe(true);
+    expect(looksLikeAuthUrl("/signup")).toBe(true);
+    expect(looksLikeAuthUrl("/register")).toBe(true);
+    expect(looksLikeAuthUrl("/auth/callback")).toBe(true);
+    expect(looksLikeAuthUrl("/app/login")).toBe(true);
+  });
+
+  it("does not match content paths containing auth-ish words", () => {
+    expect(looksLikeAuthUrl("/blog/sign-language")).toBe(false);
+    expect(looksLikeAuthUrl("/author/jane")).toBe(false);
+    expect(looksLikeAuthUrl("/dashboard")).toBe(false);
+    expect(looksLikeAuthUrl("/")).toBe(false);
+  });
+});
+
+describe("matchAuthLinks", () => {
+  const base = "https://app.example.com";
+
+  it("picks login and signup from observed links (text and href)", () => {
+    const { loginUrl, signupUrl } = matchAuthLinks(
+      [
+        { text: "Home", href: "/" },
+        { text: "Sign in", href: "/session/new" },
+        { text: "Get started", href: "/onboarding/create-account" },
+      ],
+      base,
+    );
+    expect(loginUrl).toBe("https://app.example.com/session/new");
+    expect(signupUrl).toBe("https://app.example.com/onboarding/create-account");
+  });
+
+  it("ignores cross-origin and javascript links", () => {
+    const { loginUrl, signupUrl } = matchAuthLinks(
+      [
+        { text: "Log in", href: "https://other.example.org/login" },
+        { text: "Sign up", href: "javascript:void(0)" },
+      ],
+      base,
+    );
+    expect(loginUrl).toBeUndefined();
+    expect(signupUrl).toBeUndefined();
+  });
+
+  it("returns nothing when no auth links are rendered (no guessing)", () => {
+    const result = matchAuthLinks(
+      [
+        { text: "Docs", href: "/docs" },
+        { text: "Pricing", href: "/pricing" },
+      ],
+      base,
+    );
+    expect(result.loginUrl).toBeUndefined();
+    expect(result.signupUrl).toBeUndefined();
+  });
+
+  it("resolves relative hrefs against the base and strips hashes", () => {
+    const { loginUrl } = matchAuthLinks(
+      [{ text: "", href: "login#top" }],
+      `${base}/deep/page`,
+    );
+    expect(loginUrl).toBe("https://app.example.com/deep/login");
+  });
+
+  it("a signup-only page yields no loginUrl", () => {
+    const { loginUrl, signupUrl } = matchAuthLinks(
+      [{ text: "Register", href: "/register" }],
+      base,
+    );
+    expect(loginUrl).toBeUndefined();
+    expect(signupUrl).toBe("https://app.example.com/register");
+  });
+});

--- a/src/lib/qa-agent/auth-links.ts
+++ b/src/lib/qa-agent/auth-links.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure auth-surface matchers shared by the QA agent's crawl and login step.
+ * Everything here operates on DOM-observed link text/hrefs — auth URLs are
+ * never guessed (no probing /login or /signup that nothing links to).
+ */
+
+const LOGIN_RE = /\b(?:log[ _-]?in|sign[ _-]?in)\b/i;
+const SIGNUP_RE =
+  /\b(?:sign[ _-]?up|register|create[ _-]+(?:an?[ _-]+)?account)\b/i;
+
+/** True when a link's text or href reads as an auth page (login OR signup). */
+export function isAuthLink(text: string, href: string): boolean {
+  return (
+    LOGIN_RE.test(text) ||
+    SIGNUP_RE.test(text) ||
+    LOGIN_RE.test(href) ||
+    SIGNUP_RE.test(href)
+  );
+}
+
+/** True when a pathname looks like an auth page (used to decide "still on the
+ *  login surface" after a login attempt). Segment-anchored so content paths
+ *  like /blog/sign-language don't match. */
+export function looksLikeAuthUrl(pathname: string): boolean {
+  return /(?:^|\/)(?:log[_-]?in|sign[_-]?in|sign[_-]?up|register|auth)(?:$|[/?#._-])/i.test(
+    pathname,
+  );
+}
+
+/**
+ * Pick the login and signup URLs out of a page's observed links. Same-origin
+ * only, first match wins, returns absolute URLs (hash stripped).
+ */
+export function matchAuthLinks(
+  links: Array<{ text: string; href: string }>,
+  baseUrl: string,
+): { loginUrl?: string; signupUrl?: string } {
+  let base: URL;
+  try {
+    base = new URL(baseUrl);
+  } catch {
+    return {};
+  }
+  let loginUrl: string | undefined;
+  let signupUrl: string | undefined;
+  for (const link of links) {
+    if (!link.href || link.href.startsWith("javascript:")) continue;
+    let url: URL;
+    try {
+      url = new URL(link.href, base);
+    } catch {
+      continue;
+    }
+    if (url.origin !== base.origin) continue;
+    url.hash = "";
+    const haystack = `${link.text} ${url.pathname}`;
+    if (!loginUrl && LOGIN_RE.test(haystack)) loginUrl = url.href;
+    if (!signupUrl && SIGNUP_RE.test(haystack)) signupUrl = url.href;
+    if (loginUrl && signupUrl) break;
+  }
+  return { loginUrl, signupUrl };
+}

--- a/src/lib/qa-agent/auth.ts
+++ b/src/lib/qa-agent/auth.ts
@@ -1,0 +1,263 @@
+import { chromium, type Browser, type Page } from "playwright";
+import * as queries from "@/lib/db/queries";
+import { injectStorageStateIntoEb } from "@/lib/eb/inject-storage-state";
+import { attemptLogin } from "@/lib/qa-agent/crawl";
+import { looksLikeAuthUrl, matchAuthLinks } from "@/lib/qa-agent/auth-links";
+
+/**
+ * qa_login step helpers: deterministic resolution of how a QA run
+ * authenticates. Everything that touches a browser drives the run's Embedded
+ * Browser over CDP (never a host-process Chromium), mirroring crawl.ts.
+ */
+
+const NAV_TIMEOUT_MS = 30_000;
+const SETTLE_TIMEOUT_MS = 8_000;
+
+/** What the repo's existing setup infrastructure offers for auth. */
+export interface ExistingAuthSetup {
+  /** Newest usable storage state (from default steps, or the repo's list). */
+  storageStateId?: string;
+  storageStateName?: string;
+  /** First default setup step that is a test (its id, for qaAuth.setupTestId). */
+  setupTestId?: string;
+  /** Repo default setup steps include a test/script/storage_state — the
+   *  executor already applies them to every test. */
+  defaultSetupInUse: boolean;
+}
+
+/**
+ * Check the repo's existing setup infrastructure, strongest first: default
+ * setup steps (storage_state step wins, then test/script steps), then the
+ * repo's storage-state list (non-expired, newest first, agent-captured names
+ * preferred so a prior QA/QuickStart login is picked over unrelated states).
+ */
+export async function findExistingAuthSetup(
+  repositoryId: string,
+): Promise<ExistingAuthSetup> {
+  const result: ExistingAuthSetup = { defaultSetupInUse: false };
+
+  const defaults = await queries
+    .getDefaultSetupSteps(repositoryId)
+    .catch(() => []);
+  if (defaults.length > 0) {
+    result.defaultSetupInUse = true;
+    const storageStep = defaults.find(
+      (s) => s.stepType === "storage_state" && s.storageStateId,
+    );
+    if (storageStep?.storageStateId) {
+      result.storageStateId = storageStep.storageStateId;
+      result.storageStateName = storageStep.storageStateName ?? undefined;
+    }
+    const testStep = defaults.find((s) => s.stepType === "test" && s.testId);
+    if (testStep?.testId) result.setupTestId = testStep.testId;
+  }
+
+  if (!result.storageStateId) {
+    const now = Date.now();
+    const rows = await queries.getStorageStates(repositoryId).catch(() => []);
+    const preferred = (name: string) =>
+      /^(QA agent |QuickStart login |QuickStart signup )/i.test(name) ? 0 : 1;
+    const candidate = rows
+      .filter((r) => !r.expiresAt || r.expiresAt.getTime() > now)
+      .sort(
+        (a, b) =>
+          preferred(a.name) - preferred(b.name) ||
+          (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0),
+      )[0];
+    if (candidate) {
+      result.storageStateId = candidate.id;
+      result.storageStateName = candidate.name;
+    }
+  }
+
+  return result;
+}
+
+async function connectToEb(
+  cdpUrl: string,
+): Promise<{ browser: Browser; page: Page }> {
+  const browser = await chromium.connectOverCDP(cdpUrl);
+  const context = browser.contexts()[0] ?? (await browser.newContext());
+  const page = context.pages()[0] ?? (await context.newPage());
+  return { browser, page };
+}
+
+async function gotoAndSettle(page: Page, url: string): Promise<void> {
+  await page.goto(url, {
+    waitUntil: "domcontentloaded",
+    timeout: NAV_TIMEOUT_MS,
+  });
+  await page
+    .waitForLoadState("networkidle", { timeout: SETTLE_TIMEOUT_MS })
+    .catch(() => {});
+}
+
+/** Authed heuristic: the target page shows no password field and the final
+ *  URL is not an auth page. Navigates the page to targetUrl first. */
+export async function probeAuthedState(
+  page: Page,
+  targetUrl: string,
+): Promise<boolean> {
+  try {
+    await gotoAndSettle(page, targetUrl);
+    const password = page.locator('input[type="password"]').first();
+    const hasPassword = await password
+      .isVisible({ timeout: 2000 })
+      .catch(() => false);
+    if (hasPassword) return false;
+    return !looksLikeAuthUrl(new URL(page.url()).pathname);
+  } catch {
+    return false;
+  }
+}
+
+/** Serialize the EB's default-context session if it carries any material
+ *  (cookies / localStorage / IndexedDB). Null = nothing worth persisting. */
+async function captureStorageStateFromContext(
+  page: Page,
+): Promise<string | null> {
+  const state = await page.context().storageState({ indexedDB: true });
+  const origins = (state.origins ?? []) as Array<{
+    localStorage?: unknown[];
+    indexedDB?: unknown[];
+  }>;
+  const hasMaterial =
+    (state.cookies?.length ?? 0) > 0 ||
+    origins.some(
+      (o) =>
+        (Array.isArray(o.localStorage) && o.localStorage.length > 0) ||
+        (Array.isArray(o.indexedDB) && o.indexedDB.length > 0),
+    );
+  return hasMaterial ? JSON.stringify(state) : null;
+}
+
+/**
+ * Validate a stored storage state against the target app on the EB.
+ * `deferred: true` means the capture is IndexedDB-only and can't be injected
+ * over CDP — not a failure; validation falls to discovery/execution (the
+ * executor's runner path applies full storage states natively).
+ */
+export async function validateStorageStateOnEb(
+  cdpUrl: string,
+  storageStateJson: string,
+  targetUrl: string,
+): Promise<{ validated: boolean; deferred: boolean }> {
+  const injected = await injectStorageStateIntoEb(cdpUrl, storageStateJson);
+  if (!injected) return { validated: false, deferred: true };
+  let browser: Browser | null = null;
+  try {
+    const conn = await connectToEb(cdpUrl);
+    browser = conn.browser;
+    return {
+      validated: await probeAuthedState(conn.page, targetUrl),
+      deferred: false,
+    };
+  } catch {
+    return { validated: false, deferred: false };
+  } finally {
+    if (browser) await browser.close().catch(() => {});
+  }
+}
+
+/** Extract the login/signup links the target app actually renders. */
+export async function findAuthLinksOnEb(
+  cdpUrl: string,
+  targetUrl: string,
+): Promise<{ loginUrl?: string; signupUrl?: string }> {
+  let browser: Browser | null = null;
+  try {
+    const conn = await connectToEb(cdpUrl);
+    browser = conn.browser;
+    const page = conn.page;
+    await gotoAndSettle(page, targetUrl);
+    const links = await page.evaluate(() =>
+      Array.from(document.querySelectorAll("a[href]")).map((a) => ({
+        text: (a.textContent ?? "").replace(/\s+/g, " ").trim(),
+        href: (a as HTMLAnchorElement).getAttribute("href") || "",
+      })),
+    );
+    return matchAuthLinks(links, targetUrl);
+  } catch {
+    return {};
+  } finally {
+    if (browser) await browser.close().catch(() => {});
+  }
+}
+
+/**
+ * Drive a real login with the provided credentials on the EB: navigate to the
+ * DOM-discovered login page (or stay put when a password form is already
+ * visible), submit, verify the authed heuristic, and capture the session.
+ */
+export async function loginWithCredsOnEb(opts: {
+  cdpUrl: string;
+  targetUrl: string;
+  loginUrl?: string;
+  credentials: { email: string; password: string };
+}): Promise<{ ok: boolean; storageStateJson?: string; detail?: string }> {
+  let browser: Browser | null = null;
+  try {
+    const conn = await connectToEb(opts.cdpUrl);
+    browser = conn.browser;
+    const page = conn.page;
+    await gotoAndSettle(page, opts.targetUrl);
+    const passwordVisible = await page
+      .locator('input[type="password"]')
+      .first()
+      .isVisible({ timeout: 1500 })
+      .catch(() => false);
+    if (!passwordVisible) {
+      if (!opts.loginUrl) {
+        return { ok: false, detail: "no login form or login link found" };
+      }
+      await gotoAndSettle(page, opts.loginUrl);
+    }
+    const submitted = await attemptLogin(page, opts.credentials);
+    if (!submitted) {
+      return { ok: false, detail: "no password form on the login page" };
+    }
+    const authed = await probeAuthedState(page, opts.targetUrl);
+    if (!authed) {
+      return { ok: false, detail: "still on an auth page after submit" };
+    }
+    const storageStateJson = await captureStorageStateFromContext(page);
+    if (!storageStateJson) {
+      return {
+        ok: false,
+        detail: "logged-in UI reached but no session material was captured",
+      };
+    }
+    return { ok: true, storageStateJson };
+  } catch (err) {
+    return {
+      ok: false,
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    if (browser) await browser.close().catch(() => {});
+  }
+}
+
+/**
+ * Post-crawl check used by discovery: is the EB's session authed against the
+ * target, and if so, what does its session look like? Lets discovery upgrade
+ * a `creds_untested` resolution after its inline login succeeded.
+ */
+export async function probeAndCaptureOnEb(
+  cdpUrl: string,
+  targetUrl: string,
+): Promise<{ authed: boolean; storageStateJson?: string }> {
+  let browser: Browser | null = null;
+  try {
+    const conn = await connectToEb(cdpUrl);
+    browser = conn.browser;
+    const authed = await probeAuthedState(conn.page, targetUrl);
+    if (!authed) return { authed: false };
+    const storageStateJson = await captureStorageStateFromContext(conn.page);
+    return { authed: true, storageStateJson: storageStateJson ?? undefined };
+  } catch {
+    return { authed: false };
+  } finally {
+    if (browser) await browser.close().catch(() => {});
+  }
+}

--- a/src/lib/qa-agent/auth.ts
+++ b/src/lib/qa-agent/auth.ts
@@ -20,6 +20,10 @@ export interface ExistingAuthSetup {
   storageStateName?: string;
   /** First default setup step that is a test (its id, for qaAuth.setupTestId). */
   setupTestId?: string;
+  /** First default setup step that is a script — runnable to mint a fresh
+   *  session when no (valid) storage state exists. */
+  setupScriptId?: string;
+  setupStepName?: string;
   /** Repo default setup steps include a test/script/storage_state — the
    *  executor already applies them to every test. */
   defaultSetupInUse: boolean;
@@ -49,7 +53,18 @@ export async function findExistingAuthSetup(
       result.storageStateName = storageStep.storageStateName ?? undefined;
     }
     const testStep = defaults.find((s) => s.stepType === "test" && s.testId);
-    if (testStep?.testId) result.setupTestId = testStep.testId;
+    if (testStep?.testId) {
+      result.setupTestId = testStep.testId;
+      result.setupStepName = testStep.testName ?? undefined;
+    } else {
+      const scriptStep = defaults.find(
+        (s) => s.stepType === "script" && s.scriptId,
+      );
+      if (scriptStep?.scriptId) {
+        result.setupScriptId = scriptStep.scriptId;
+        result.setupStepName = scriptStep.scriptName ?? undefined;
+      }
+    }
   }
 
   if (!result.storageStateId) {

--- a/src/lib/qa-agent/code-check.test.ts
+++ b/src/lib/qa-agent/code-check.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildCodeCheckDigest,
+  extractDeclaredEndpoints,
+  extractMethodsFromSource,
+  isApiRouteFile,
+  selectApiRouteFiles,
+  type QaCodeCheck,
+} from "./code-check";
+import { buildDocsDigest, isSupportedDocName } from "./docs";
+import type { TreeEntry } from "@/lib/github/content";
+
+const blob = (path: string): TreeEntry => ({
+  path,
+  mode: "100644",
+  type: "blob",
+  sha: path,
+  url: "",
+});
+
+describe("isApiRouteFile / selectApiRouteFiles", () => {
+  it("matches App Router route files and pages/api files only", () => {
+    expect(isApiRouteFile("src/app/api/users/route.ts")).toBe(true);
+    expect(isApiRouteFile("app/api/auth/[...all]/route.ts")).toBe(true);
+    expect(isApiRouteFile("pages/api/login.ts")).toBe(true);
+    expect(isApiRouteFile("pages/api/orders/index.ts")).toBe(true);
+    expect(isApiRouteFile("src/app/dashboard/page.tsx")).toBe(false);
+    expect(isApiRouteFile("src/lib/api/client.ts")).toBe(false);
+  });
+
+  it("filters trees to blobs and caps the selection", () => {
+    const tree = [
+      blob("src/app/api/a/route.ts"),
+      { ...blob("src/app/api/b/route.ts"), type: "tree" as const },
+      blob("README.md"),
+    ];
+    expect(selectApiRouteFiles(tree).map((e) => e.path)).toEqual([
+      "src/app/api/a/route.ts",
+    ]);
+  });
+});
+
+describe("extractMethodsFromSource", () => {
+  it("finds App Router method exports", () => {
+    const src = `export async function GET(req: Request) {}\nexport const POST = async () => {};`;
+    expect(extractMethodsFromSource(src).sort()).toEqual(["GET", "POST"]);
+  });
+
+  it("finds pages/api req.method checks", () => {
+    const src = `export default function handler(req, res) { if (req.method === "DELETE") {} }`;
+    expect(extractMethodsFromSource(src)).toEqual(["DELETE"]);
+  });
+
+  it("defaults to GET when no method is discernible", () => {
+    expect(extractMethodsFromSource("export default handler")).toEqual(["GET"]);
+  });
+});
+
+describe("extractDeclaredEndpoints", () => {
+  it("maps file paths to URL paths with dynamic segments", async () => {
+    const tree = [
+      blob("src/app/api/users/[id]/route.ts"),
+      blob("src/app/(app)/api/ignored-group/route.ts"),
+      blob("pages/api/auth/[...all].ts"),
+      blob("src/app/api/broken/route.ts"),
+    ];
+    const sources: Record<string, string | null> = {
+      "src/app/api/users/[id]/route.ts":
+        "export async function GET() {}\nexport async function DELETE() {}",
+      "src/app/(app)/api/ignored-group/route.ts":
+        "export async function POST() {}",
+      "pages/api/auth/[...all].ts": 'if (req.method === "POST") {}',
+      "src/app/api/broken/route.ts": null,
+    };
+    const endpoints = await extractDeclaredEndpoints(tree, async (p) => {
+      return sources[p] ?? null;
+    });
+    expect(endpoints).toContainEqual({
+      method: "GET",
+      path: "/api/users/:id",
+      file: "src/app/api/users/[id]/route.ts",
+    });
+    expect(endpoints).toContainEqual({
+      method: "POST",
+      path: "/api/ignored-group",
+      file: "src/app/(app)/api/ignored-group/route.ts",
+    });
+    expect(endpoints).toContainEqual({
+      method: "POST",
+      path: "/api/auth/:all*",
+      file: "pages/api/auth/[...all].ts",
+    });
+    // Unreadable files are skipped, not failed.
+    expect(endpoints.some((e) => e.file.includes("broken"))).toBe(false);
+  });
+});
+
+describe("buildCodeCheckDigest", () => {
+  it("renders stack facts, notes, and declared endpoints", () => {
+    const check: QaCodeCheck = {
+      framework: "Next.js 16 (App Router)",
+      authMechanism: "better-auth",
+      apiLayer: "REST",
+      projectDescription: "A demo bank.",
+      testingNotes: ["stripe: mock payment intents in tests"],
+      declaredEndpoints: [
+        {
+          method: "POST",
+          path: "/api/transfer",
+          file: "app/api/transfer/route.ts",
+        },
+      ],
+    };
+    const digest = buildCodeCheckDigest(check);
+    expect(digest).toContain("## Code analysis");
+    expect(digest).toContain("Framework: Next.js 16 (App Router)");
+    expect(digest).toContain("Auth: better-auth");
+    expect(digest).toContain("- stripe: mock payment intents in tests");
+    expect(digest).toContain("- POST /api/transfer");
+  });
+});
+
+describe("docs digest", () => {
+  it("filters supported extensions", () => {
+    expect(isSupportedDocName("SPEC.md")).toBe(true);
+    expect(isSupportedDocName("manual.PDF")).toBe(true);
+    expect(isSupportedDocName("notes.docx")).toBe(true);
+    expect(isSupportedDocName("image.png")).toBe(false);
+  });
+
+  it("shares the budget across docs and labels each", () => {
+    const digest = buildDocsDigest([
+      { name: "spec.md", text: "Users can transfer money." },
+      { name: "faq.txt", text: "x".repeat(50_000) },
+    ]);
+    expect(digest).toContain("### Document: spec.md");
+    expect(digest).toContain("Users can transfer money.");
+    expect(digest).toContain("### Document: faq.txt");
+    expect(digest).toContain("…(truncated)");
+    expect(digest.length).toBeLessThan(16_500);
+  });
+
+  it("returns empty for empty docs", () => {
+    expect(buildDocsDigest([{ name: "a.md", text: "   " }])).toBe("");
+  });
+});

--- a/src/lib/qa-agent/code-check.ts
+++ b/src/lib/qa-agent/code-check.ts
@@ -70,6 +70,11 @@ export function isApiRouteFile(path: string): boolean {
   return appRouterPath(path) !== null || pagesApiPath(path) !== null;
 }
 
+/** URL path an API route file serves, or null when it isn't a route file. */
+export function apiRouteUrlPath(filePath: string): string | null {
+  return appRouterPath(filePath) ?? pagesApiPath(filePath);
+}
+
 /** Pick the API route files worth reading, smallest-path-first for stability. */
 export function selectApiRouteFiles(tree: TreeEntry[]): TreeEntry[] {
   return tree
@@ -112,7 +117,7 @@ export async function extractDeclaredEndpoints(
   const endpoints: QaDeclaredEndpoint[] = [];
   for (const entry of selectApiRouteFiles(tree)) {
     if (endpoints.length >= MAX_ENDPOINTS) break;
-    const urlPath = appRouterPath(entry.path) ?? pagesApiPath(entry.path);
+    const urlPath = apiRouteUrlPath(entry.path);
     if (!urlPath) continue;
     const source = await getContent(entry.path).catch(() => null);
     if (!source) continue;

--- a/src/lib/qa-agent/code-check.ts
+++ b/src/lib/qa-agent/code-check.ts
@@ -1,0 +1,158 @@
+import type { TreeEntry } from "@/lib/github/content";
+
+/**
+ * QA Agent code check — static analysis of the connected repo that feeds the
+ * planner with facts the live crawl cannot see: API endpoints DECLARED in
+ * code (vs merely observed on the wire), the framework/auth stack, and
+ * dependency-derived testing implications. Extraction is deterministic
+ * (tree + regex over a capped set of files); the AI summary layer stays in
+ * the planner.
+ */
+
+export interface QaDeclaredEndpoint {
+  method: string;
+  path: string;
+  /** Source file the handler was found in (repo-relative). */
+  file: string;
+}
+
+export interface QaCodeCheck {
+  framework?: string;
+  authMechanism?: string;
+  apiLayer?: string;
+  projectDescription?: string;
+  /** Dependency/testing notes from codebase intelligence. */
+  testingNotes: string[];
+  declaredEndpoints: QaDeclaredEndpoint[];
+}
+
+const MAX_ROUTE_FILES = 20;
+const MAX_FILE_CHARS = 6000;
+const MAX_ENDPOINTS = 60;
+
+const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
+
+// Next.js App Router: app/<segments>/route.ts(x|js) → URL path from the dirs.
+function appRouterPath(filePath: string): string | null {
+  const match = filePath.match(/(?:^|\/)app\/(.*)\/route\.(?:ts|tsx|js|mjs)$/);
+  if (!match) return null;
+  const segments = match[1]
+    .split("/")
+    // Route groups "(group)" and parallel routes "@slot" don't affect the URL.
+    .filter(
+      (s) => !(s.startsWith("(") && s.endsWith(")")) && !s.startsWith("@"),
+    )
+    .map((s) =>
+      s
+        .replace(/^\[\[\.\.\.(.+)\]\]$/, ":$1*")
+        .replace(/^\[\.\.\.(.+)\]$/, ":$1*")
+        .replace(/^\[(.+)\]$/, ":$1"),
+    );
+  return "/" + segments.join("/");
+}
+
+/** Next.js Pages Router: pages/api/** → URL path from the file path. */
+function pagesApiPath(filePath: string): string | null {
+  const match = filePath.match(
+    /(?:^|\/)pages\/(api\/.*?)(?:\/index)?\.(?:ts|tsx|js|mjs)$/,
+  );
+  if (!match) return null;
+  const segments = match[1].split("/").map((s) =>
+    s
+      .replace(/^\[\[\.\.\.(.+)\]\]$/, ":$1*")
+      .replace(/^\[\.\.\.(.+)\]$/, ":$1*")
+      .replace(/^\[(.+)\]$/, ":$1"),
+  );
+  return "/" + segments.join("/");
+}
+
+export function isApiRouteFile(path: string): boolean {
+  return appRouterPath(path) !== null || pagesApiPath(path) !== null;
+}
+
+/** Pick the API route files worth reading, smallest-path-first for stability. */
+export function selectApiRouteFiles(tree: TreeEntry[]): TreeEntry[] {
+  return tree
+    .filter((e) => e.type === "blob" && isApiRouteFile(e.path))
+    .sort((a, b) => a.path.localeCompare(b.path))
+    .slice(0, MAX_ROUTE_FILES);
+}
+
+/** Extract the HTTP methods a route file declares. App Router exports
+ *  `export async function GET/POST/...` (or const arrow equivalents);
+ *  Pages Router handlers switch on `req.method === "POST"` etc. */
+export function extractMethodsFromSource(source: string): string[] {
+  const methods = new Set<string>();
+  for (const method of HTTP_METHODS) {
+    if (
+      new RegExp(
+        `export\\s+(?:async\\s+)?(?:function\\s+${method}\\b|const\\s+${method}\\s*=)`,
+      ).test(source) ||
+      new RegExp(
+        `\\breq(?:uest)?\\.method\\s*===?\\s*["'\`]${method}["'\`]`,
+      ).test(source)
+    ) {
+      methods.add(method);
+    }
+  }
+  // A pages/api file with no explicit method check handles everything — call
+  // that GET for planning purposes rather than exploding the matrix.
+  return methods.size > 0 ? [...methods] : ["GET"];
+}
+
+/**
+ * Walk the repo tree, read the (capped) API route files, and produce the
+ * declared-endpoint list. `getContent` abstracts the GitHub blob fetch so the
+ * extraction logic stays pure and unit-testable.
+ */
+export async function extractDeclaredEndpoints(
+  tree: TreeEntry[],
+  getContent: (path: string) => Promise<string | null>,
+): Promise<QaDeclaredEndpoint[]> {
+  const endpoints: QaDeclaredEndpoint[] = [];
+  for (const entry of selectApiRouteFiles(tree)) {
+    if (endpoints.length >= MAX_ENDPOINTS) break;
+    const urlPath = appRouterPath(entry.path) ?? pagesApiPath(entry.path);
+    if (!urlPath) continue;
+    const source = await getContent(entry.path).catch(() => null);
+    if (!source) continue;
+    for (const method of extractMethodsFromSource(
+      source.slice(0, MAX_FILE_CHARS),
+    )) {
+      endpoints.push({ method, path: urlPath, file: entry.path });
+      if (endpoints.length >= MAX_ENDPOINTS) break;
+    }
+  }
+  return endpoints;
+}
+
+const MAX_DIGEST_ENDPOINTS = 40;
+
+/** Planner-digest section for the code check. */
+export function buildCodeCheckDigest(check: QaCodeCheck): string {
+  const lines: string[] = ["## Code analysis (from the connected repository)"];
+  const facts = [
+    check.framework && `Framework: ${check.framework}`,
+    check.authMechanism && `Auth: ${check.authMechanism}`,
+    check.apiLayer && `API layer: ${check.apiLayer}`,
+  ].filter(Boolean);
+  if (facts.length) lines.push(facts.join(" · "));
+  if (check.projectDescription) {
+    lines.push(`About: ${check.projectDescription}`);
+  }
+  if (check.testingNotes.length) {
+    lines.push(
+      "Testing implications:",
+      ...check.testingNotes.slice(0, 8).map((n) => `- ${n}`),
+    );
+  }
+  if (check.declaredEndpoints.length) {
+    lines.push(
+      "API endpoints declared in code (may not all appear during a crawl):",
+      ...check.declaredEndpoints
+        .slice(0, MAX_DIGEST_ENDPOINTS)
+        .map((e) => `- ${e.method} ${e.path}`),
+    );
+  }
+  return lines.join("\n");
+}

--- a/src/lib/qa-agent/crawl.ts
+++ b/src/lib/qa-agent/crawl.ts
@@ -1,5 +1,6 @@
 import { chromium, type Page } from "playwright";
 import type { QaPageSnapshot } from "@/lib/db/schema";
+import { isAuthLink } from "@/lib/qa-agent/auth-links";
 
 /**
  * QA Agent live discovery crawl. Connects to a provisioned Embedded Browser
@@ -21,6 +22,9 @@ export interface QaCrawlOptions {
   onPage?: (snapshot: QaPageSnapshot, index: number) => void;
   /** Login before crawling: fills the first form containing a password field. */
   credentials?: { email: string; password: string };
+  /** Rank login/signup/register links first when picking pages to follow, so
+   *  public-only discovery reliably maps the auth surface within maxPages. */
+  prioritizeAuthLinks?: boolean;
   signal?: AbortSignal;
 }
 
@@ -138,6 +142,7 @@ function pickNextLinks(
   base: URL,
   visited: Set<string>,
   count: number,
+  prioritizeAuth = false,
 ): string[] {
   const seen = new Set<string>();
   const candidates: Array<{ url: string; score: number }> = [];
@@ -150,14 +155,18 @@ function pickNextLinks(
     // Prefer labeled nav links with shallow paths; skip asset-ish URLs.
     if (/\.(png|jpe?g|svg|css|js|pdf|zip)(\?|$)/i.test(url.pathname)) continue;
     const depth = url.pathname.split("/").filter(Boolean).length;
-    const score = (link.text ? 0 : 5) + depth;
+    const authBonus =
+      prioritizeAuth && isAuthLink(link.text, url.pathname) ? 10 : 0;
+    const score = (link.text ? 0 : 5) + depth - authBonus;
     candidates.push({ url: key, score });
   }
   candidates.sort((a, b) => a.score - b.score);
   return candidates.slice(0, count).map((c) => c.url);
 }
 
-async function attemptLogin(
+/** Fill and submit the first form containing a password field. Shared with the
+ *  qa_login step, which drives the same deterministic login on its own EB. */
+export async function attemptLogin(
   page: Page,
   credentials: { email: string; password: string },
 ): Promise<boolean> {
@@ -265,6 +274,7 @@ export async function crawlTargetApp(
           base,
           visited,
           maxPages - pages.length,
+          options.prioritizeAuthLinks,
         )) {
           queue.push(next);
         }

--- a/src/lib/qa-agent/crawl.ts
+++ b/src/lib/qa-agent/crawl.ts
@@ -22,6 +22,10 @@ export interface QaCrawlOptions {
   onPage?: (snapshot: QaPageSnapshot, index: number) => void;
   /** Login before crawling: fills the first form containing a password field. */
   credentials?: { email: string; password: string };
+  /** DOM-discovered login page (from qa_login). When set with credentials,
+   *  the crawl logs in THERE before mapping, instead of relying on the first
+   *  crawled page happening to show a password form. */
+  loginUrl?: string;
   /** Rank login/signup/register links first when picking pages to follow, so
    *  public-only discovery reliably maps the auth surface within maxPages. */
   prioritizeAuthLinks?: boolean;
@@ -213,6 +217,28 @@ export async function crawlTargetApp(
     const page = context.pages()[0] ?? (await context.newPage());
     const base = new URL(targetUrl);
 
+    // Console errors observed while the current page loads, keyed per page.
+    // Deduped and capped so a chatty page can't bloat the digest.
+    let currentConsoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() !== "error") return;
+      if (currentConsoleErrors.length >= 15) return;
+      const text = msg.text().replace(/\s+/g, " ").trim().slice(0, 200);
+      if (text && !currentConsoleErrors.includes(text)) {
+        currentConsoleErrors.push(text);
+      }
+    });
+    page.on("pageerror", (err) => {
+      if (currentConsoleErrors.length >= 15) return;
+      const text = `${err.name}: ${err.message}`
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, 200);
+      if (text && !currentConsoleErrors.includes(text)) {
+        currentConsoleErrors.push(text);
+      }
+    });
+
     // Same-origin fetch/XHR observation, keyed per visited page.
     let currentEndpoints: QaPageSnapshot["apiEndpoints"] = [];
     page.on("response", (response) => {
@@ -233,6 +259,23 @@ export async function crawlTargetApp(
       }
     });
 
+    // With a known login page, authenticate BEFORE the crawl starts so every
+    // mapped page reflects the post-login state.
+    if (options.credentials && options.loginUrl) {
+      try {
+        await page.goto(options.loginUrl, {
+          waitUntil: "domcontentloaded",
+          timeout: PAGE_NAV_TIMEOUT_MS,
+        });
+        await page
+          .waitForLoadState("networkidle", { timeout: PAGE_SETTLE_TIMEOUT_MS })
+          .catch(() => {});
+        loginAttempted = await attemptLogin(page, options.credentials);
+      } catch {
+        // Best-effort — the first-page fallback below still applies.
+      }
+    }
+
     const visited = new Set<string>();
     const queue: string[] = [new URL(targetUrl).href];
 
@@ -242,6 +285,7 @@ export async function crawlTargetApp(
       if (visited.has(url)) continue;
       visited.add(url);
       currentEndpoints = [];
+      currentConsoleErrors = [];
       try {
         await page.goto(url, {
           waitUntil: "domcontentloaded",
@@ -255,7 +299,7 @@ export async function crawlTargetApp(
 
         // On the first page, log in when credentials are provided and a
         // password field is present, then re-extract the authed DOM.
-        if (pages.length === 0 && options.credentials) {
+        if (pages.length === 0 && options.credentials && !loginAttempted) {
           loginAttempted = await attemptLogin(page, options.credentials);
         }
 
@@ -264,6 +308,7 @@ export async function crawlTargetApp(
           url,
           ...dom,
           apiEndpoints: [...currentEndpoints],
+          consoleErrors: [...currentConsoleErrors],
         };
         pages.push(snapshot);
         options.onPage?.(snapshot, pages.length - 1);

--- a/src/lib/qa-agent/crawl.ts
+++ b/src/lib/qa-agent/crawl.ts
@@ -1,0 +1,280 @@
+import { chromium, type Page } from "playwright";
+import type { QaPageSnapshot } from "@/lib/db/schema";
+
+/**
+ * QA Agent live discovery crawl. Connects to a provisioned Embedded Browser
+ * over CDP (never a host-process browser), renders the target URL, extracts a
+ * structured page map of the LIVE DOM, then follows a handful of same-origin
+ * links and maps those too. While each page loads, same-origin fetch/XHR
+ * responses are recorded so the planner can ground API-group tests in real
+ * endpoints. Deterministic — no AI involved. Driving the EB's page makes the
+ * crawl watchable via the EB screencast.
+ */
+
+const PAGE_NAV_TIMEOUT_MS = 30_000;
+const PAGE_SETTLE_TIMEOUT_MS = 8_000;
+
+export interface QaCrawlOptions {
+  /** Total pages to map, including the root. */
+  maxPages?: number;
+  /** Optional per-page callback for progress reporting. */
+  onPage?: (snapshot: QaPageSnapshot, index: number) => void;
+  /** Login before crawling: fills the first form containing a password field. */
+  credentials?: { email: string; password: string };
+  signal?: AbortSignal;
+}
+
+async function extractDom(
+  page: Page,
+): Promise<Omit<QaPageSnapshot, "url" | "apiEndpoints">> {
+  return (await page.evaluate(() => {
+    const text = (el: Element | null): string =>
+      (el?.textContent ?? "").replace(/\s+/g, " ").trim();
+    const uniq = (arr: string[]): string[] =>
+      Array.from(new Set(arr.filter(Boolean)));
+
+    const headings = Array.from(document.querySelectorAll("h1,h2,h3"))
+      .map((h) => ({ level: Number(h.tagName[1]), text: text(h) }))
+      .filter((h) => h.text)
+      .slice(0, 30);
+
+    const labelFor = (el: Element): string | null => {
+      const id = el.getAttribute("id");
+      if (id) {
+        const lab = document.querySelector(`label[for="${CSS.escape(id)}"]`);
+        if (lab) return text(lab);
+      }
+      return (
+        el.getAttribute("aria-label") || el.getAttribute("placeholder") || null
+      );
+    };
+
+    const forms = Array.from(document.querySelectorAll("form"))
+      .slice(0, 8)
+      .map((f) => ({
+        name: f.getAttribute("name") || f.getAttribute("id"),
+        action: f.getAttribute("action"),
+        method: (f.getAttribute("method") || "get").toLowerCase(),
+        inputs: Array.from(f.querySelectorAll("input,textarea,select"))
+          .slice(0, 20)
+          .map((i) => ({
+            tag: i.tagName.toLowerCase(),
+            type: i.getAttribute("type"),
+            name: i.getAttribute("name"),
+            id: i.getAttribute("id"),
+            label: labelFor(i),
+          })),
+      }));
+
+    const buttons = uniq(
+      Array.from(
+        document.querySelectorAll(
+          "button,[role=button],input[type=submit],input[type=button]",
+        ),
+      )
+        .map(
+          (b) =>
+            text(b) ||
+            b.getAttribute("value") ||
+            b.getAttribute("aria-label") ||
+            "",
+        )
+        .filter(Boolean),
+    ).slice(0, 30);
+
+    const links = Array.from(document.querySelectorAll("a[href]"))
+      .map((a) => ({
+        text: text(a),
+        href: (a as HTMLAnchorElement).getAttribute("href") || "",
+      }))
+      .filter((l) => l.href && !l.href.startsWith("javascript:"))
+      .slice(0, 60);
+
+    const testIds = uniq(
+      Array.from(document.querySelectorAll("[data-testid]")).map(
+        (e) => e.getAttribute("data-testid") || "",
+      ),
+    ).slice(0, 40);
+
+    const candidateSelectors = uniq([
+      ...testIds.map((t) => `getByTestId('${t}')`),
+      ...buttons
+        .slice(0, 10)
+        .map(
+          (b) =>
+            `getByRole('button', { name: /${b
+              .slice(0, 40)
+              .replace(/[.*+?^${}()|[\]\\/]/g, "\\$&")}/i })`,
+        ),
+    ]).slice(0, 40);
+
+    return {
+      title: document.title || null,
+      finalUrl: location.href,
+      headings,
+      forms,
+      buttons,
+      links,
+      testIds,
+      candidateSelectors,
+    };
+  })) as Omit<QaPageSnapshot, "url" | "apiEndpoints">;
+}
+
+function sameOrigin(href: string, base: URL): URL | null {
+  try {
+    const url = new URL(href, base);
+    if (url.origin !== base.origin) return null;
+    url.hash = "";
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+/** Pick the next unvisited same-origin links, preferring short nav-like paths. */
+function pickNextLinks(
+  snapshot: QaPageSnapshot,
+  base: URL,
+  visited: Set<string>,
+  count: number,
+): string[] {
+  const seen = new Set<string>();
+  const candidates: Array<{ url: string; score: number }> = [];
+  for (const link of snapshot.links) {
+    const url = sameOrigin(link.href, base);
+    if (!url) continue;
+    const key = url.href;
+    if (visited.has(key) || seen.has(key)) continue;
+    seen.add(key);
+    // Prefer labeled nav links with shallow paths; skip asset-ish URLs.
+    if (/\.(png|jpe?g|svg|css|js|pdf|zip)(\?|$)/i.test(url.pathname)) continue;
+    const depth = url.pathname.split("/").filter(Boolean).length;
+    const score = (link.text ? 0 : 5) + depth;
+    candidates.push({ url: key, score });
+  }
+  candidates.sort((a, b) => a.score - b.score);
+  return candidates.slice(0, count).map((c) => c.url);
+}
+
+async function attemptLogin(
+  page: Page,
+  credentials: { email: string; password: string },
+): Promise<boolean> {
+  try {
+    const password = page.locator('input[type="password"]').first();
+    if (!(await password.isVisible({ timeout: 2000 }).catch(() => false))) {
+      return false;
+    }
+    const user = page
+      .locator(
+        'input[type="email"], input[autocomplete="username"], input[name*="mail" i], input[name*="user" i], input[type="text"]',
+      )
+      .first();
+    if (await user.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await user.fill(credentials.email);
+    }
+    await password.fill(credentials.password);
+    const submit = page
+      .locator(
+        'button[type="submit"], input[type="submit"], form button, [role="button"]',
+      )
+      .first();
+    await submit.click({ timeout: 3000 });
+    await page
+      .waitForLoadState("networkidle", { timeout: PAGE_SETTLE_TIMEOUT_MS })
+      .catch(() => {});
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function crawlTargetApp(
+  cdpUrl: string,
+  targetUrl: string,
+  options: QaCrawlOptions = {},
+): Promise<{ pages: QaPageSnapshot[]; loginAttempted: boolean }> {
+  const maxPages = Math.max(1, Math.min(options.maxPages ?? 6, 12));
+  const browser = await chromium.connectOverCDP(cdpUrl);
+  const pages: QaPageSnapshot[] = [];
+  let loginAttempted = false;
+  try {
+    const context = browser.contexts()[0] ?? (await browser.newContext());
+    const page = context.pages()[0] ?? (await context.newPage());
+    const base = new URL(targetUrl);
+
+    // Same-origin fetch/XHR observation, keyed per visited page.
+    let currentEndpoints: QaPageSnapshot["apiEndpoints"] = [];
+    page.on("response", (response) => {
+      try {
+        const req = response.request();
+        const type = req.resourceType();
+        if (type !== "fetch" && type !== "xhr") return;
+        const url = new URL(response.url());
+        if (url.origin !== base.origin) return;
+        if (currentEndpoints.length >= 40) return;
+        currentEndpoints.push({
+          method: req.method(),
+          path: url.pathname + url.search.slice(0, 60),
+          status: response.status(),
+        });
+      } catch {
+        // Observation is best-effort.
+      }
+    });
+
+    const visited = new Set<string>();
+    const queue: string[] = [new URL(targetUrl).href];
+
+    while (queue.length > 0 && pages.length < maxPages) {
+      if (options.signal?.aborted) break;
+      const url = queue.shift()!;
+      if (visited.has(url)) continue;
+      visited.add(url);
+      currentEndpoints = [];
+      try {
+        await page.goto(url, {
+          waitUntil: "domcontentloaded",
+          timeout: PAGE_NAV_TIMEOUT_MS,
+        });
+        await page
+          .waitForLoadState("networkidle", {
+            timeout: PAGE_SETTLE_TIMEOUT_MS,
+          })
+          .catch(() => {});
+
+        // On the first page, log in when credentials are provided and a
+        // password field is present, then re-extract the authed DOM.
+        if (pages.length === 0 && options.credentials) {
+          loginAttempted = await attemptLogin(page, options.credentials);
+        }
+
+        const dom = await extractDom(page);
+        const snapshot: QaPageSnapshot = {
+          url,
+          ...dom,
+          apiEndpoints: [...currentEndpoints],
+        };
+        pages.push(snapshot);
+        options.onPage?.(snapshot, pages.length - 1);
+        visited.add(snapshot.finalUrl);
+
+        for (const next of pickNextLinks(
+          snapshot,
+          base,
+          visited,
+          maxPages - pages.length,
+        )) {
+          queue.push(next);
+        }
+      } catch (err) {
+        console.warn(`[QaCrawl] failed to map ${url}:`, err);
+      }
+    }
+    return { pages, loginAttempted };
+  } finally {
+    // Disconnect CDP; the EB itself is released by the caller.
+    await browser.close().catch(() => {});
+  }
+}

--- a/src/lib/qa-agent/docs.ts
+++ b/src/lib/qa-agent/docs.ts
@@ -1,0 +1,94 @@
+/**
+ * QA Agent documentation intake. Users upload product docs (requirements,
+ * specs, manuals) on the setup card; the decoded text is condensed into a
+ * digest the planner treats as authoritative for intended behavior — letting
+ * it plan journeys and coverage for documented functionality the live crawl
+ * or code check alone would miss. Only the digest is persisted (session
+ * metadata), never the raw upload.
+ */
+
+export interface QaUploadedDoc {
+  name: string;
+  /** Base64-encoded file content (same transport as spec imports). */
+  contentBase64: string;
+}
+
+export interface QaDocSummary {
+  name: string;
+  chars: number;
+}
+
+export const MAX_DOC_FILES = 5;
+/** Per-file decoded-text cap (chars). */
+export const MAX_DOC_CHARS = 40_000;
+/** Total digest cap fed to the planner (chars). */
+export const MAX_DOCS_DIGEST_CHARS = 15_000;
+
+const SUPPORTED_EXTENSIONS = [".md", ".txt", ".pdf", ".docx"];
+
+export function isSupportedDocName(name: string): boolean {
+  const lower = name.toLowerCase();
+  return SUPPORTED_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+/** Decode one uploaded doc to plain text (pdf via unpdf, docx via mammoth,
+ *  everything else utf-8) — mirrors the spec-import upload path. */
+export async function decodeUploadedDoc(doc: QaUploadedDoc): Promise<string> {
+  const buf = Buffer.from(doc.contentBase64, "base64");
+  const lower = doc.name.toLowerCase();
+  let text: string;
+  if (lower.endsWith(".pdf")) {
+    const { extractText } = await import("unpdf");
+    const { text: pages } = await extractText(new Uint8Array(buf));
+    text = Array.isArray(pages) ? pages.join("\n") : String(pages);
+  } else if (lower.endsWith(".docx")) {
+    const mammoth = (await import("mammoth")).default;
+    const { value } = await mammoth.extractRawText({ buffer: buf });
+    text = value;
+  } else {
+    text = buf.toString("utf-8");
+  }
+  return text.slice(0, MAX_DOC_CHARS);
+}
+
+/** Condense decoded docs into the planner's documentation digest. Each doc
+ *  gets a fair share of the total budget so one giant file can't crowd out
+ *  the others. */
+export function buildDocsDigest(
+  docs: Array<{ name: string; text: string }>,
+): string {
+  const nonEmpty = docs.filter((d) => d.text.trim());
+  if (nonEmpty.length === 0) return "";
+  const perDoc = Math.floor(MAX_DOCS_DIGEST_CHARS / nonEmpty.length);
+  return nonEmpty
+    .map((d) => {
+      const body =
+        d.text.length > perDoc
+          ? d.text.slice(0, perDoc) + "\n…(truncated)"
+          : d.text;
+      return `### Document: ${d.name}\n${body.trim()}`;
+    })
+    .join("\n\n");
+}
+
+/** Decode + digest an upload set; returns per-file summaries for the UI and
+ *  the digest for the planner. Unsupported/undecodable files are skipped. */
+export async function processUploadedDocs(uploads: QaUploadedDoc[]): Promise<{
+  summaries: QaDocSummary[];
+  digest: string;
+}> {
+  const docs: Array<{ name: string; text: string }> = [];
+  for (const upload of uploads.slice(0, MAX_DOC_FILES)) {
+    if (!isSupportedDocName(upload.name)) continue;
+    try {
+      const text = await decodeUploadedDoc(upload);
+      if (text.trim()) docs.push({ name: upload.name, text });
+    } catch (err) {
+      console.warn(`[QaDocs] failed to decode ${upload.name}:`, err);
+    }
+  }
+  return {
+    summaries: docs.map((d) => ({ name: d.name, chars: d.text.length })),
+    digest: buildDocsDigest(docs),
+  };
+}

--- a/src/lib/qa-agent/plan.test.ts
+++ b/src/lib/qa-agent/plan.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildApiDefinition,
+  buildDiscoveryDigest,
+  buildGeneratorPrompt,
+  buildPlannerUserPrompt,
+  computeQaSummary,
+  enabledPlanItems,
+  groupPlaywrightOverrides,
+  isQaTestPlan,
+  normalizeQaGroups,
+  sanitizeQaPlan,
+} from "./plan";
+import type {
+  QaDiscovery,
+  QaGeneratedTest,
+  QaPageSnapshot,
+  QaTestPlan,
+} from "@/lib/db/schema";
+
+const page = (overrides: Partial<QaPageSnapshot> = {}): QaPageSnapshot => ({
+  url: "https://app.example.com/",
+  finalUrl: "https://app.example.com/",
+  title: "Example Bank",
+  headings: [{ level: 1, text: "Welcome" }],
+  forms: [
+    {
+      name: "login",
+      action: "/login",
+      method: "post",
+      inputs: [
+        {
+          tag: "input",
+          type: "email",
+          name: "email",
+          id: "email",
+          label: "Email",
+        },
+        {
+          tag: "input",
+          type: "password",
+          name: "password",
+          id: "password",
+          label: "Password",
+        },
+      ],
+    },
+  ],
+  buttons: ["Sign in", "Transfer"],
+  links: [{ text: "Accounts", href: "/accounts" }],
+  testIds: ["login-submit"],
+  candidateSelectors: ["getByTestId('login-submit')"],
+  apiEndpoints: [{ method: "GET", path: "/api/accounts", status: 200 }],
+  ...overrides,
+});
+
+const discovery = (overrides: Partial<QaDiscovery> = {}): QaDiscovery => ({
+  targetUrl: "https://app.example.com",
+  crawledPages: [page()],
+  githubConnected: false,
+  ...overrides,
+});
+
+const validPlan = (): QaTestPlan => ({
+  appProfile: {
+    summary: "A demo bank",
+    businessDomain: "banking",
+    primaryOutcome: "a transfer is completed",
+  },
+  journeys: [
+    {
+      id: "J1",
+      title: "Transfer money",
+      priority: "P1",
+      steps: ["Log in", "Open transfer", "Submit"],
+      businessOutcome: "money moved between accounts",
+      endStateVerification: "destination balance increased",
+    },
+  ],
+  items: [
+    {
+      id: "T1",
+      group: "journey",
+      title: "Complete a transfer",
+      priority: "P1",
+      journeyId: "J1",
+      pagePath: "/transfer",
+      scenario: "1. Log in 2. Transfer 10 3. Verify balance",
+    },
+    {
+      id: "T2",
+      group: "smoke",
+      title: "Landing renders",
+      priority: "P1",
+      scenario: "1. Open / 2. Expect heading Welcome",
+    },
+    {
+      id: "T3",
+      group: "api",
+      title: "Accounts endpoint",
+      priority: "P2",
+      scenario: "GET /api/accounts returns 200",
+      api: { method: "GET", path: "/api/accounts", expectedStatus: 200 },
+    },
+  ],
+});
+
+describe("normalizeQaGroups", () => {
+  it("always includes journey and keeps canonical order", () => {
+    expect(normalizeQaGroups(["smoke"])).toEqual(["journey", "smoke"]);
+    expect(normalizeQaGroups([])).toEqual(["journey"]);
+  });
+
+  it("drops unknown groups", () => {
+    expect(normalizeQaGroups(["nope" as never, "a11y", "perf"])).toEqual([
+      "journey",
+      "a11y",
+      "perf",
+    ]);
+  });
+});
+
+describe("groupPlaywrightOverrides", () => {
+  it("enforces the a11y layer for a11y tests", () => {
+    expect(groupPlaywrightOverrides("a11y")).toEqual({ a11yMode: "enforce" });
+  });
+  it("enforces the perf layer for perf tests", () => {
+    expect(groupPlaywrightOverrides("perf")).toEqual({ perfMode: "enforce" });
+  });
+  it("downgrades network/console noise for failure-injection groups", () => {
+    expect(groupPlaywrightOverrides("resilience")).toEqual({
+      networkMode: "log",
+      consoleMode: "log",
+    });
+    expect(groupPlaywrightOverrides("negative")).toEqual({
+      networkMode: "log",
+      consoleMode: "log",
+    });
+  });
+  it("leaves other groups on repo defaults", () => {
+    expect(groupPlaywrightOverrides("smoke")).toBeUndefined();
+    expect(groupPlaywrightOverrides("journey")).toBeUndefined();
+  });
+});
+
+describe("isQaTestPlan", () => {
+  it("accepts a valid plan", () => {
+    expect(isQaTestPlan(validPlan())).toBe(true);
+  });
+
+  it("rejects a plan without items", () => {
+    expect(isQaTestPlan({ ...validPlan(), items: [] })).toBe(false);
+  });
+
+  it("rejects malformed journeys", () => {
+    const plan = validPlan();
+    (plan.journeys[0] as unknown as Record<string, unknown>).steps = "no";
+    expect(isQaTestPlan(plan)).toBe(false);
+  });
+
+  it("rejects api items with a bad method", () => {
+    const plan = validPlan();
+    (plan.items[2].api as unknown as Record<string, unknown>).method = "HEAD";
+    expect(isQaTestPlan(plan)).toBe(false);
+  });
+
+  it("rejects attacker-shaped objects (wrong keys)", () => {
+    expect(isQaTestPlan({ evil: true })).toBe(false);
+    expect(isQaTestPlan(null)).toBe(false);
+    expect(isQaTestPlan("plan")).toBe(false);
+  });
+});
+
+describe("sanitizeQaPlan", () => {
+  it("drops items in unselected groups", () => {
+    const out = sanitizeQaPlan(validPlan(), ["journey", "smoke"]);
+    expect(out.items.map((i) => i.id)).toEqual(["T1", "T2"]);
+  });
+
+  it("clears orphaned journey references", () => {
+    const plan = validPlan();
+    plan.items[1].journeyId = "J404";
+    const out = sanitizeQaPlan(plan, ["journey", "smoke", "api"]);
+    expect(out.items[1].journeyId).toBeUndefined();
+    expect(out.items[0].journeyId).toBe("J1");
+  });
+});
+
+describe("enabledPlanItems", () => {
+  it("filters explicitly disabled items only", () => {
+    const plan = validPlan();
+    plan.items[1].enabled = false;
+    expect(enabledPlanItems(plan).map((i) => i.id)).toEqual(["T1", "T3"]);
+  });
+});
+
+describe("buildDiscoveryDigest", () => {
+  it("includes selectors, forms, and observed API endpoints", () => {
+    const digest = buildDiscoveryDigest(discovery());
+    expect(digest).toContain("getByTestId('login-submit')");
+    expect(digest).toContain("GET /api/accounts → 200");
+    expect(digest).toContain('input[email] "Email"');
+  });
+
+  it("includes static routes when present and caps length", () => {
+    const digest = buildDiscoveryDigest(
+      discovery({
+        githubConnected: true,
+        framework: "nextjs",
+        staticRoutes: [{ path: "/accounts", type: "page" }],
+      }),
+    );
+    expect(digest).toContain("/accounts (page)");
+    const huge = buildDiscoveryDigest(
+      discovery({
+        crawledPages: Array.from({ length: 40 }, (_, i) =>
+          page({
+            url: `https://app.example.com/p${i}`,
+            finalUrl: `https://app.example.com/p${i}`,
+            headings: Array.from({ length: 10 }, (_, j) => ({
+              level: 2,
+              text: `Section ${"x".repeat(80)} ${j}`,
+            })),
+          }),
+        ),
+      }),
+    );
+    expect(huge.length).toBeLessThanOrEqual(24_000 + 20);
+    expect(huge.endsWith("…(truncated)")).toBe(true);
+  });
+});
+
+describe("buildPlannerUserPrompt", () => {
+  it("states credential availability and embeds feedback", () => {
+    const withCreds = buildPlannerUserPrompt({
+      digest: "D",
+      groups: ["journey", "smoke"],
+      credsProvided: true,
+    });
+    expect(withCreds).toContain("YES — journeys may authenticate");
+    const rejected = buildPlannerUserPrompt({
+      digest: "D",
+      groups: ["journey"],
+      credsProvided: false,
+      feedback: "Cover the transfer form too",
+    });
+    expect(rejected).toContain("Cover the transfer form too");
+    expect(rejected).toContain("NO — public surface only");
+  });
+});
+
+describe("buildGeneratorPrompt", () => {
+  it("includes group guidance, journey outcome, and selector hints", () => {
+    const plan = validPlan();
+    const prompt = buildGeneratorPrompt({
+      item: {
+        ...plan.items[0],
+        selectorHints: ["getByTestId('login-submit')"],
+      },
+      plan,
+      targetUrl: "https://app.example.com",
+    });
+    expect(prompt).toContain("BUSINESS-OUTCOME JOURNEY");
+    expect(prompt).toContain("destination balance increased");
+    expect(prompt).toContain("getByTestId('login-submit')");
+  });
+
+  it("passes credentials only when provided", () => {
+    const plan = validPlan();
+    const noCreds = buildGeneratorPrompt({
+      item: plan.items[1],
+      plan,
+      targetUrl: "https://app.example.com",
+    });
+    expect(noCreds).not.toContain("password");
+    const withCreds = buildGeneratorPrompt({
+      item: plan.items[1],
+      plan,
+      targetUrl: "https://app.example.com",
+      credentials: { email: "qa@example.com", password: "s3cret" },
+    });
+    expect(withCreds).toContain("qa@example.com");
+  });
+});
+
+describe("buildApiDefinition", () => {
+  it("builds an absolute URL from the target base and asserts status", () => {
+    const def = buildApiDefinition(
+      validPlan().items[2],
+      "https://app.example.com/",
+    );
+    expect(def).not.toBeNull();
+    expect(def!.url).toBe("https://app.example.com/api/accounts");
+    expect(def!.method).toBe("GET");
+    expect(def!.assertions[0]).toMatchObject({ kind: "status", equals: 200 });
+  });
+
+  it("returns null for non-api items", () => {
+    expect(
+      buildApiDefinition(validPlan().items[0], "https://app.example.com"),
+    ).toBeNull();
+  });
+});
+
+describe("computeQaSummary", () => {
+  it("aggregates counts and journey traceability", () => {
+    const plan = validPlan();
+    const generated: QaGeneratedTest[] = [
+      {
+        planItemId: "T1",
+        group: "journey",
+        testId: "test-1",
+        name: "Complete a transfer",
+        status: "passed",
+      },
+      {
+        planItemId: "T2",
+        group: "smoke",
+        testId: "test-2",
+        name: "Landing renders",
+        status: "healed",
+      },
+      {
+        planItemId: "T3",
+        group: "api",
+        name: "Accounts endpoint",
+        status: "generation_failed",
+      },
+    ];
+    const summary = computeQaSummary(plan, generated);
+    expect(summary.planned).toBe(3);
+    expect(summary.generated).toBe(2);
+    expect(summary.passed).toBe(2);
+    expect(summary.healed).toBe(1);
+    expect(summary.failed).toBe(0);
+    expect(summary.byGroup.journey).toMatchObject({ planned: 1, passed: 1 });
+    expect(summary.journeyCoverage.J1).toEqual(["test-1"]);
+  });
+
+  it("excludes disabled items from planned counts", () => {
+    const plan = validPlan();
+    plan.items[2].enabled = false;
+    const summary = computeQaSummary(plan, []);
+    expect(summary.planned).toBe(2);
+  });
+});

--- a/src/lib/qa-agent/plan.test.ts
+++ b/src/lib/qa-agent/plan.test.ts
@@ -437,3 +437,57 @@ describe("computeQaSummary with covered entries", () => {
     expect(summary.journeyCoverage.J1).toEqual(["ex-1"]);
   });
 });
+
+describe("coverage matrix", () => {
+  it("builds business-area × group cells from plan + ledger", () => {
+    const plan = validPlan();
+    plan.items[0].businessArea = "Payments";
+    plan.items[1].businessArea = "Marketing";
+    // T3 (api) left without a businessArea → rolls up under "General"
+    const summary = computeQaSummary(plan, [
+      {
+        planItemId: "T1",
+        group: "journey",
+        testId: "t-1",
+        name: "Complete a transfer",
+        status: "passed",
+      },
+      {
+        planItemId: "T3",
+        group: "api",
+        testId: "ex-1",
+        name: "Accounts endpoint",
+        status: "covered",
+      },
+    ]);
+    expect(summary.matrix?.Payments?.journey).toEqual({
+      planned: 1,
+      covered: 0,
+      generated: 1,
+      passed: 1,
+    });
+    expect(summary.matrix?.General?.api).toEqual({
+      planned: 1,
+      covered: 1,
+      generated: 0,
+      passed: 0,
+    });
+    // Marketing smoke item has no ledger entry — a pure gap.
+    expect(summary.matrix?.Marketing?.smoke).toEqual({
+      planned: 1,
+      covered: 0,
+      generated: 0,
+      passed: 0,
+    });
+  });
+
+  it("accepts plans with and without businessArea (validator tolerance)", () => {
+    const plan = validPlan();
+    expect(isQaTestPlan(plan)).toBe(true);
+    plan.items[0].businessArea = "Payments";
+    plan.journeys[0].businessArea = "Payments";
+    expect(isQaTestPlan(plan)).toBe(true);
+    (plan.items[0] as unknown as Record<string, unknown>).businessArea = 42;
+    expect(isQaTestPlan(plan)).toBe(false);
+  });
+});

--- a/src/lib/qa-agent/plan.test.ts
+++ b/src/lib/qa-agent/plan.test.ts
@@ -239,21 +239,22 @@ describe("buildDiscoveryDigest", () => {
 });
 
 describe("buildPlannerUserPrompt", () => {
-  it("states credential availability and embeds feedback", () => {
-    const withCreds = buildPlannerUserPrompt({
+  it("states auth availability and embeds feedback", () => {
+    const authed = buildPlannerUserPrompt({
       digest: "D",
       groups: ["journey", "smoke"],
-      credsProvided: true,
+      authenticated: true,
     });
-    expect(withCreds).toContain("YES — journeys may authenticate");
+    expect(authed).toContain("Authenticated session available: YES");
+    expect(authed).toContain("in-app surface");
     const rejected = buildPlannerUserPrompt({
       digest: "D",
       groups: ["journey"],
-      credsProvided: false,
+      authenticated: false,
       feedback: "Cover the transfer form too",
     });
     expect(rejected).toContain("Cover the transfer form too");
-    expect(rejected).toContain("NO — public surface only");
+    expect(rejected).toContain("Authenticated session available: NO");
   });
 });
 
@@ -433,7 +434,7 @@ describe("existing coverage in planner prompt", () => {
     const prompt = buildPlannerUserPrompt({
       digest: "D",
       groups: ["journey"],
-      credsProvided: false,
+      authenticated: false,
       existingCoverage: '- "Login smoke"',
     });
     expect(prompt).toContain("ALREADY CONTAINS");

--- a/src/lib/qa-agent/plan.test.ts
+++ b/src/lib/qa-agent/plan.test.ts
@@ -286,6 +286,29 @@ describe("buildGeneratorPrompt", () => {
     });
     expect(withCreds).toContain("qa@example.com");
   });
+
+  it("pre-authenticated sessions forbid login steps and omit credentials", () => {
+    const plan = validPlan();
+    const prompt = buildGeneratorPrompt({
+      item: plan.items[1],
+      plan,
+      targetUrl: "https://app.example.com",
+      auth: { preAuthenticated: true },
+    });
+    expect(prompt).toContain("already authenticated");
+    expect(prompt).toContain("Do NOT write login steps");
+    expect(prompt).not.toContain("s3cret");
+
+    const notPreAuthed = buildGeneratorPrompt({
+      item: plan.items[1],
+      plan,
+      targetUrl: "https://app.example.com",
+      credentials: { email: "qa@example.com", password: "s3cret" },
+      auth: { preAuthenticated: false },
+    });
+    expect(notPreAuthed).not.toContain("already authenticated");
+    expect(notPreAuthed).toContain("qa@example.com");
+  });
 });
 
 describe("buildApiDefinition", () => {

--- a/src/lib/qa-agent/plan.test.ts
+++ b/src/lib/qa-agent/plan.test.ts
@@ -9,6 +9,8 @@ import {
   enabledPlanItems,
   groupPlaywrightOverrides,
   isQaTestPlan,
+  itemGroups,
+  itemPlaywrightOverrides,
   matchPlanToExistingTests,
   normalizeQaGroups,
   sanitizeQaPlan,
@@ -17,6 +19,7 @@ import type {
   QaDiscovery,
   QaGeneratedTest,
   QaPageSnapshot,
+  QaPlanItem,
   QaTestPlan,
 } from "@/lib/db/schema";
 
@@ -489,5 +492,111 @@ describe("coverage matrix", () => {
     expect(isQaTestPlan(plan)).toBe(true);
     (plan.items[0] as unknown as Record<string, unknown>).businessArea = 42;
     expect(isQaTestPlan(plan)).toBe(false);
+  });
+});
+
+describe("multi-group plan items", () => {
+  const multiItem = (overrides: Partial<QaPlanItem> = {}): QaPlanItem => ({
+    id: "T9",
+    group: "smoke",
+    groups: ["smoke", "a11y", "perf"],
+    title: "Landing renders, accessible, fast",
+    priority: "P1",
+    scenario: "1. Open / 2. Expect heading Welcome",
+    ...overrides,
+  });
+
+  it("itemGroups falls back to [group] and normalizes order/dupes", () => {
+    expect(itemGroups(validPlan().items[1])).toEqual(["smoke"]);
+    // Primary first, rest in canonical order, dupes dropped.
+    expect(
+      itemGroups(multiItem({ groups: ["a11y", "perf", "smoke", "a11y"] })),
+    ).toEqual(["a11y", "smoke", "perf"]);
+  });
+
+  it("validator accepts groups arrays and rejects invalid ids in them", () => {
+    const plan = validPlan();
+    plan.items.push(multiItem());
+    expect(isQaTestPlan(plan)).toBe(true);
+    // groups-only item (no primary group) is accepted; sanitize backfills.
+    const groupsOnly = multiItem();
+    delete (groupsOnly as Partial<QaPlanItem>).group;
+    plan.items[plan.items.length - 1] = groupsOnly;
+    expect(isQaTestPlan(plan)).toBe(true);
+    plan.items[plan.items.length - 1] = multiItem({
+      groups: ["smoke", "nope" as never],
+    });
+    expect(isQaTestPlan(plan)).toBe(false);
+  });
+
+  it("sanitize strips unselected groups, keeps the item, backfills group", () => {
+    const plan = validPlan();
+    const groupsOnly = multiItem({ groups: ["a11y", "smoke", "perf"] });
+    delete (groupsOnly as Partial<QaPlanItem>).group;
+    plan.items.push(groupsOnly);
+    const out = sanitizeQaPlan(plan, ["journey", "smoke"]);
+    const kept = out.items.find((i) => i.id === "T9")!;
+    expect(kept.groups).toEqual(["smoke"]);
+    expect(kept.group).toBe("smoke");
+    // Item with no surviving group is dropped (T3 is api-only).
+    expect(out.items.some((i) => i.id === "T3")).toBe(false);
+  });
+
+  it("itemPlaywrightOverrides merges overrides across groups", () => {
+    expect(itemPlaywrightOverrides(["smoke", "a11y", "perf"])).toEqual({
+      a11yMode: "enforce",
+      perfMode: "enforce",
+    });
+    expect(itemPlaywrightOverrides(["ui", "resilience"])).toEqual({
+      networkMode: "log",
+      consoleMode: "log",
+    });
+    expect(itemPlaywrightOverrides(["smoke", "ui"])).toBeUndefined();
+  });
+
+  it("generator prompt lists all groups and stacks their guidance", () => {
+    const plan = validPlan();
+    const prompt = buildGeneratorPrompt({
+      item: multiItem(),
+      plan,
+      targetUrl: "https://app.example.com",
+    });
+    expect(prompt).toContain("Coverage groups: smoke + a11y + perf");
+    expect(prompt).toContain("SMOKE test");
+    expect(prompt).toContain("ACCESSIBILITY test");
+    expect(prompt).toContain("PERFORMANCE test");
+  });
+
+  it("summary counts a multi-group test in every tagged bucket and cell", () => {
+    const plan = validPlan();
+    plan.items = [multiItem({ businessArea: "Marketing" })];
+    const summary = computeQaSummary(plan, [
+      {
+        planItemId: "T9",
+        group: "smoke",
+        groups: ["smoke", "a11y", "perf"],
+        testId: "t-9",
+        name: "Landing renders, accessible, fast",
+        status: "passed",
+      },
+    ]);
+    // One test, three coverage marks.
+    expect(summary.planned).toBe(1);
+    expect(summary.generated).toBe(1);
+    expect(summary.passed).toBe(1);
+    for (const g of ["smoke", "a11y", "perf"] as const) {
+      expect(summary.byGroup[g]).toMatchObject({
+        planned: 1,
+        generated: 1,
+        passed: 1,
+      });
+      expect(summary.matrix?.Marketing?.[g]).toEqual({
+        planned: 1,
+        covered: 0,
+        generated: 1,
+        passed: 1,
+      });
+    }
+    expect(summary.byGroup.ui).toBeUndefined();
   });
 });

--- a/src/lib/qa-agent/plan.test.ts
+++ b/src/lib/qa-agent/plan.test.ts
@@ -3,17 +3,24 @@ import {
   buildApiDefinition,
   buildDiscoveryDigest,
   buildExistingCoverageDigest,
+  buildExistingPlanDigest,
   buildGeneratorPrompt,
+  buildJourneyRefinerUserPrompt,
   buildPlannerUserPrompt,
   computeQaSummary,
   enabledPlanItems,
+  explainInvalidRefinedJourneys,
   groupPlaywrightOverrides,
   isQaTestPlan,
+  isRefinedJourneys,
   itemGroups,
   itemPlaywrightOverrides,
   matchPlanToExistingTests,
+  mergeRefinedJourneys,
   normalizeQaGroups,
   sanitizeQaPlan,
+  MAX_PLAN_ITEMS,
+  type RefinedJourneys,
 } from "./plan";
 import type {
   QaDiscovery,
@@ -313,6 +320,41 @@ describe("buildGeneratorPrompt", () => {
     expect(notPreAuthed).not.toContain("already authenticated");
     expect(notPreAuthed).toContain("qa@example.com");
   });
+
+  it("threads the login context into every auth mode", () => {
+    const plan = validPlan();
+    const loginContext = {
+      loginUrl: "https://app.example.com/login",
+      signupUrl: "https://app.example.com/register",
+    };
+    // Pre-authenticated: still names the login page (for lapse reporting).
+    const preAuth = buildGeneratorPrompt({
+      item: plan.items[1],
+      plan,
+      targetUrl: "https://app.example.com",
+      auth: { preAuthenticated: true },
+      loginContext,
+    });
+    expect(preAuth).toContain("/login");
+    // Credentials: log in AT the real login URL.
+    const creds = buildGeneratorPrompt({
+      item: plan.items[1],
+      plan,
+      targetUrl: "https://app.example.com",
+      credentials: { email: "qa@example.com", password: "s3cret" },
+      loginContext,
+    });
+    expect(creds).toContain("at https://app.example.com/login");
+    // Public-only run: no session, no creds — still names where auth lives.
+    const publicOnly = buildGeneratorPrompt({
+      item: plan.items[1],
+      plan,
+      targetUrl: "https://app.example.com",
+      loginContext,
+    });
+    expect(publicOnly).toContain("No authenticated session");
+    expect(publicOnly).toContain("/register");
+  });
 });
 
 describe("buildApiDefinition", () => {
@@ -439,6 +481,168 @@ describe("existing coverage in planner prompt", () => {
     });
     expect(prompt).toContain("ALREADY CONTAINS");
     expect(prompt).toContain('- "Login smoke"');
+  });
+});
+
+describe("journey refiner — validation + prompts", () => {
+  const validRefined = (): RefinedJourneys => ({
+    journeys: [
+      {
+        id: "U1",
+        title: "Invite a teammate",
+        priority: "P1",
+        businessArea: "Team",
+        steps: ["Open settings", "Invite", "Verify pending"],
+        businessOutcome: "an invite is created",
+        endStateVerification: "invitee appears in the pending list",
+      },
+    ],
+    items: [
+      {
+        id: "UT1",
+        group: "journey",
+        groups: ["journey", "ui"],
+        title: "Invite teammate flow",
+        priority: "P1",
+        journeyId: "U1",
+        businessArea: "Team",
+        scenario: "1. Open settings 2. Invite 3. Assert pending row",
+      },
+    ],
+  });
+
+  it("accepts a well-formed refiner payload and rejects junk", () => {
+    expect(isRefinedJourneys(validRefined())).toBe(true);
+    expect(isRefinedJourneys({ journeys: [], items: [] })).toBe(false);
+    expect(explainInvalidRefinedJourneys({ journeys: [], items: [] })).toMatch(
+      /no journeys and no items/,
+    );
+    const bad = validRefined();
+    (bad.items[0] as unknown as Record<string, unknown>).scenario = 42;
+    expect(isRefinedJourneys(bad)).toBe(false);
+  });
+
+  it("embeds user journeys + existing plan digest in the prompt", () => {
+    const prompt = buildJourneyRefinerUserPrompt({
+      digest: "DIGEST",
+      groups: ["journey", "ui"],
+      userJourneys: ["Invite a teammate", "Delete a project"],
+      existingPlanDigest: buildExistingPlanDigest(validPlan()),
+      authenticated: true,
+    });
+    expect(prompt).toContain("1. Invite a teammate");
+    expect(prompt).toContain("2. Delete a project");
+    expect(prompt).toContain('test: "Complete a transfer"');
+    expect(prompt).toContain("Authenticated session available: YES");
+  });
+});
+
+describe("mergeRefinedJourneys", () => {
+  const refined = (): RefinedJourneys => ({
+    journeys: [
+      {
+        id: "A",
+        title: "Invite a teammate",
+        priority: "P1",
+        businessArea: "Team",
+        steps: ["Invite"],
+        businessOutcome: "invite created",
+        endStateVerification: "pending row",
+      },
+    ],
+    items: [
+      {
+        id: "X",
+        group: "ui",
+        groups: ["ui"],
+        title: "Invite teammate flow",
+        priority: "P1",
+        journeyId: "A",
+        businessArea: "Team",
+        scenario: "invite steps",
+      },
+    ],
+  });
+
+  it("appends new journeys/items with fresh ids, preserving the existing plan", () => {
+    const plan = validPlan();
+    const {
+      plan: merged,
+      addedJourneys,
+      addedItems,
+    } = mergeRefinedJourneys(plan, refined(), [
+      "journey",
+      "smoke",
+      "api",
+      "ui",
+    ]);
+    expect(addedJourneys).toBe(1);
+    expect(addedItems).toBe(1);
+    // Existing items are untouched.
+    expect(merged.items.slice(0, 3).map((i) => i.id)).toEqual([
+      "T1",
+      "T2",
+      "T3",
+    ]);
+    const newItem = merged.items[merged.items.length - 1];
+    // Fresh, collision-free id; journeyId remapped to the new journey.
+    expect(newItem.id).not.toBe("X");
+    const newJourney = merged.journeys[merged.journeys.length - 1];
+    expect(newItem.journeyId).toBe(newJourney.id);
+    // journey-linked item is forced to carry the "journey" group.
+    expect(itemGroups(newItem)).toContain("journey");
+  });
+
+  it("strips groups the user did not select", () => {
+    const r = refined();
+    r.items[0].groups = ["ui", "perf"];
+    const { plan: merged } = mergeRefinedJourneys(validPlan(), r, [
+      "journey",
+      "ui",
+    ]);
+    const newItem = merged.items[merged.items.length - 1];
+    expect(itemGroups(newItem)).not.toContain("perf");
+    expect(itemGroups(newItem)).toContain("ui");
+  });
+
+  it("dedupes against existing item titles", () => {
+    const r = refined();
+    r.items[0].title = "Landing renders"; // already in validPlan()
+    const { addedItems } = mergeRefinedJourneys(validPlan(), r, [
+      "journey",
+      "smoke",
+      "ui",
+    ]);
+    expect(addedItems).toBe(0);
+  });
+
+  it("bounds newly added items when the plan is already full", () => {
+    const plan = validPlan();
+    // Pad the plan to the cap so the budget floor (4) governs.
+    plan.items = Array.from({ length: MAX_PLAN_ITEMS }, (_, i) => ({
+      id: `P${i}`,
+      group: "ui" as const,
+      title: `Existing ${i}`,
+      priority: "P2" as const,
+      scenario: "x",
+    }));
+    const many: RefinedJourneys = {
+      journeys: [],
+      items: Array.from({ length: 20 }, (_, i) => ({
+        id: `N${i}`,
+        group: "ui" as const,
+        groups: ["ui" as const],
+        title: `New journey item ${i}`,
+        priority: (i < 6 ? "P1" : "P3") as "P1" | "P3",
+        scenario: "y",
+      })),
+    };
+    const { addedItems, trimmed } = mergeRefinedJourneys(plan, many, [
+      "journey",
+      "ui",
+    ]);
+    expect(addedItems).toBe(4); // max(4, MAX - full) === 4
+    expect(trimmed).toBe(16);
   });
 });
 

--- a/src/lib/qa-agent/plan.test.ts
+++ b/src/lib/qa-agent/plan.test.ts
@@ -230,8 +230,11 @@ describe("buildDiscoveryDigest", () => {
         ),
       }),
     );
-    expect(huge.length).toBeLessThanOrEqual(24_000 + 20);
-    expect(huge.endsWith("…(truncated)")).toBe(true);
+    // Truncates at a page boundary (never mid-page) with an omission note,
+    // and drops the last crawled page rather than slicing it in half.
+    expect(huge.length).toBeLessThanOrEqual(24_000 + 100);
+    expect(huge).toContain("omitted to fit the context budget");
+    expect(huge).not.toContain("/p39");
   });
 });
 

--- a/src/lib/qa-agent/plan.test.ts
+++ b/src/lib/qa-agent/plan.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect } from "vitest";
 import {
   buildApiDefinition,
   buildDiscoveryDigest,
+  buildExistingCoverageDigest,
   buildGeneratorPrompt,
   buildPlannerUserPrompt,
   computeQaSummary,
   enabledPlanItems,
   groupPlaywrightOverrides,
   isQaTestPlan,
+  matchPlanToExistingTests,
   normalizeQaGroups,
   sanitizeQaPlan,
 } from "./plan";
@@ -342,5 +344,96 @@ describe("computeQaSummary", () => {
     plan.items[2].enabled = false;
     const summary = computeQaSummary(plan, []);
     expect(summary.planned).toBe(2);
+  });
+});
+
+describe("matchPlanToExistingTests", () => {
+  const items = () => validPlan().items;
+  const existing = [
+    { id: "ex-1", name: "Complete a transfer" },
+    { id: "ex-2", name: "landing RENDERS!" },
+  ];
+
+  it("matches by normalized title", () => {
+    const m = matchPlanToExistingTests(items(), existing);
+    expect(m.get("T1")).toBe("ex-1");
+    expect(m.get("T2")).toBe("ex-2");
+    expect(m.has("T3")).toBe(false);
+  });
+
+  it("prefers prior-ledger links and ignores dead test ids", () => {
+    const ledger: QaGeneratedTest[] = [
+      {
+        planItemId: "T3",
+        group: "api",
+        testId: "ex-1",
+        name: "old name",
+        status: "passed",
+      },
+      {
+        planItemId: "T2",
+        group: "smoke",
+        testId: "deleted-test",
+        name: "Landing renders",
+        status: "passed",
+      },
+    ];
+    const m = matchPlanToExistingTests(items(), existing, ledger);
+    expect(m.get("T3")).toBe("ex-1"); // ledger link wins
+    expect(m.get("T2")).toBe("ex-2"); // dead id falls back to title match
+  });
+
+  it("returns empty when nothing exists", () => {
+    expect(matchPlanToExistingTests(items(), []).size).toBe(0);
+  });
+});
+
+describe("buildExistingCoverageDigest", () => {
+  it("lists names with area and api marker", () => {
+    const digest = buildExistingCoverageDigest([
+      { id: "1", name: "Login smoke", functionalAreaName: "QA: Smoke" },
+      { id: "2", name: "Accounts endpoint", testType: "api" },
+    ]);
+    expect(digest).toContain('"Login smoke" (area: QA: Smoke)');
+    expect(digest).toContain('"Accounts endpoint" [api]');
+  });
+});
+
+describe("existing coverage in planner prompt", () => {
+  it("embeds the existing-tests section when provided", () => {
+    const prompt = buildPlannerUserPrompt({
+      digest: "D",
+      groups: ["journey"],
+      credsProvided: false,
+      existingCoverage: '- "Login smoke"',
+    });
+    expect(prompt).toContain("ALREADY CONTAINS");
+    expect(prompt).toContain('- "Login smoke"');
+  });
+});
+
+describe("computeQaSummary with covered entries", () => {
+  it("counts covered separately and keeps journey traceability", () => {
+    const plan = validPlan();
+    const summary = computeQaSummary(plan, [
+      {
+        planItemId: "T1",
+        group: "journey",
+        testId: "ex-1",
+        name: "Complete a transfer",
+        status: "covered",
+      },
+      {
+        planItemId: "T2",
+        group: "smoke",
+        testId: "new-1",
+        name: "Landing renders",
+        status: "passed",
+      },
+    ]);
+    expect(summary.covered).toBe(1);
+    expect(summary.generated).toBe(1);
+    expect(summary.byGroup.journey).toMatchObject({ covered: 1, generated: 0 });
+    expect(summary.journeyCoverage.J1).toEqual(["ex-1"]);
   });
 });

--- a/src/lib/qa-agent/plan.ts
+++ b/src/lib/qa-agent/plan.ts
@@ -1,0 +1,502 @@
+import type {
+  ApiTestDefinition,
+  QaDiscovery,
+  QaGeneratedTest,
+  QaPageSnapshot,
+  QaPlanItem,
+  QaPlanJourney,
+  QaPriority,
+  QaSummaryData,
+  QaTestGroup,
+  QaTestPlan,
+  TestPlaywrightOverrides,
+} from "@/lib/db/schema";
+
+/**
+ * QA Agent — pure planning helpers. Everything here is deterministic and
+ * side-effect free so it can be unit-tested without a DB, browser, or AI
+ * provider. The orchestrator (src/server/actions/qa-agent.ts) wires these
+ * into the step machine.
+ */
+
+// ---------------------------------------------------------------------------
+// Groups
+// ---------------------------------------------------------------------------
+
+export const QA_GROUPS: Array<{
+  id: QaTestGroup;
+  label: string;
+  description: string;
+  /** journey is always planned; the user cannot deselect it. */
+  locked?: boolean;
+}> = [
+  {
+    id: "journey",
+    label: "Business journeys",
+    description:
+      "Critical user journeys with verified business outcomes (e.g. order placed)",
+    locked: true,
+  },
+  {
+    id: "smoke",
+    label: "Smoke",
+    description: "Fast, read-mostly checks of critical paths — the PR gate",
+  },
+  {
+    id: "api",
+    label: "API",
+    description: "Headless HTTP tests against observed API endpoints",
+  },
+  {
+    id: "ui",
+    label: "UI",
+    description: "User-visible flows and interactions per page",
+  },
+  {
+    id: "hybrid",
+    label: "Hybrid",
+    description: "API-seeded state exercised and verified through the UI",
+  },
+  {
+    id: "a11y",
+    label: "Accessibility",
+    description: "WCAG 2.2 AA checks (axe) on key pages and interaction states",
+  },
+  {
+    id: "perf",
+    label: "Performance",
+    description: "Core Web Vitals budgets (LCP/CLS/TTFB) on key pages",
+  },
+  {
+    id: "resilience",
+    label: "Resilience",
+    description: "Network failure injection and error-path behavior",
+  },
+  {
+    id: "negative",
+    label: "Negative",
+    description: "Input validation matrices, boundaries, and abuse strings",
+  },
+];
+
+export const QA_GROUP_IDS = QA_GROUPS.map((g) => g.id);
+
+export function normalizeQaGroups(groups: QaTestGroup[]): QaTestGroup[] {
+  const valid = groups.filter((g): g is QaTestGroup =>
+    QA_GROUP_IDS.includes(g),
+  );
+  const set = new Set<QaTestGroup>(valid);
+  set.add("journey");
+  // Keep canonical order for stable UI/prompt output.
+  return QA_GROUP_IDS.filter((g) => set.has(g));
+}
+
+/**
+ * Per-group check-layer overrides applied to generated tests. Sparse — absent
+ * keys fall through to repo defaults (see TestPlaywrightOverrides). a11y and
+ * perf tests enforce their layer so the suite actually gates on them; for
+ * resilience/negative tests console+network noise is expected (we
+ * deliberately break the network), so those layers only log.
+ */
+export function groupPlaywrightOverrides(
+  group: QaTestGroup,
+): TestPlaywrightOverrides | undefined {
+  switch (group) {
+    case "a11y":
+      return { a11yMode: "enforce" };
+    case "perf":
+      return { perfMode: "enforce" };
+    case "resilience":
+    case "negative":
+      return { networkMode: "log", consoleMode: "log" };
+    default:
+      return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Plan validation (parseAiJson predicate)
+// ---------------------------------------------------------------------------
+
+const PRIORITIES: QaPriority[] = ["P1", "P2", "P3"];
+
+function isStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every((s) => typeof s === "string");
+}
+
+function isJourney(v: unknown): v is QaPlanJourney {
+  if (!v || typeof v !== "object") return false;
+  const j = v as Record<string, unknown>;
+  return (
+    typeof j.id === "string" &&
+    typeof j.title === "string" &&
+    PRIORITIES.includes(j.priority as QaPriority) &&
+    isStringArray(j.steps) &&
+    typeof j.businessOutcome === "string" &&
+    typeof j.endStateVerification === "string"
+  );
+}
+
+function isPlanItem(v: unknown): v is QaPlanItem {
+  if (!v || typeof v !== "object") return false;
+  const i = v as Record<string, unknown>;
+  if (
+    typeof i.id !== "string" ||
+    !QA_GROUP_IDS.includes(i.group as QaTestGroup) ||
+    typeof i.title !== "string" ||
+    !PRIORITIES.includes(i.priority as QaPriority) ||
+    typeof i.scenario !== "string"
+  ) {
+    return false;
+  }
+  if (i.api !== undefined) {
+    const a = i.api as Record<string, unknown>;
+    if (
+      !a ||
+      typeof a !== "object" ||
+      typeof a.path !== "string" ||
+      !["GET", "POST", "PUT", "PATCH", "DELETE"].includes(a.method as string)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function isQaTestPlan(v: unknown): v is QaTestPlan {
+  if (!v || typeof v !== "object") return false;
+  const p = v as Record<string, unknown>;
+  const profile = p.appProfile as Record<string, unknown> | undefined;
+  if (!profile || typeof profile.summary !== "string") return false;
+  if (!Array.isArray(p.journeys) || !p.journeys.every(isJourney)) return false;
+  if (!Array.isArray(p.items) || !p.items.every(isPlanItem)) return false;
+  return p.items.length > 0;
+}
+
+/** Drop plan items in groups the user did not select, and orphaned journey
+ *  references. Keeps the plan internally consistent after AI generation. */
+export function sanitizeQaPlan(
+  plan: QaTestPlan,
+  groups: QaTestGroup[],
+): QaTestPlan {
+  const allowed = new Set(groups);
+  const journeyIds = new Set(plan.journeys.map((j) => j.id));
+  return {
+    ...plan,
+    items: plan.items
+      .filter((i) => allowed.has(i.group))
+      .map((i) =>
+        i.journeyId && !journeyIds.has(i.journeyId)
+          ? { ...i, journeyId: undefined }
+          : i,
+      ),
+  };
+}
+
+export function enabledPlanItems(plan: QaTestPlan): QaPlanItem[] {
+  return plan.items.filter((i) => i.enabled !== false);
+}
+
+// ---------------------------------------------------------------------------
+// Discovery digest — condensed, deterministic, capped
+// ---------------------------------------------------------------------------
+
+const MAX_DIGEST_CHARS = 24_000;
+
+function pageDigest(p: QaPageSnapshot): string {
+  const lines: string[] = [];
+  lines.push(`### Page: ${p.finalUrl}${p.title ? ` — "${p.title}"` : ""}`);
+  if (p.headings.length) {
+    lines.push(
+      `Headings: ${p.headings
+        .slice(0, 10)
+        .map((h) => `h${h.level} "${h.text}"`)
+        .join("; ")}`,
+    );
+  }
+  for (const f of p.forms.slice(0, 5)) {
+    const inputs = f.inputs
+      .slice(0, 12)
+      .map((i) => {
+        const label = i.label || i.name || i.id || i.type || i.tag;
+        return `${i.tag}${i.type ? `[${i.type}]` : ""} "${label}"`;
+      })
+      .join(", ");
+    lines.push(
+      `Form${f.name ? ` "${f.name}"` : ""} (${f.method.toUpperCase()}${f.action ? ` → ${f.action}` : ""}): ${inputs}`,
+    );
+  }
+  if (p.buttons.length) {
+    lines.push(`Buttons: ${p.buttons.slice(0, 20).join(" | ")}`);
+  }
+  if (p.links.length) {
+    lines.push(
+      `Links: ${p.links
+        .slice(0, 25)
+        .map((l) => `"${l.text || "(icon)"}" → ${l.href}`)
+        .join("; ")}`,
+    );
+  }
+  if (p.testIds.length) {
+    lines.push(`data-testid: ${p.testIds.slice(0, 30).join(", ")}`);
+  }
+  if (p.candidateSelectors.length) {
+    lines.push(
+      `Verified selectors: ${p.candidateSelectors.slice(0, 20).join(" ; ")}`,
+    );
+  }
+  if (p.apiEndpoints.length) {
+    lines.push(
+      `API calls observed: ${p.apiEndpoints
+        .slice(0, 20)
+        .map((e) => `${e.method} ${e.path} → ${e.status}`)
+        .join("; ")}`,
+    );
+  }
+  return lines.join("\n");
+}
+
+export function buildDiscoveryDigest(discovery: QaDiscovery): string {
+  const sections: string[] = [];
+  sections.push(`Target URL: ${discovery.targetUrl}`);
+  if (discovery.staticRoutes?.length) {
+    sections.push(
+      `## Routes from source code (${discovery.framework ?? "unknown framework"})\n` +
+        discovery.staticRoutes
+          .slice(0, 80)
+          .map((r) => `- ${r.path} (${r.type})`)
+          .join("\n"),
+    );
+  } else if (discovery.githubConnected) {
+    sections.push("## Routes from source code\n(none found by static scan)");
+  }
+  sections.push("## Live crawl (rendered DOM — authoritative for selectors)");
+  for (const page of discovery.crawledPages) {
+    sections.push(pageDigest(page));
+  }
+  const digest = sections.join("\n\n");
+  return digest.length > MAX_DIGEST_CHARS
+    ? digest.slice(0, MAX_DIGEST_CHARS) + "\n…(truncated)"
+    : digest;
+}
+
+// ---------------------------------------------------------------------------
+// Planner prompts
+// ---------------------------------------------------------------------------
+
+/** Distilled 2025/2026 web-app test-design best practices (playwright.dev,
+ *  web.dev CWV, Deque/axe, testing-trophy, IEEE-829-derived planning). The
+ *  planner must ground every item in the discovery digest, not this text. */
+const BEST_PRACTICES = `TEST DESIGN PRINCIPLES (follow strictly):
+- Risk-based prioritization: P1 = revenue/universal-gateway/critical-consequence flows, P2 = important features, P3 = nice-to-have. Score by business impact × likelihood of breakage.
+- Smoke tier: read-mostly checks of critical paths (page loads, login form present, core nav works). Production-safe — no data mutation.
+- Business journeys: identify the app's PRIMARY business outcome (a bank transfer completed, an order placed, a signup finished) and plan complete end-to-end journeys that PROVE the outcome — a success toast is not proof; specify end-state verification (balance changed, record visible in a list, API returns the created resource).
+- API tests: exercise observed API endpoints headlessly (status, response shape). Prefer endpoints seen during the live crawl.
+- Hybrid tests: seed or verify state via API where endpoints exist, exercise the behavior via UI. Never build test state through long UI click chains.
+- UI tests: user-visible flows per page. Assert user-visible outcomes with web-first assertions; never implementation details.
+- Accessibility: key pages AND post-interaction states (open modal, error state). WCAG 2.2 AA via axe.
+- Performance: Core Web Vitals budgets on key pages — LCP ≤ 2.5s, CLS ≤ 0.1, TTFB ≤ 800ms.
+- Resilience: abort/fail API calls, offline mode, 500/429 responses — assert graceful error UI, no blank screens, no data loss.
+- Negative: per-form input matrices — empty, whitespace, boundary lengths (min−1/min/max/max+1), wrong type, unicode/emoji, inert XSS payload strings, oversized input, double-submit.
+- Selector strategy for scenarios: reference elements by role+name or data-testid exactly as they appear in the discovery digest. NEVER invent selectors.
+- Every test must be independent and idempotent where possible.`;
+
+export function buildPlannerSystemPrompt(): string {
+  return `You are a principal QA architect designing a comprehensive automated test suite for a web application. You are given real discovery data: rendered-DOM page maps, verified selectors, observed API endpoints, and (when available) routes from the app's source code.
+
+${BEST_PRACTICES}
+
+OUTPUT: a single JSON object, no markdown fences, no commentary, matching exactly:
+{
+  "appProfile": { "summary": string, "businessDomain": string, "primaryOutcome": string },
+  "journeys": [ { "id": "J1", "title": string, "priority": "P1"|"P2"|"P3", "steps": [string], "businessOutcome": string, "endStateVerification": string } ],
+  "items": [ { "id": "T1", "group": <group>, "title": string, "priority": "P1"|"P2"|"P3", "journeyId": string?, "pagePath": string?, "rationale": string, "scenario": string, "selectorHints": [string]?, "api": { "method": "GET"|"POST"|"PUT"|"PATCH"|"DELETE", "path": string, "expectedStatus": number }? } ],
+  "entryCriteria": [string],
+  "exitCriteria": [string],
+  "risks": [string]
+}
+
+RULES:
+- "scenario" must be generator-ready: numbered concrete steps with expected results, grounded in the discovery digest (real button labels, real form fields, real paths).
+- Every journey needs at least one covering item with group "journey" and journeyId set (traceability).
+- Items in group "api" MUST include the "api" object using an endpoint observed in discovery. Do not plan api items for endpoints you did not observe.
+- selectorHints must be copied from the digest's verified selectors / data-testid lists — never invented.
+- pagePath is relative to the target URL (e.g. "/login").
+- 2-4 items per selected group, 1-3 journeys. Quality over quantity: every item must be executable against the discovered pages.
+- If credentials are provided, journeys may include login; if not, plan public-surface coverage only.`;
+}
+
+export function buildPlannerUserPrompt(opts: {
+  digest: string;
+  groups: QaTestGroup[];
+  credsProvided: boolean;
+  feedback?: string;
+}): string {
+  const groupList = opts.groups
+    .map((g) => {
+      const meta = QA_GROUPS.find((m) => m.id === g);
+      return `- ${g}: ${meta?.description ?? ""}`;
+    })
+    .join("\n");
+  const parts = [
+    `Design the test plan for the application described below.`,
+    `Selected coverage groups:\n${groupList}`,
+    `Login credentials available: ${opts.credsProvided ? "YES — journeys may authenticate" : "NO — public surface only"}`,
+  ];
+  if (opts.feedback) {
+    parts.push(
+      `The previous plan was rejected by the human reviewer with this feedback — address it:\n${opts.feedback}`,
+    );
+  }
+  parts.push(`--- DISCOVERY DIGEST ---\n${opts.digest}`);
+  return parts.join("\n\n");
+}
+
+// ---------------------------------------------------------------------------
+// Generator prompt per plan item
+// ---------------------------------------------------------------------------
+
+const GROUP_GENERATION_GUIDANCE: Partial<Record<QaTestGroup, string>> = {
+  smoke:
+    "This is a SMOKE test: read-only, fast, production-safe. No data mutation. Assert the page renders its critical content and key controls are visible.",
+  a11y: "This is an ACCESSIBILITY test. After reaching each state described in the scenario, take a screenshot checkpoint. Structure interactions so key states (initial page, opened dialogs, error states) are each reached and captured — the platform runs axe automatically on captured states.",
+  perf: "This is a PERFORMANCE test. Navigate to the target page(s) with a plain page.goto and take a screenshot checkpoint per page — the platform captures Core Web Vitals automatically. Do not add artificial waits.",
+  resilience:
+    "This is a RESILIENCE test. Use page.route() to inject failures BEFORE the interaction (e.g. await page.route('**/api/**', route => route.abort('failed')) or route.fulfill({ status: 500, body: '{}' })). Then perform the interaction and assert graceful error UI: an error message is visible, the page did not blank, and data was not silently lost. Unroute afterwards if the scenario continues.",
+  negative:
+    "This is a NEGATIVE test. Drive the form(s) through the invalid-input matrix in the scenario (empty, boundary, wrong type, XSS-payload-as-inert-text). Assert validation feedback appears and no invalid submission succeeds.",
+  hybrid:
+    "This is a HYBRID test. Where the scenario says to verify via API, use the page's fetch from the browser context (const res = await page.evaluate(...fetch...)) against the same origin and assert on the JSON, in addition to UI assertions.",
+  journey:
+    "This is a BUSINESS-OUTCOME JOURNEY. Complete the full flow and then PROVE the outcome per the end-state verification (assert the persisted result is visible: updated balance, created record in a list, confirmation with a real identifier). A success toast alone is insufficient.",
+};
+
+export function buildGeneratorPrompt(opts: {
+  item: QaPlanItem;
+  plan: QaTestPlan;
+  targetUrl: string;
+  credentials?: { email: string; password: string };
+}): string {
+  const { item, plan } = opts;
+  const journey = item.journeyId
+    ? plan.journeys.find((j) => j.id === item.journeyId)
+    : undefined;
+  const parts: string[] = [];
+  parts.push(`Test: ${item.title}`);
+  parts.push(`Coverage group: ${item.group} · Priority: ${item.priority}`);
+  if (item.pagePath) parts.push(`Page under test: ${item.pagePath}`);
+  const guidance = GROUP_GENERATION_GUIDANCE[item.group];
+  if (guidance) parts.push(guidance);
+  parts.push(`Scenario:\n${item.scenario}`);
+  if (journey) {
+    parts.push(
+      `Journey context: "${journey.title}" — business outcome: ${journey.businessOutcome}. End-state verification requirement: ${journey.endStateVerification}`,
+    );
+  }
+  if (item.selectorHints?.length) {
+    parts.push(
+      `Verified selectors from discovery (prefer these):\n${item.selectorHints
+        .map((s) => `- ${s}`)
+        .join("\n")}`,
+    );
+  }
+  if (opts.credentials) {
+    parts.push(
+      `If the scenario requires authentication, log in first with email "${opts.credentials.email}" and password "${opts.credentials.password}".`,
+    );
+  }
+  return parts.join("\n\n");
+}
+
+// ---------------------------------------------------------------------------
+// API-group item → headless ApiTestDefinition
+// ---------------------------------------------------------------------------
+
+export function buildApiDefinition(
+  item: QaPlanItem,
+  targetUrl: string,
+): ApiTestDefinition | null {
+  if (!item.api) return null;
+  const base = targetUrl.replace(/\/+$/, "");
+  const path = item.api.path.startsWith("/")
+    ? item.api.path
+    : `/${item.api.path}`;
+  const isAbsolute = /^https?:\/\//i.test(item.api.path);
+  return {
+    method: item.api.method,
+    url: isAbsolute ? item.api.path : `${base}${path}`,
+    ...(item.api.body !== undefined ? { body: item.api.body } : {}),
+    assertions: [
+      {
+        kind: "status",
+        equals: item.api.expectedStatus ?? 200,
+        description:
+          item.api.description ?? `${item.title} returns expected status`,
+      },
+      {
+        kind: "latencyMs",
+        maxMs: 5000,
+        description: "responds within 5s",
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Summary / traceability
+// ---------------------------------------------------------------------------
+
+export function computeQaSummary(
+  plan: QaTestPlan,
+  generated: QaGeneratedTest[],
+): QaSummaryData {
+  const items = enabledPlanItems(plan);
+  const byGroup: QaSummaryData["byGroup"] = {};
+  for (const item of items) {
+    const bucket = (byGroup[item.group] ??= {
+      planned: 0,
+      generated: 0,
+      passed: 0,
+    });
+    bucket.planned += 1;
+  }
+  let generatedCount = 0;
+  let passed = 0;
+  let failed = 0;
+  let healed = 0;
+  for (const g of generated) {
+    const bucket = (byGroup[g.group] ??= {
+      planned: 0,
+      generated: 0,
+      passed: 0,
+    });
+    if (g.status !== "generation_failed" && g.status !== "generating") {
+      generatedCount += 1;
+      bucket.generated += 1;
+    }
+    if (g.status === "passed" || g.status === "healed") {
+      passed += 1;
+      bucket.passed += 1;
+    }
+    if (g.status === "healed") healed += 1;
+    if (g.status === "failed") failed += 1;
+  }
+  const journeyCoverage: Record<string, string[]> = {};
+  for (const journey of plan.journeys) {
+    const coveringItems = new Set(
+      items.filter((i) => i.journeyId === journey.id).map((i) => i.id),
+    );
+    journeyCoverage[journey.id] = generated
+      .filter((g) => g.testId && coveringItems.has(g.planItemId))
+      .map((g) => g.testId!) as string[];
+  }
+  return {
+    planned: items.length,
+    generated: generatedCount,
+    passed,
+    failed,
+    healed,
+    byGroup,
+    journeyCoverage,
+  };
+}

--- a/src/lib/qa-agent/plan.ts
+++ b/src/lib/qa-agent/plan.ts
@@ -450,13 +450,20 @@ RULES:
 - pagePath is relative to the target URL (e.g. "/login").
 - "businessArea" is REQUIRED on every item and journey: a short, consistent functional-domain name (e.g. "Authentication", "Accounts", "Checkout", "Marketing"). Use 2-5 distinct areas total and reuse the exact same spelling across items — they become the rows of a coverage matrix.
 - Every selected group must appear in at least one item's "groups". Plan the SMALLEST test set that achieves this — typically 1-2 items per page/flow — and 1-3 journeys. Quality over quantity: every item must be executable against the discovered pages. HARD LIMITS: at most ${MAX_PLAN_ITEMS} items and ${MAX_PLAN_JOURNEYS} journeys — consolidate rather than exceed them (tests generate one at a time, so a bloated plan is slow and low-signal).
-- If credentials are provided, journeys may include login; if not, plan public-surface coverage only.`;
+- Ground the plan in the DISCOVERY DIGEST's actual crawled pages. When the digest's crawled pages are signed-in, in-app pages (a dashboard, resource lists, detail/settings pages), the app IS authenticated for this run — plan coverage of that in-app product surface. Never collapse an authenticated run into public login/register pages that the crawl did not even map; the auth pages are the gateway, not the product.
+- Authentication: when an authenticated session is available (see the user message), plan the in-app surface and journeys need NOT script a login (the session is applied automatically) — do not spend items on the login form unless login itself is a listed coverage goal. When no authenticated session is available, plan public-surface coverage only.`;
 }
 
 export function buildPlannerUserPrompt(opts: {
   digest: string;
   groups: QaTestGroup[];
-  credsProvided: boolean;
+  /** The discovery crawl ran with an authenticated session AND generated tests
+   *  will run authenticated (typed credentials, a captured storage state, or
+   *  repo default setup steps). When true the planner must cover the
+   *  discovered signed-in in-app surface, not just public auth/marketing pages.
+   *  This is auth AVAILABILITY, not "plaintext credentials were typed" — a
+   *  storage-state session counts. */
+  authenticated: boolean;
   feedback?: string;
   /** Digest of tests that already exist in the repo (see
    *  buildExistingCoverageDigest). Present on refresh/spec runs so the
@@ -472,7 +479,9 @@ export function buildPlannerUserPrompt(opts: {
   const parts = [
     `Design the test plan for the application described below.`,
     `Selected coverage groups:\n${groupList}`,
-    `Login credentials available: ${opts.credsProvided ? "YES — journeys may authenticate" : "NO — public surface only"}`,
+    opts.authenticated
+      ? "Authenticated session available: YES — the discovery crawl ran signed-in and every generated test starts authenticated. The DISCOVERY DIGEST below is the signed-in, in-app surface. Plan coverage of THAT in-app surface (the real product features the crawl mapped — dashboards, lists, detail pages, settings, create/edit flows). Do NOT reduce the plan to public login/register/marketing pages; those are the gateway, not the product. Journeys must exercise the primary in-app outcome, not just reaching the app."
+      : "Authenticated session available: NO — public surface only. Plan coverage of the public pages the crawl mapped (login, register, forgot-password, marketing) only; do not plan tests that require being signed in.",
   ];
   if (opts.existingCoverage) {
     parts.push(

--- a/src/lib/qa-agent/plan.ts
+++ b/src/lib/qa-agent/plan.ts
@@ -1,3 +1,4 @@
+import { buildCodeCheckDigest } from "./code-check";
 import type {
   ApiTestDefinition,
   QaDiscovery,
@@ -361,6 +362,9 @@ function pageDigest(p: QaPageSnapshot): string {
 export function buildDiscoveryDigest(discovery: QaDiscovery): string {
   const sections: string[] = [];
   sections.push(`Target URL: ${discovery.targetUrl}`);
+  if (discovery.codeCheck) {
+    sections.push(buildCodeCheckDigest(discovery.codeCheck));
+  }
   if (discovery.staticRoutes?.length) {
     sections.push(
       `## Routes from source code (${discovery.framework ?? "unknown framework"})\n` +
@@ -445,7 +449,7 @@ RULES:
 - "scenario" must be generator-ready: numbered concrete steps with expected results, grounded in the discovery digest (real button labels, real form fields, real paths).
 - "groups" lists EVERY coverage group the test satisfies, most-defining first — the scenario must genuinely exercise each listed group (a11y: reaches the key interaction states; perf: plain navigation to the page; ui: user-visible interaction).
 - Every journey needs at least one covering item with "journey" in its groups and journeyId set (traceability).
-- Items with "api" in groups MUST include the "api" object using an endpoint observed in discovery. Do not plan api items for endpoints you did not observe.
+- Items with "api" in groups MUST include the "api" object using an endpoint observed during the live crawl OR declared in the code analysis. Do not invent endpoints that appear in neither.
 - selectorHints must be copied from the digest's verified selectors / data-testid lists — never invented.
 - pagePath is relative to the target URL (e.g. "/login").
 - "businessArea" is REQUIRED on every item and journey: a short, consistent functional-domain name (e.g. "Authentication", "Accounts", "Checkout", "Marketing"). Use 2-5 distinct areas total and reuse the exact same spelling across items — they become the rows of a coverage matrix.
@@ -469,6 +473,9 @@ export function buildPlannerUserPrompt(opts: {
    *  buildExistingCoverageDigest). Present on refresh/spec runs so the
    *  planner designs against the CURRENT suite instead of a blank slate. */
   existingCoverage?: string;
+  /** Condensed uploaded product documentation (requirements/specs/manuals) —
+   *  authoritative for intended behavior, journeys, and business areas. */
+  docsDigest?: string;
 }): string {
   const groupList = opts.groups
     .map((g) => {
@@ -483,6 +490,11 @@ export function buildPlannerUserPrompt(opts: {
       ? "Authenticated session available: YES — the discovery crawl ran signed-in and every generated test starts authenticated. The DISCOVERY DIGEST below is the signed-in, in-app surface. Plan coverage of THAT in-app surface (the real product features the crawl mapped — dashboards, lists, detail pages, settings, create/edit flows). Do NOT reduce the plan to public login/register/marketing pages; those are the gateway, not the product. Journeys must exercise the primary in-app outcome, not just reaching the app."
       : "Authenticated session available: NO — public surface only. Plan coverage of the public pages the crawl mapped (login, register, forgot-password, marketing) only; do not plan tests that require being signed in.",
   ];
+  if (opts.docsDigest) {
+    parts.push(
+      `PRODUCT DOCUMENTATION was provided (below). Treat it as AUTHORITATIVE for intended behavior: derive journeys, business outcomes, business areas, and priorities from it; use its terminology; and plan coverage for documented behavior even when the crawl did not reach it (note "documented, not observed in crawl" in the rationale — such items still need concrete, cautious scenarios).\n\n--- PRODUCT DOCUMENTATION ---\n${opts.docsDigest}`,
+    );
+  }
   if (opts.existingCoverage) {
     parts.push(
       `The repository ALREADY CONTAINS the automated tests listed below (created by earlier runs or by hand). Design the plan for the application as it is NOW: keep the plan complete (every journey and coverage angle listed, so traceability stays whole), and when a scenario is already well covered by an existing test, reuse that test's exact name as the item title so it can be matched — do not invent a variation of it. Focus new/changed scenarios on what the existing suite does NOT cover.\n\n--- EXISTING TESTS ---\n${opts.existingCoverage}`,

--- a/src/lib/qa-agent/plan.ts
+++ b/src/lib/qa-agent/plan.ts
@@ -91,6 +91,16 @@ export function normalizeQaGroups(groups: QaTestGroup[]): QaTestGroup[] {
   return QA_GROUP_IDS.filter((g) => set.has(g));
 }
 
+/** All coverage groups a plan item satisfies: `groups` (deduped, primary
+ *  first, rest in canonical order) or `[group]` for legacy single-group
+ *  items. One generated test counts toward every group returned here. */
+export function itemGroups(item: QaPlanItem): QaTestGroup[] {
+  const raw = item.groups?.filter((g) => QA_GROUP_IDS.includes(g));
+  if (!raw?.length) return [item.group];
+  const rest = new Set(raw.filter((g) => g !== raw[0]));
+  return [raw[0], ...QA_GROUP_IDS.filter((g) => rest.has(g))];
+}
+
 /**
  * Per-group check-layer overrides applied to generated tests. Sparse — absent
  * keys fall through to repo defaults (see TestPlaywrightOverrides). a11y and
@@ -112,6 +122,20 @@ export function groupPlaywrightOverrides(
     default:
       return undefined;
   }
+}
+
+/** Merged check-layer overrides for a (possibly multi-group) plan item.
+ *  Group override keys are disjoint (a11yMode / perfMode / networkMode+
+ *  consoleMode), so a plain spread-merge is conflict-free. */
+export function itemPlaywrightOverrides(
+  groups: QaTestGroup[],
+): TestPlaywrightOverrides | undefined {
+  let merged: TestPlaywrightOverrides | undefined;
+  for (const group of groups) {
+    const overrides = groupPlaywrightOverrides(group);
+    if (overrides) merged = { ...merged, ...overrides };
+  }
+  return merged;
 }
 
 // ---------------------------------------------------------------------------
@@ -141,9 +165,15 @@ function isJourney(v: unknown): v is QaPlanJourney {
 function isPlanItem(v: unknown): v is QaPlanItem {
   if (!v || typeof v !== "object") return false;
   const i = v as Record<string, unknown>;
+  const hasGroup = QA_GROUP_IDS.includes(i.group as QaTestGroup);
+  const hasGroups =
+    Array.isArray(i.groups) &&
+    i.groups.length > 0 &&
+    i.groups.every((g) => QA_GROUP_IDS.includes(g as QaTestGroup));
+  if (i.groups !== undefined && !hasGroups) return false;
   if (
     typeof i.id !== "string" ||
-    !QA_GROUP_IDS.includes(i.group as QaTestGroup) ||
+    (!hasGroup && !hasGroups) ||
     typeof i.title !== "string" ||
     !PRIORITIES.includes(i.priority as QaPriority) ||
     typeof i.scenario !== "string" ||
@@ -175,24 +205,27 @@ export function isQaTestPlan(v: unknown): v is QaTestPlan {
   return p.items.length > 0;
 }
 
-/** Drop plan items in groups the user did not select, and orphaned journey
- *  references. Keeps the plan internally consistent after AI generation. */
+/** Drop plan items whose groups the user did not select (multi-group items
+ *  survive with disallowed groups stripped), backfill the primary `group`
+ *  when the AI only emitted `groups`, and clear orphaned journey references.
+ *  Keeps the plan internally consistent after AI generation. */
 export function sanitizeQaPlan(
   plan: QaTestPlan,
   groups: QaTestGroup[],
 ): QaTestPlan {
   const allowed = new Set(groups);
   const journeyIds = new Set(plan.journeys.map((j) => j.id));
-  return {
-    ...plan,
-    items: plan.items
-      .filter((i) => allowed.has(i.group))
-      .map((i) =>
-        i.journeyId && !journeyIds.has(i.journeyId)
-          ? { ...i, journeyId: undefined }
-          : i,
-      ),
-  };
+  const items: QaPlanItem[] = [];
+  for (const raw of plan.items) {
+    const kept = itemGroups(raw).filter((g) => allowed.has(g));
+    if (kept.length === 0) continue;
+    const item: QaPlanItem = { ...raw, group: kept[0], groups: kept };
+    if (item.journeyId && !journeyIds.has(item.journeyId)) {
+      item.journeyId = undefined;
+    }
+    items.push(item);
+  }
+  return { ...plan, items };
 }
 
 export function enabledPlanItems(plan: QaTestPlan): QaPlanItem[] {
@@ -301,7 +334,12 @@ const BEST_PRACTICES = `TEST DESIGN PRINCIPLES (follow strictly):
 - Resilience: abort/fail API calls, offline mode, 500/429 responses — assert graceful error UI, no blank screens, no data loss.
 - Negative: per-form input matrices — empty, whitespace, boundary lengths (min−1/min/max/max+1), wrong type, unicode/emoji, inert XSS payload strings, oversized input, double-submit.
 - Selector strategy for scenarios: reference elements by role+name or data-testid exactly as they appear in the discovery digest. NEVER invent selectors.
-- Every test must be independent and idempotent where possible.`;
+- Every test must be independent and idempotent where possible.
+
+CONSOLIDATION (minimize test count): the platform runs EVERY check layer (visual, a11y/axe, performance/CWV, console, network, text, DOM) on each test execution automatically. When multiple coverage angles exercise the same page or flow, plan ONE test tagged with all applicable groups instead of separate tests — never plan a standalone a11y or perf test for a page another planned test already visits; tag that test instead. Compatibility rules:
+- smoke, ui, hybrid, journey, a11y, perf combine freely in one test.
+- resilience and negative may combine with each other (both expect console/network noise) but NEVER with smoke or journey (smoke is production-safe read-only; an injected failure invalidates outcome proof).
+- api never combines (headless, no browser).`;
 
 export function buildPlannerSystemPrompt(): string {
   return `You are a principal QA architect designing a comprehensive automated test suite for a web application. You are given real discovery data: rendered-DOM page maps, verified selectors, observed API endpoints, and (when available) routes from the app's source code.
@@ -312,7 +350,7 @@ OUTPUT: a single JSON object, no markdown fences, no commentary, matching exactl
 {
   "appProfile": { "summary": string, "businessDomain": string, "primaryOutcome": string },
   "journeys": [ { "id": "J1", "title": string, "priority": "P1"|"P2"|"P3", "businessArea": string, "steps": [string], "businessOutcome": string, "endStateVerification": string } ],
-  "items": [ { "id": "T1", "group": <group>, "title": string, "priority": "P1"|"P2"|"P3", "journeyId": string?, "businessArea": string, "pagePath": string?, "rationale": string, "scenario": string, "selectorHints": [string]?, "api": { "method": "GET"|"POST"|"PUT"|"PATCH"|"DELETE", "path": string, "expectedStatus": number }? } ],
+  "items": [ { "id": "T1", "groups": [<group>, ...], "title": string, "priority": "P1"|"P2"|"P3", "journeyId": string?, "businessArea": string, "pagePath": string?, "rationale": string, "scenario": string, "selectorHints": [string]?, "api": { "method": "GET"|"POST"|"PUT"|"PATCH"|"DELETE", "path": string, "expectedStatus": number }? } ],
   "entryCriteria": [string],
   "exitCriteria": [string],
   "risks": [string]
@@ -320,12 +358,13 @@ OUTPUT: a single JSON object, no markdown fences, no commentary, matching exactl
 
 RULES:
 - "scenario" must be generator-ready: numbered concrete steps with expected results, grounded in the discovery digest (real button labels, real form fields, real paths).
-- Every journey needs at least one covering item with group "journey" and journeyId set (traceability).
-- Items in group "api" MUST include the "api" object using an endpoint observed in discovery. Do not plan api items for endpoints you did not observe.
+- "groups" lists EVERY coverage group the test satisfies, most-defining first — the scenario must genuinely exercise each listed group (a11y: reaches the key interaction states; perf: plain navigation to the page; ui: user-visible interaction).
+- Every journey needs at least one covering item with "journey" in its groups and journeyId set (traceability).
+- Items with "api" in groups MUST include the "api" object using an endpoint observed in discovery. Do not plan api items for endpoints you did not observe.
 - selectorHints must be copied from the digest's verified selectors / data-testid lists — never invented.
 - pagePath is relative to the target URL (e.g. "/login").
 - "businessArea" is REQUIRED on every item and journey: a short, consistent functional-domain name (e.g. "Authentication", "Accounts", "Checkout", "Marketing"). Use 2-5 distinct areas total and reuse the exact same spelling across items — they become the rows of a coverage matrix.
-- 2-4 items per selected group, 1-3 journeys. Quality over quantity: every item must be executable against the discovered pages.
+- Every selected group must appear in at least one item's "groups". Plan the SMALLEST test set that achieves this — typically 1-2 items per page/flow — and 1-3 journeys. Quality over quantity: every item must be executable against the discovered pages.
 - If credentials are provided, journeys may include login; if not, plan public-surface coverage only.`;
 }
 
@@ -462,15 +501,22 @@ export function buildGeneratorPrompt(opts: {
   credentials?: { email: string; password: string };
 }): string {
   const { item, plan } = opts;
+  const groups = itemGroups(item);
   const journey = item.journeyId
     ? plan.journeys.find((j) => j.id === item.journeyId)
     : undefined;
   const parts: string[] = [];
   parts.push(`Test: ${item.title}`);
-  parts.push(`Coverage group: ${item.group} · Priority: ${item.priority}`);
+  parts.push(
+    `Coverage group${groups.length > 1 ? "s" : ""}: ${groups.join(" + ")} · Priority: ${item.priority}`,
+  );
   if (item.pagePath) parts.push(`Page under test: ${item.pagePath}`);
-  const guidance = GROUP_GENERATION_GUIDANCE[item.group];
-  if (guidance) parts.push(guidance);
+  // Multi-group items get every group's guidance (canonical order, primary
+  // first — itemGroups guarantees that), so one test serves all its tags.
+  for (const group of groups) {
+    const guidance = GROUP_GENERATION_GUIDANCE[group];
+    if (guidance) parts.push(guidance);
+  }
   parts.push(`Scenario:\n${item.scenario}`);
   if (journey) {
     parts.push(
@@ -542,9 +588,13 @@ export function computeQaSummary(
     covered: 0,
     passed: 0,
   });
+  // A multi-group test counts toward EVERY group it is tagged with — per-group
+  // buckets measure coverage, not test count (top-level totals stay per-test).
   for (const item of items) {
-    const bucket = (byGroup[item.group] ??= emptyBucket());
-    bucket.planned += 1;
+    for (const group of itemGroups(item)) {
+      const bucket = (byGroup[group] ??= emptyBucket());
+      bucket.planned += 1;
+    }
   }
   let generatedCount = 0;
   let covered = 0;
@@ -552,19 +602,20 @@ export function computeQaSummary(
   let failed = 0;
   let healed = 0;
   for (const g of generated) {
-    const bucket = (byGroup[g.group] ??= emptyBucket());
+    const groups = g.groups?.length ? g.groups : [g.group];
+    const buckets = groups.map((grp) => (byGroup[grp] ??= emptyBucket()));
     if (g.status === "covered") {
       covered += 1;
-      bucket.covered += 1;
+      for (const bucket of buckets) bucket.covered += 1;
       continue;
     }
     if (g.status !== "generation_failed" && g.status !== "generating") {
       generatedCount += 1;
-      bucket.generated += 1;
+      for (const bucket of buckets) bucket.generated += 1;
     }
     if (g.status === "passed" || g.status === "healed") {
       passed += 1;
-      bucket.passed += 1;
+      for (const bucket of buckets) bucket.passed += 1;
     }
     if (g.status === "healed") healed += 1;
     if (g.status === "failed") failed += 1;
@@ -586,21 +637,24 @@ export function computeQaSummary(
   for (const item of items) {
     const area = item.businessArea?.trim() || "General";
     const row = (matrix[area] ??= {});
-    const cell = (row[item.group] ??= {
-      planned: 0,
-      covered: 0,
-      generated: 0,
-      passed: 0,
-    });
-    cell.planned += 1;
     const entry = ledgerByItem.get(item.id);
-    if (!entry) continue;
-    if (entry.status === "covered") {
-      cell.covered += 1;
-    } else if (entry.status !== "generating" && entry.testId) {
-      cell.generated += 1;
-      if (entry.status === "passed" || entry.status === "healed") {
-        cell.passed += 1;
+    // A multi-group test marks every group column it is tagged with.
+    for (const group of itemGroups(item)) {
+      const cell = (row[group] ??= {
+        planned: 0,
+        covered: 0,
+        generated: 0,
+        passed: 0,
+      });
+      cell.planned += 1;
+      if (!entry) continue;
+      if (entry.status === "covered") {
+        cell.covered += 1;
+      } else if (entry.status !== "generating" && entry.testId) {
+        cell.generated += 1;
+        if (entry.status === "passed" || entry.status === "healed") {
+          cell.passed += 1;
+        }
       }
     }
   }

--- a/src/lib/qa-agent/plan.ts
+++ b/src/lib/qa-agent/plan.ts
@@ -331,6 +331,10 @@ export function buildPlannerUserPrompt(opts: {
   groups: QaTestGroup[];
   credsProvided: boolean;
   feedback?: string;
+  /** Digest of tests that already exist in the repo (see
+   *  buildExistingCoverageDigest). Present on refresh/spec runs so the
+   *  planner designs against the CURRENT suite instead of a blank slate. */
+  existingCoverage?: string;
 }): string {
   const groupList = opts.groups
     .map((g) => {
@@ -343,6 +347,11 @@ export function buildPlannerUserPrompt(opts: {
     `Selected coverage groups:\n${groupList}`,
     `Login credentials available: ${opts.credsProvided ? "YES — journeys may authenticate" : "NO — public surface only"}`,
   ];
+  if (opts.existingCoverage) {
+    parts.push(
+      `The repository ALREADY CONTAINS the automated tests listed below (created by earlier runs or by hand). Design the plan for the application as it is NOW: keep the plan complete (every journey and coverage angle listed, so traceability stays whole), and when a scenario is already well covered by an existing test, reuse that test's exact name as the item title so it can be matched — do not invent a variation of it. Focus new/changed scenarios on what the existing suite does NOT cover.\n\n--- EXISTING TESTS ---\n${opts.existingCoverage}`,
+    );
+  }
   if (opts.feedback) {
     parts.push(
       `The previous plan was rejected by the human reviewer with this feedback — address it:\n${opts.feedback}`,
@@ -350,6 +359,78 @@ export function buildPlannerUserPrompt(opts: {
   }
   parts.push(`--- DISCOVERY DIGEST ---\n${opts.digest}`);
   return parts.join("\n\n");
+}
+
+// ---------------------------------------------------------------------------
+// Existing-coverage matching (segmented re-runs)
+// ---------------------------------------------------------------------------
+
+/** The slice of a repo test the matcher/planner needs. */
+export interface ExistingTestSummary {
+  id: string;
+  name: string;
+  testType?: string | null;
+  functionalAreaName?: string | null;
+}
+
+const MAX_EXISTING_DIGEST_TESTS = 120;
+
+export function buildExistingCoverageDigest(
+  tests: ExistingTestSummary[],
+): string {
+  return tests
+    .slice(0, MAX_EXISTING_DIGEST_TESTS)
+    .map(
+      (t) =>
+        `- "${t.name}"${t.functionalAreaName ? ` (area: ${t.functionalAreaName})` : ""}${t.testType === "api" ? " [api]" : ""}`,
+    )
+    .join("\n");
+}
+
+function normalizeTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+/**
+ * Deterministically match plan items to tests that already exist. Two
+ * signals, strongest first:
+ *  1. A prior run's ledger linked the same plan-item id to a test that still
+ *     exists (fill_gaps reuses the source session's plan, so ids are stable).
+ *  2. Normalized-title equality with an existing test's name (covers manual
+ *     tests and the planner echoing an existing test's exact name).
+ * Returns planItemId → existing testId.
+ */
+export function matchPlanToExistingTests(
+  items: QaPlanItem[],
+  existingTests: ExistingTestSummary[],
+  priorLedger?: QaGeneratedTest[],
+): Map<string, string> {
+  const liveIds = new Set(existingTests.map((t) => t.id));
+  const byTitle = new Map<string, string>();
+  for (const t of existingTests) {
+    const key = normalizeTitle(t.name);
+    if (key && !byTitle.has(key)) byTitle.set(key, t.id);
+  }
+  const priorByItem = new Map<string, string>();
+  for (const entry of priorLedger ?? []) {
+    if (entry.testId && liveIds.has(entry.testId)) {
+      priorByItem.set(entry.planItemId, entry.testId);
+    }
+  }
+  const matches = new Map<string, string>();
+  for (const item of items) {
+    const prior = priorByItem.get(item.id);
+    if (prior) {
+      matches.set(item.id, prior);
+      continue;
+    }
+    const byName = byTitle.get(normalizeTitle(item.title));
+    if (byName) matches.set(item.id, byName);
+  }
+  return matches;
 }
 
 // ---------------------------------------------------------------------------
@@ -452,24 +533,28 @@ export function computeQaSummary(
 ): QaSummaryData {
   const items = enabledPlanItems(plan);
   const byGroup: QaSummaryData["byGroup"] = {};
+  const emptyBucket = () => ({
+    planned: 0,
+    generated: 0,
+    covered: 0,
+    passed: 0,
+  });
   for (const item of items) {
-    const bucket = (byGroup[item.group] ??= {
-      planned: 0,
-      generated: 0,
-      passed: 0,
-    });
+    const bucket = (byGroup[item.group] ??= emptyBucket());
     bucket.planned += 1;
   }
   let generatedCount = 0;
+  let covered = 0;
   let passed = 0;
   let failed = 0;
   let healed = 0;
   for (const g of generated) {
-    const bucket = (byGroup[g.group] ??= {
-      planned: 0,
-      generated: 0,
-      passed: 0,
-    });
+    const bucket = (byGroup[g.group] ??= emptyBucket());
+    if (g.status === "covered") {
+      covered += 1;
+      bucket.covered += 1;
+      continue;
+    }
     if (g.status !== "generation_failed" && g.status !== "generating") {
       generatedCount += 1;
       bucket.generated += 1;
@@ -493,6 +578,7 @@ export function computeQaSummary(
   return {
     planned: items.length,
     generated: generatedCount,
+    covered,
     passed,
     failed,
     healed,

--- a/src/lib/qa-agent/plan.ts
+++ b/src/lib/qa-agent/plan.ts
@@ -26,6 +26,8 @@ import type {
 export const QA_GROUPS: Array<{
   id: QaTestGroup;
   label: string;
+  /** Compact label for narrow matrix column headers. */
+  short: string;
   description: string;
   /** journey is always planned; the user cannot deselect it. */
   locked?: boolean;
@@ -33,6 +35,7 @@ export const QA_GROUPS: Array<{
   {
     id: "journey",
     label: "Business journeys",
+    short: "Journey",
     description:
       "Critical user journeys with verified business outcomes (e.g. order placed)",
     locked: true,
@@ -40,41 +43,49 @@ export const QA_GROUPS: Array<{
   {
     id: "smoke",
     label: "Smoke",
+    short: "Smoke",
     description: "Fast, read-mostly checks of critical paths — the PR gate",
   },
   {
     id: "api",
     label: "API",
+    short: "API",
     description: "Headless HTTP tests against observed API endpoints",
   },
   {
     id: "ui",
     label: "UI",
+    short: "UI",
     description: "User-visible flows and interactions per page",
   },
   {
     id: "hybrid",
     label: "Hybrid",
+    short: "Hybrid",
     description: "API-seeded state exercised and verified through the UI",
   },
   {
     id: "a11y",
     label: "Accessibility",
+    short: "A11y",
     description: "WCAG 2.2 AA checks (axe) on key pages and interaction states",
   },
   {
     id: "perf",
     label: "Performance",
+    short: "Perf",
     description: "Core Web Vitals budgets (LCP/CLS/TTFB) on key pages",
   },
   {
     id: "resilience",
     label: "Resilience",
+    short: "Resil",
     description: "Network failure injection and error-path behavior",
   },
   {
     id: "negative",
     label: "Negative",
+    short: "Neg",
     description: "Input validation matrices, boundaries, and abuse strings",
   },
 ];
@@ -499,6 +510,10 @@ export function buildGeneratorPrompt(opts: {
   plan: QaTestPlan;
   targetUrl: string;
   credentials?: { email: string; password: string };
+  /** When qa_login captured a session, tests start authenticated via setup
+   *  steps — the generator must not script a login (and gets no plaintext
+   *  credentials). */
+  auth?: { preAuthenticated: boolean };
 }): string {
   const { item, plan } = opts;
   const groups = itemGroups(item);
@@ -530,7 +545,11 @@ export function buildGeneratorPrompt(opts: {
         .join("\n")}`,
     );
   }
-  if (opts.credentials) {
+  if (opts.auth?.preAuthenticated) {
+    parts.push(
+      "The browser session starts already authenticated — a stored login session is applied as a setup step before the test runs. Do NOT write login steps; navigate straight to the page under test.",
+    );
+  } else if (opts.credentials) {
     parts.push(
       `If the scenario requires authentication, log in first with email "${opts.credentials.email}" and password "${opts.credentials.password}".`,
     );

--- a/src/lib/qa-agent/plan.ts
+++ b/src/lib/qa-agent/plan.ts
@@ -1,4 +1,5 @@
 import { buildCodeCheckDigest } from "./code-check";
+import { buildPrChangesDigest } from "./pr-check";
 import type {
   ApiTestDefinition,
   QaDiscovery,
@@ -197,7 +198,8 @@ function isPlanItem(v: unknown): v is QaPlanItem {
     typeof i.title !== "string" ||
     !PRIORITIES.includes(i.priority as QaPriority) ||
     typeof i.scenario !== "string" ||
-    (i.businessArea !== undefined && typeof i.businessArea !== "string")
+    (i.businessArea !== undefined && typeof i.businessArea !== "string") ||
+    (i.changeRefs !== undefined && !isStringArray(i.changeRefs))
   ) {
     return false;
   }
@@ -365,6 +367,9 @@ export function buildDiscoveryDigest(discovery: QaDiscovery): string {
   if (discovery.codeCheck) {
     sections.push(buildCodeCheckDigest(discovery.codeCheck));
   }
+  if (discovery.prChanges) {
+    sections.push(buildPrChangesDigest(discovery.prChanges));
+  }
   if (discovery.staticRoutes?.length) {
     sections.push(
       `## Routes from source code (${discovery.framework ?? "unknown framework"})\n` +
@@ -439,7 +444,7 @@ OUTPUT: a single JSON object, no markdown fences, no commentary, matching exactl
 {
   "appProfile": { "summary": string, "businessDomain": string, "primaryOutcome": string },
   "journeys": [ { "id": "J1", "title": string, "priority": "P1"|"P2"|"P3", "businessArea": string, "steps": [string], "businessOutcome": string, "endStateVerification": string } ],
-  "items": [ { "id": "T1", "groups": [<group>, ...], "title": string, "priority": "P1"|"P2"|"P3", "journeyId": string?, "businessArea": string, "pagePath": string?, "rationale": string, "scenario": string, "selectorHints": [string]?, "api": { "method": "GET"|"POST"|"PUT"|"PATCH"|"DELETE", "path": string, "expectedStatus": number }? } ],
+  "items": [ { "id": "T1", "groups": [<group>, ...], "title": string, "priority": "P1"|"P2"|"P3", "journeyId": string?, "businessArea": string, "pagePath": string?, "rationale": string, "scenario": string, "selectorHints": [string]?, "changeRefs": [string]?, "api": { "method": "GET"|"POST"|"PUT"|"PATCH"|"DELETE", "path": string, "expectedStatus": number }? } ],
   "entryCriteria": [string],
   "exitCriteria": [string],
   "risks": [string]
@@ -455,7 +460,8 @@ RULES:
 - "businessArea" is REQUIRED on every item and journey: a short, consistent functional-domain name (e.g. "Authentication", "Accounts", "Checkout", "Marketing"). Use 2-5 distinct areas total and reuse the exact same spelling across items — they become the rows of a coverage matrix.
 - Every selected group must appear in at least one item's "groups". Plan the SMALLEST test set that achieves this — typically 1-2 items per page/flow — and 1-3 journeys. Quality over quantity: every item must be executable against the discovered pages. HARD LIMITS: at most ${MAX_PLAN_ITEMS} items and ${MAX_PLAN_JOURNEYS} journeys — consolidate rather than exceed them (tests generate one at a time, so a bloated plan is slow and low-signal).
 - Ground the plan in the DISCOVERY DIGEST's actual crawled pages. When the digest's crawled pages are signed-in, in-app pages (a dashboard, resource lists, detail/settings pages), the app IS authenticated for this run — plan coverage of that in-app product surface. Never collapse an authenticated run into public login/register pages that the crawl did not even map; the auth pages are the gateway, not the product.
-- Authentication: when an authenticated session is available (see the user message), plan the in-app surface and journeys need NOT script a login (the session is applied automatically) — do not spend items on the login form unless login itself is a listed coverage goal. When no authenticated session is available, plan public-surface coverage only.`;
+- Authentication: when an authenticated session is available (see the user message), plan the in-app surface and journeys need NOT script a login (the session is applied automatically) — do not spend items on the login form unless login itself is a listed coverage goal. When no authenticated session is available, plan public-surface coverage only.
+- Branch changes: when the digest contains a "Changes on branch" section (a PR/branch diff), treat those changes as the highest-risk surface — every user-observable listed change needs a covering item (raise its priority accordingly), and each covering item MUST set "changeRefs" to the exact ref strings it covers, copied verbatim from the digest's [ref: …] tags. Only skip a listed change when it has no user-facing surface (say so in a risk note).`;
 }
 
 export function buildPlannerUserPrompt(opts: {

--- a/src/lib/qa-agent/plan.ts
+++ b/src/lib/qa-agent/plan.ts
@@ -133,7 +133,8 @@ function isJourney(v: unknown): v is QaPlanJourney {
     PRIORITIES.includes(j.priority as QaPriority) &&
     isStringArray(j.steps) &&
     typeof j.businessOutcome === "string" &&
-    typeof j.endStateVerification === "string"
+    typeof j.endStateVerification === "string" &&
+    (j.businessArea === undefined || typeof j.businessArea === "string")
   );
 }
 
@@ -145,7 +146,8 @@ function isPlanItem(v: unknown): v is QaPlanItem {
     !QA_GROUP_IDS.includes(i.group as QaTestGroup) ||
     typeof i.title !== "string" ||
     !PRIORITIES.includes(i.priority as QaPriority) ||
-    typeof i.scenario !== "string"
+    typeof i.scenario !== "string" ||
+    (i.businessArea !== undefined && typeof i.businessArea !== "string")
   ) {
     return false;
   }
@@ -309,8 +311,8 @@ ${BEST_PRACTICES}
 OUTPUT: a single JSON object, no markdown fences, no commentary, matching exactly:
 {
   "appProfile": { "summary": string, "businessDomain": string, "primaryOutcome": string },
-  "journeys": [ { "id": "J1", "title": string, "priority": "P1"|"P2"|"P3", "steps": [string], "businessOutcome": string, "endStateVerification": string } ],
-  "items": [ { "id": "T1", "group": <group>, "title": string, "priority": "P1"|"P2"|"P3", "journeyId": string?, "pagePath": string?, "rationale": string, "scenario": string, "selectorHints": [string]?, "api": { "method": "GET"|"POST"|"PUT"|"PATCH"|"DELETE", "path": string, "expectedStatus": number }? } ],
+  "journeys": [ { "id": "J1", "title": string, "priority": "P1"|"P2"|"P3", "businessArea": string, "steps": [string], "businessOutcome": string, "endStateVerification": string } ],
+  "items": [ { "id": "T1", "group": <group>, "title": string, "priority": "P1"|"P2"|"P3", "journeyId": string?, "businessArea": string, "pagePath": string?, "rationale": string, "scenario": string, "selectorHints": [string]?, "api": { "method": "GET"|"POST"|"PUT"|"PATCH"|"DELETE", "path": string, "expectedStatus": number }? } ],
   "entryCriteria": [string],
   "exitCriteria": [string],
   "risks": [string]
@@ -322,6 +324,7 @@ RULES:
 - Items in group "api" MUST include the "api" object using an endpoint observed in discovery. Do not plan api items for endpoints you did not observe.
 - selectorHints must be copied from the digest's verified selectors / data-testid lists — never invented.
 - pagePath is relative to the target URL (e.g. "/login").
+- "businessArea" is REQUIRED on every item and journey: a short, consistent functional-domain name (e.g. "Authentication", "Accounts", "Checkout", "Marketing"). Use 2-5 distinct areas total and reuse the exact same spelling across items — they become the rows of a coverage matrix.
 - 2-4 items per selected group, 1-3 journeys. Quality over quantity: every item must be executable against the discovered pages.
 - If credentials are provided, journeys may include login; if not, plan public-surface coverage only.`;
 }
@@ -575,6 +578,33 @@ export function computeQaSummary(
       .filter((g) => g.testId && coveringItems.has(g.planItemId))
       .map((g) => g.testId!) as string[];
   }
+
+  // Coverage matrix: business area × test group. Rows come from the plan's
+  // businessArea labels ("General" when the planner omitted one).
+  const ledgerByItem = new Map(generated.map((g) => [g.planItemId, g]));
+  const matrix: NonNullable<QaSummaryData["matrix"]> = {};
+  for (const item of items) {
+    const area = item.businessArea?.trim() || "General";
+    const row = (matrix[area] ??= {});
+    const cell = (row[item.group] ??= {
+      planned: 0,
+      covered: 0,
+      generated: 0,
+      passed: 0,
+    });
+    cell.planned += 1;
+    const entry = ledgerByItem.get(item.id);
+    if (!entry) continue;
+    if (entry.status === "covered") {
+      cell.covered += 1;
+    } else if (entry.status !== "generating" && entry.testId) {
+      cell.generated += 1;
+      if (entry.status === "passed" || entry.status === "healed") {
+        cell.passed += 1;
+      }
+    }
+  }
+
   return {
     planned: items.length,
     generated: generatedCount,
@@ -583,6 +613,7 @@ export function computeQaSummary(
     failed,
     healed,
     byGroup,
+    matrix,
     journeyCoverage,
   };
 }

--- a/src/lib/qa-agent/plan.ts
+++ b/src/lib/qa-agent/plan.ts
@@ -498,6 +498,225 @@ export function buildPlannerUserPrompt(opts: {
 }
 
 // ---------------------------------------------------------------------------
+// Journey refiner — turn a human's plain-language journeys into structured,
+// grounded journeys + covering items and MERGE them into an existing plan.
+// The condensed digest loses domain intent; this lets the human inject the
+// journeys they care about and have the AI make them executable, without
+// re-planning (existing items and the reviewer's enable/disable choices stay).
+// ---------------------------------------------------------------------------
+
+/** The AI journey refiner returns only NEW additions to merge into the plan. */
+export interface RefinedJourneys {
+  journeys: QaPlanJourney[];
+  items: QaPlanItem[];
+}
+
+/** Hard cap on how many items ONE refine call can add, on top of the plan's
+ *  existing items. Bounds sequential browser-generation time. */
+export const MAX_REFINED_NEW_ITEMS = MAX_PLAN_ITEMS;
+
+export function isRefinedJourneys(v: unknown): v is RefinedJourneys {
+  if (!v || typeof v !== "object") return false;
+  const r = v as Record<string, unknown>;
+  if (!Array.isArray(r.journeys) || !r.journeys.every(isJourney)) return false;
+  if (!Array.isArray(r.items) || !r.items.every(isPlanItem)) return false;
+  return r.journeys.length > 0 || r.items.length > 0;
+}
+
+/** First concrete reason a value fails isRefinedJourneys, for retry prompts. */
+export function explainInvalidRefinedJourneys(v: unknown): string | null {
+  if (!v || typeof v !== "object")
+    return "top-level value is not a JSON object";
+  const r = v as Record<string, unknown>;
+  if (!Array.isArray(r.journeys)) return '"journeys" must be an array';
+  const badJourney = r.journeys.findIndex((j) => !isJourney(j));
+  if (badJourney !== -1) {
+    return `journeys[${badJourney}] is malformed — each journey needs id, title, priority (P1|P2|P3), steps[], businessOutcome, endStateVerification`;
+  }
+  if (!Array.isArray(r.items)) return '"items" must be an array';
+  const badItem = r.items.findIndex((i) => !isPlanItem(i));
+  if (badItem !== -1) {
+    return `items[${badItem}] is malformed — each item needs id, group or groups[], title, priority (P1|P2|P3), scenario`;
+  }
+  if (r.journeys.length === 0 && r.items.length === 0) {
+    return "produced no journeys and no items — refine the user's journeys into at least one journey and one covering item";
+  }
+  return null;
+}
+
+export function buildJourneyRefinerSystemPrompt(): string {
+  return `You are a principal QA architect. A QA engineer has written one or more user journeys in plain language that they want ADDED to an existing, already-approved test plan for a web application. Refine each into a rigorous, executable journey plus the covering test items that prove it, grounded in the real discovery data (rendered-DOM page maps, verified selectors, observed API endpoints).
+
+${BEST_PRACTICES}
+
+OUTPUT: a single JSON object, no markdown fences, no commentary, matching exactly:
+{
+  "journeys": [ { "id": "U1", "title": string, "priority": "P1"|"P2"|"P3", "businessArea": string, "steps": [string], "businessOutcome": string, "endStateVerification": string } ],
+  "items": [ { "id": "UT1", "groups": [<group>, ...], "title": string, "priority": "P1"|"P2"|"P3", "journeyId": string, "businessArea": string, "pagePath": string?, "rationale": string, "scenario": string, "selectorHints": [string]?, "api": { "method": ..., "path": string, "expectedStatus": number }? } ]
+}
+
+RULES:
+- Output ONLY the NEW journeys the user asked for and the items that cover them — do NOT restate the existing plan (it is shown for context so you avoid duplicating it).
+- Refine, don't merely echo: turn each plain-language journey into concrete numbered steps, a real business outcome, and an end-state verification that proves the outcome beyond a toast.
+- Ground every step, selector, and path in the DISCOVERY DIGEST. If the user's journey references a page or action not present in the digest, plan the closest real flow the digest supports and note the assumption in "rationale" — never invent selectors or routes.
+- Each journey needs at least one covering item with "journey" in its groups and journeyId set to that journey's id.
+- Respect the selected coverage groups only. Consolidate: one item may carry several compatible groups (see CONSOLIDATION).
+- Keep it tight: at most one or two items per journey unless the user's journey is genuinely multi-page. Every item must be executable against the discovered pages.`;
+}
+
+export function buildJourneyRefinerUserPrompt(opts: {
+  digest: string;
+  groups: QaTestGroup[];
+  userJourneys: string[];
+  /** Titles of the plan's current journeys + items, so the refiner does not
+   *  duplicate coverage that already exists. */
+  existingPlanDigest: string;
+  authenticated: boolean;
+}): string {
+  const groupList = opts.groups
+    .map((g) => {
+      const meta = QA_GROUPS.find((m) => m.id === g);
+      return `- ${g}: ${meta?.description ?? ""}`;
+    })
+    .join("\n");
+  const journeyList = opts.userJourneys
+    .map((j, i) => `${i + 1}. ${j}`)
+    .join("\n");
+  return [
+    `Refine the user-supplied journeys below into structured journeys + covering test items, grounded in the discovery digest.`,
+    `Selected coverage groups:\n${groupList}`,
+    opts.authenticated
+      ? "Authenticated session available: YES — the discovery digest is the signed-in, in-app surface and generated tests run authenticated. Plan the journeys against that in-app surface."
+      : "Authenticated session available: NO — public surface only.",
+    `--- USER-SUPPLIED JOURNEYS (refine these) ---\n${journeyList}`,
+    `--- EXISTING PLAN (context only — DO NOT duplicate) ---\n${opts.existingPlanDigest}`,
+    `--- DISCOVERY DIGEST ---\n${opts.digest}`,
+  ].join("\n\n");
+}
+
+/** Compact digest of a plan's current journeys + item titles for the refiner. */
+export function buildExistingPlanDigest(plan: QaTestPlan): string {
+  const journeys = plan.journeys.length
+    ? plan.journeys.map((j) => `- journey: "${j.title}"`).join("\n")
+    : "(none)";
+  const items = plan.items.length
+    ? plan.items.map((i) => `- test: "${i.title}"`).join("\n")
+    : "(none)";
+  return `Journeys:\n${journeys}\n\nTests:\n${items}`;
+}
+
+const PRIORITY_RANK: Record<QaPriority, number> = { P1: 0, P2: 1, P3: 2 };
+
+/**
+ * Merge AI-refined journeys/items into an existing plan WITHOUT disturbing the
+ * existing items or the reviewer's enable/disable choices. Deduplicates against
+ * existing titles, strips groups the user didn't select, remaps AI ids to fresh
+ * collision-free ids (preserving journey→item links), guarantees journey-linked
+ * items carry the "journey" group, and bounds how many new items are added so
+ * sequential browser generation stays tractable. Returns the merged plan plus a
+ * count of items that were dropped by the budget.
+ */
+export function mergeRefinedJourneys(
+  plan: QaTestPlan,
+  refined: RefinedJourneys,
+  groups: QaTestGroup[],
+): {
+  plan: QaTestPlan;
+  addedJourneys: number;
+  addedItems: number;
+  trimmed: number;
+} {
+  const allowed = new Set(groups);
+  const existingItemTitles = new Set(
+    plan.items.map((i) => normalizeTitle(i.title)),
+  );
+  const existingJourneyByTitle = new Map(
+    plan.journeys.map((j) => [normalizeTitle(j.title), j.id]),
+  );
+
+  // Journeys: dedup by title (map dup ids onto the existing journey), remap the
+  // rest to fresh U-prefixed ids. Journeys are cheap metadata — allow up to
+  // MAX_PLAN_JOURNEYS new ones on top of the existing set.
+  const idMap = new Map<string, string>();
+  const newJourneys: QaPlanJourney[] = [];
+  let jn = plan.journeys.length;
+  for (const rj of refined.journeys) {
+    const dupId = existingJourneyByTitle.get(normalizeTitle(rj.title));
+    if (dupId) {
+      idMap.set(rj.id, dupId);
+      continue;
+    }
+    if (newJourneys.length >= MAX_PLAN_JOURNEYS) continue;
+    const newId = `U${++jn}`;
+    idMap.set(rj.id, newId);
+    newJourneys.push({ ...rj, id: newId });
+  }
+  const journeyIds = new Set([
+    ...plan.journeys.map((j) => j.id),
+    ...newJourneys.map((j) => j.id),
+  ]);
+
+  // Items: strip disallowed groups, dedup by title, remap ids + journeyId,
+  // ensure journey-linked items carry the "journey" group.
+  const candidates: QaPlanItem[] = [];
+  let tn = plan.items.length;
+  for (const ri of refined.items) {
+    let kept = itemGroups(ri).filter((g) => allowed.has(g));
+    if (kept.length === 0) continue;
+    if (existingItemTitles.has(normalizeTitle(ri.title))) continue;
+    const mappedJourneyId = ri.journeyId ? idMap.get(ri.journeyId) : undefined;
+    const journeyId =
+      mappedJourneyId && journeyIds.has(mappedJourneyId)
+        ? mappedJourneyId
+        : undefined;
+    if (journeyId && allowed.has("journey") && !kept.includes("journey")) {
+      kept = ["journey", ...kept];
+    }
+    candidates.push({
+      ...ri,
+      id: `U${++tn}`,
+      group: kept[0],
+      groups: kept,
+      journeyId,
+    });
+  }
+
+  // Bound new items so combined stays near MAX_PLAN_ITEMS, but always admit a
+  // few of the user's items even when the plan is already full (explicit ask).
+  const budget = Math.max(4, MAX_PLAN_ITEMS - plan.items.length);
+  const ranked = candidates
+    .map((it, idx) => ({ it, idx }))
+    .sort(
+      (a, b) =>
+        PRIORITY_RANK[a.it.priority] - PRIORITY_RANK[b.it.priority] ||
+        a.idx - b.idx,
+    );
+  const keptItems = ranked.slice(0, budget).map((x) => x.it);
+  // Restore original refiner order for the kept subset (stable, readable plan).
+  const keptIds = new Set(keptItems.map((i) => i.id));
+  const newItems = candidates.filter((i) => keptIds.has(i.id));
+  // Drop journeys that ended up with no covering item (deduped or trimmed away)
+  // — an orphan journey would show as an empty matrix row with nothing to run.
+  const linkedJourneyIds = new Set(
+    newItems.map((i) => i.journeyId).filter(Boolean) as string[],
+  );
+  const admittedJourneys = newJourneys.filter((j) =>
+    linkedJourneyIds.has(j.id),
+  );
+
+  return {
+    plan: {
+      ...plan,
+      journeys: [...plan.journeys, ...admittedJourneys],
+      items: [...plan.items, ...newItems],
+    },
+    addedJourneys: admittedJourneys.length,
+    addedItems: newItems.length,
+    trimmed: candidates.length - newItems.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Existing-coverage matching (segmented re-runs)
 // ---------------------------------------------------------------------------
 
@@ -597,6 +816,11 @@ export function buildGeneratorPrompt(opts: {
    *  steps — the generator must not script a login (and gets no plaintext
    *  credentials). */
   auth?: { preAuthenticated: boolean };
+  /** How the app authenticates, resolved by qa_login. Passed so the generator
+   *  always knows the auth story of the page it's exploring — the login page it
+   *  will be redirected to if the session lapses, and the sign-up page for
+   *  register/onboarding scenarios. Never URL-guessed (DOM-observed). */
+  loginContext?: { loginUrl?: string; signupUrl?: string };
 }): string {
   const { item, plan } = opts;
   const groups = itemGroups(item);
@@ -628,13 +852,23 @@ export function buildGeneratorPrompt(opts: {
         .join("\n")}`,
     );
   }
+  const login = opts.loginContext;
+  const loginRef = login?.loginUrl
+    ? ` The app's login page is ${login.loginUrl}${login.signupUrl ? ` and its sign-up page is ${login.signupUrl}` : ""} (DOM-observed).`
+    : "";
   if (opts.auth?.preAuthenticated) {
     parts.push(
-      "The browser session starts already authenticated — a stored login session is applied as a setup step before the test runs. Do NOT write login steps; navigate straight to the page under test.",
+      `The browser session starts already authenticated — a stored login session is applied as a setup step before the test runs. Do NOT write login steps; navigate straight to the page under test. If you are unexpectedly redirected to a login page during exploration the injected session lapsed — do not script a manual login to work around it; report it.${loginRef}`,
     );
   } else if (opts.credentials) {
     parts.push(
-      `If the scenario requires authentication, log in first with email "${opts.credentials.email}" and password "${opts.credentials.password}".`,
+      `If the scenario requires authentication, log in first${login?.loginUrl ? ` at ${login.loginUrl}` : ""} with email "${opts.credentials.email}" and password "${opts.credentials.password}".${login?.signupUrl ? ` The sign-up page is ${login.signupUrl}.` : ""}`,
+    );
+  } else if (loginRef) {
+    // Public-surface run: no session, no creds — still tell the generator where
+    // auth lives so login/register/forgot-password scenarios ground correctly.
+    parts.push(
+      `No authenticated session is available for this run.${loginRef}`,
     );
   }
   return parts.join("\n\n");

--- a/src/lib/qa-agent/plan.ts
+++ b/src/lib/qa-agent/plan.ts
@@ -92,6 +92,14 @@ export const QA_GROUPS: Array<{
 
 export const QA_GROUP_IDS = QA_GROUPS.map((g) => g.id);
 
+/** Defensive backstop on plan size. Browser tests generate SEQUENTIALLY on a
+ *  single Embedded Browser (each with a multi-minute timeout), so an unbounded
+ *  plan can run for hours. The planner prompt asks for a small set; these caps
+ *  keep a runaway plan bounded even if it ignores that. Overflow trims lowest
+ *  priority first (see sanitizeQaPlan). */
+export const MAX_PLAN_ITEMS = 20;
+export const MAX_PLAN_JOURNEYS = 5;
+
 export function normalizeQaGroups(groups: QaTestGroup[]): QaTestGroup[] {
   const valid = groups.filter((g): g is QaTestGroup =>
     QA_GROUP_IDS.includes(g),
@@ -216,6 +224,31 @@ export function isQaTestPlan(v: unknown): v is QaTestPlan {
   return p.items.length > 0;
 }
 
+/** First concrete reason a value fails isQaTestPlan, or null when it passes.
+ *  Fed into the planner-retry prompt so the model gets a specific correction
+ *  instead of a blind "that wasn't valid JSON". */
+export function explainInvalidQaPlan(v: unknown): string | null {
+  if (!v || typeof v !== "object")
+    return "top-level value is not a JSON object";
+  const p = v as Record<string, unknown>;
+  const profile = p.appProfile as Record<string, unknown> | undefined;
+  if (!profile || typeof profile.summary !== "string") {
+    return 'missing "appProfile.summary" (a string)';
+  }
+  if (!Array.isArray(p.journeys)) return '"journeys" must be an array';
+  const badJourney = p.journeys.findIndex((j) => !isJourney(j));
+  if (badJourney !== -1) {
+    return `journeys[${badJourney}] is malformed — each journey needs id, title, priority (P1|P2|P3), steps[], businessOutcome, endStateVerification`;
+  }
+  if (!Array.isArray(p.items)) return '"items" must be an array';
+  if (p.items.length === 0) return '"items" is empty — plan at least one test';
+  const badItem = p.items.findIndex((i) => !isPlanItem(i));
+  if (badItem !== -1) {
+    return `items[${badItem}] is malformed — each item needs id, group or groups[], title, priority (P1|P2|P3), scenario; api items need api.path and a valid api.method`;
+  }
+  return null;
+}
+
 /** Drop plan items whose groups the user did not select (multi-group items
  *  survive with disallowed groups stripped), backfill the primary `group`
  *  when the AI only emitted `groups`, and clear orphaned journey references.
@@ -225,8 +258,10 @@ export function sanitizeQaPlan(
   groups: QaTestGroup[],
 ): QaTestPlan {
   const allowed = new Set(groups);
-  const journeyIds = new Set(plan.journeys.map((j) => j.id));
-  const items: QaPlanItem[] = [];
+  // Cap journeys first so item journey-refs resolve against the kept set.
+  const journeys = plan.journeys.slice(0, MAX_PLAN_JOURNEYS);
+  const journeyIds = new Set(journeys.map((j) => j.id));
+  let items: QaPlanItem[] = [];
   for (const raw of plan.items) {
     const kept = itemGroups(raw).filter((g) => allowed.has(g));
     if (kept.length === 0) continue;
@@ -236,7 +271,20 @@ export function sanitizeQaPlan(
     }
     items.push(item);
   }
-  return { ...plan, items };
+  // Backstop overflow: keep original order under the cap; when over it, trim
+  // lowest-priority first (stable within a priority) so P1 coverage survives.
+  if (items.length > MAX_PLAN_ITEMS) {
+    const rank: Record<QaPriority, number> = { P1: 0, P2: 1, P3: 2 };
+    items = items
+      .map((it, idx) => ({ it, idx }))
+      .sort(
+        (a, b) => rank[a.it.priority] - rank[b.it.priority] || a.idx - b.idx,
+      )
+      .slice(0, MAX_PLAN_ITEMS)
+      .sort((a, b) => a.idx - b.idx)
+      .map((x) => x.it);
+  }
+  return { ...plan, journeys, items };
 }
 
 export function enabledPlanItems(plan: QaTestPlan): QaPlanItem[] {
@@ -299,6 +347,14 @@ function pageDigest(p: QaPageSnapshot): string {
         .join("; ")}`,
     );
   }
+  if (p.consoleErrors?.length) {
+    lines.push(
+      `Console errors on load (pre-existing noise — NOT caused by tests): ${p.consoleErrors
+        .slice(0, 8)
+        .map((e) => `"${e}"`)
+        .join("; ")}`,
+    );
+  }
   return lines.join("\n");
 }
 
@@ -317,13 +373,29 @@ export function buildDiscoveryDigest(discovery: QaDiscovery): string {
     sections.push("## Routes from source code\n(none found by static scan)");
   }
   sections.push("## Live crawl (rendered DOM — authoritative for selectors)");
-  for (const page of discovery.crawledPages) {
-    sections.push(pageDigest(page));
+
+  // Add whole page digests until the budget is spent, then stop at the page
+  // boundary and say how many were dropped — never slice mid-page, which would
+  // hand the planner a half-described page it can't ground selectors in.
+  const header = sections.join("\n\n");
+  const pages = discovery.crawledPages;
+  let budget = MAX_DIGEST_CHARS - header.length;
+  const pageSections: string[] = [];
+  let included = 0;
+  for (const page of pages) {
+    const section = pageDigest(page);
+    if (included > 0 && section.length + 2 > budget) break;
+    pageSections.push(section);
+    budget -= section.length + 2;
+    included += 1;
   }
-  const digest = sections.join("\n\n");
-  return digest.length > MAX_DIGEST_CHARS
-    ? digest.slice(0, MAX_DIGEST_CHARS) + "\n…(truncated)"
-    : digest;
+  const omitted = pages.length - included;
+  const body = pageSections.join("\n\n");
+  const suffix =
+    omitted > 0
+      ? `\n\n…(${omitted} more crawled page${omitted > 1 ? "s" : ""} omitted to fit the context budget)`
+      : "";
+  return `${header}\n\n${body}${suffix}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -345,7 +417,9 @@ const BEST_PRACTICES = `TEST DESIGN PRINCIPLES (follow strictly):
 - Resilience: abort/fail API calls, offline mode, 500/429 responses — assert graceful error UI, no blank screens, no data loss.
 - Negative: per-form input matrices — empty, whitespace, boundary lengths (min−1/min/max/max+1), wrong type, unicode/emoji, inert XSS payload strings, oversized input, double-submit.
 - Selector strategy for scenarios: reference elements by role+name or data-testid exactly as they appear in the discovery digest. NEVER invent selectors.
+- Console noise: the executor fails a test on ANY console error. When the digest reports pre-existing console errors for a page (third-party/analytics noise present before any test runs), the scenario for a non-resilience test on that page MUST instruct blocking those third-party requests (page.route the offending host to abort/fulfill) so the test only fails on errors it actually caused.
 - Every test must be independent and idempotent where possible.
+- Idempotent test data: any scenario that CREATES a record (signup, new order, new item, invited user) must use a per-run unique value for the uniqueness-constrained field (email, name, slug, title). Instruct the generator to stamp it at runtime (e.g. \`user-\${Date.now().toString(36)}@example.com\`) — a hardcoded value passes once, then fails every re-run on "already exists". Note this in the scenario for create flows.
 
 CONSOLIDATION (minimize test count): the platform runs EVERY check layer (visual, a11y/axe, performance/CWV, console, network, text, DOM) on each test execution automatically. When multiple coverage angles exercise the same page or flow, plan ONE test tagged with all applicable groups instead of separate tests — never plan a standalone a11y or perf test for a page another planned test already visits; tag that test instead. Compatibility rules:
 - smoke, ui, hybrid, journey, a11y, perf combine freely in one test.
@@ -375,7 +449,7 @@ RULES:
 - selectorHints must be copied from the digest's verified selectors / data-testid lists — never invented.
 - pagePath is relative to the target URL (e.g. "/login").
 - "businessArea" is REQUIRED on every item and journey: a short, consistent functional-domain name (e.g. "Authentication", "Accounts", "Checkout", "Marketing"). Use 2-5 distinct areas total and reuse the exact same spelling across items — they become the rows of a coverage matrix.
-- Every selected group must appear in at least one item's "groups". Plan the SMALLEST test set that achieves this — typically 1-2 items per page/flow — and 1-3 journeys. Quality over quantity: every item must be executable against the discovered pages.
+- Every selected group must appear in at least one item's "groups". Plan the SMALLEST test set that achieves this — typically 1-2 items per page/flow — and 1-3 journeys. Quality over quantity: every item must be executable against the discovered pages. HARD LIMITS: at most ${MAX_PLAN_ITEMS} items and ${MAX_PLAN_JOURNEYS} journeys — consolidate rather than exceed them (tests generate one at a time, so a bloated plan is slow and low-signal).
 - If credentials are provided, journeys may include login; if not, plan public-surface coverage only.`;
 }
 
@@ -498,11 +572,11 @@ const GROUP_GENERATION_GUIDANCE: Partial<Record<QaTestGroup, string>> = {
   resilience:
     "This is a RESILIENCE test. Use page.route() to inject failures BEFORE the interaction (e.g. await page.route('**/api/**', route => route.abort('failed')) or route.fulfill({ status: 500, body: '{}' })). Then perform the interaction and assert graceful error UI: an error message is visible, the page did not blank, and data was not silently lost. Unroute afterwards if the scenario continues.",
   negative:
-    "This is a NEGATIVE test. Drive the form(s) through the invalid-input matrix in the scenario (empty, boundary, wrong type, XSS-payload-as-inert-text). Assert validation feedback appears and no invalid submission succeeds.",
+    "This is a NEGATIVE test. Drive the form(s) through the invalid-input matrix in the scenario (empty, boundary, wrong type, XSS-payload-as-inert-text). Assert validation feedback appears and no invalid submission succeeds. When a valid control case creates a record, make its unique field per-run unique (see below).",
   hybrid:
     "This is a HYBRID test. Where the scenario says to verify via API, use the page's fetch from the browser context (const res = await page.evaluate(...fetch...)) against the same origin and assert on the JSON, in addition to UI assertions.",
   journey:
-    "This is a BUSINESS-OUTCOME JOURNEY. Complete the full flow and then PROVE the outcome per the end-state verification (assert the persisted result is visible: updated balance, created record in a list, confirmation with a real identifier). A success toast alone is insufficient.",
+    "This is a BUSINESS-OUTCOME JOURNEY. Complete the full flow and then PROVE the outcome per the end-state verification (assert the persisted result is visible: updated balance, created record in a list, confirmation with a real identifier). A success toast alone is insufficient. If the flow creates a record with a uniqueness-constrained field (email/name/slug), generate that value at runtime with a unique suffix (e.g. `item-` + Date.now().toString(36)) so the journey stays green on every re-run instead of failing on 'already exists'.",
 };
 
 export function buildGeneratorPrompt(opts: {

--- a/src/lib/qa-agent/pr-check.test.ts
+++ b/src/lib/qa-agent/pr-check.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildPrChangesDigest,
+  computePrChanges,
+  computePrCoverage,
+  parsePatchSymbols,
+} from "./pr-check";
+import type { QaGeneratedTest, QaPrChanges, QaTestPlan } from "@/lib/db/schema";
+
+const compareFile = (
+  filename: string,
+  patch: string | undefined,
+  status: "added" | "modified" | "removed" | "renamed" | "changed" = "modified",
+  previousFilename?: string,
+) => ({
+  filename,
+  status,
+  additions: 1,
+  deletions: 0,
+  changes: 1,
+  patch,
+  previousFilename,
+});
+
+describe("parsePatchSymbols", () => {
+  it("extracts added top-level declarations from + lines", () => {
+    const patch = [
+      "@@ -1,3 +1,9 @@",
+      "+export async function createInvoice(input: Input) {",
+      "+export const InvoiceRow = ({ id }: Props) => {",
+      "+export class InvoiceStore {",
+      "+function helperAtTopLevel() {",
+      "+  function nestedIgnored() {",
+      "+const notAFunction = 3;",
+    ].join("\n");
+    const { added } = parsePatchSymbols(patch);
+    expect([...added.keys()].sort()).toEqual([
+      "InvoiceRow",
+      "InvoiceStore",
+      "createInvoice",
+      "helperAtTopLevel",
+    ]);
+    expect(added.get("InvoiceStore")).toBe(true); // class flag
+  });
+
+  it("marks hunk-context declarations as modified, added wins", () => {
+    const patch = [
+      "@@ -10,6 +10,8 @@ export function applyDiscount(order: Order) {",
+      "+  const rate = 0.2;",
+      "@@ -40,2 +42,6 @@ export function applyDiscount(order: Order) {",
+      "+export function applyCoupon(order: Order) {",
+    ].join("\n");
+    const { added, modified } = parsePatchSymbols(patch);
+    expect([...modified.keys()]).toEqual(["applyDiscount"]);
+    expect([...added.keys()]).toEqual(["applyCoupon"]);
+  });
+
+  it("collects HTTP-method handlers separately", () => {
+    const patch = [
+      "@@ -1,1 +1,5 @@ export async function GET(req: Request) {",
+      "+export async function POST(req: Request) {",
+    ].join("\n");
+    const { methods } = parsePatchSymbols(patch);
+    expect(methods.get("POST")).toBe("added");
+    expect(methods.get("GET")).toBe("modified");
+  });
+});
+
+describe("computePrChanges", () => {
+  it("splits route files into endpoints and source files into symbols", () => {
+    const changes = computePrChanges(
+      {
+        baseBranch: "main",
+        headBranch: "feat-invoices",
+        files: [
+          compareFile(
+            "src/app/api/invoices/route.ts",
+            "@@ -0,0 +1,9 @@\n+export async function POST(req: Request) {",
+            "added",
+          ),
+          compareFile(
+            "src/lib/billing/invoice.ts",
+            "@@ -0,0 +1,4 @@\n+export function totalWithTax(cents: number) {",
+            "added",
+          ),
+          compareFile("README.md", "+# docs", "modified"),
+        ],
+      },
+      [],
+    );
+    expect(changes.endpoints).toEqual([
+      {
+        method: "POST",
+        path: "/api/invoices",
+        file: "src/app/api/invoices/route.ts",
+        change: "added",
+      },
+    ]);
+    expect(changes.symbols).toEqual([
+      {
+        name: "totalWithTax",
+        kind: "function",
+        file: "src/lib/billing/invoice.ts",
+        change: "added",
+      },
+    ]);
+    expect(changes.files).toHaveLength(3);
+  });
+
+  it("falls back to declared endpoints when the patch has no handler decl", () => {
+    const changes = computePrChanges(
+      {
+        baseBranch: "main",
+        headBranch: "fix",
+        files: [
+          compareFile(
+            "src/app/api/users/[id]/route.ts",
+            "@@ -12,3 +12,4 @@\n+  const user = await load(id);",
+          ),
+        ],
+      },
+      [
+        {
+          method: "DELETE",
+          path: "/api/users/:id",
+          file: "src/app/api/users/[id]/route.ts",
+        },
+      ],
+    );
+    expect(changes.endpoints).toEqual([
+      {
+        method: "DELETE",
+        path: "/api/users/:id",
+        file: "src/app/api/users/[id]/route.ts",
+        change: "modified",
+      },
+    ]);
+  });
+});
+
+describe("buildPrChangesDigest", () => {
+  it("emits verbatim ref tags and the coverage requirement", () => {
+    const pr: QaPrChanges = {
+      baseBranch: "main",
+      headBranch: "feat",
+      files: [
+        {
+          path: "src/lib/a.ts",
+          status: "modified",
+          additions: 4,
+          deletions: 1,
+        },
+      ],
+      symbols: [
+        {
+          name: "totalWithTax",
+          kind: "function",
+          file: "src/lib/a.ts",
+          change: "added",
+        },
+      ],
+      endpoints: [
+        {
+          method: "POST",
+          path: "/api/invoices",
+          file: "src/app/api/invoices/route.ts",
+          change: "added",
+        },
+      ],
+    };
+    const digest = buildPrChangesDigest(pr);
+    expect(digest).toContain("vs `main`");
+    expect(digest).toContain("[ref: totalWithTax]");
+    expect(digest).toContain("[ref: POST /api/invoices]");
+    expect(digest).toContain('"changeRefs"');
+  });
+});
+
+describe("computePrCoverage", () => {
+  const pr: QaPrChanges = {
+    baseBranch: "main",
+    headBranch: "feat",
+    files: [],
+    symbols: [
+      {
+        name: "totalWithTax",
+        kind: "function",
+        file: "src/lib/a.ts",
+        change: "added",
+      },
+      {
+        name: "unusedHelper",
+        kind: "function",
+        file: "src/lib/b.ts",
+        change: "added",
+      },
+    ],
+    endpoints: [
+      {
+        method: "POST",
+        path: "/api/invoices",
+        file: "src/app/api/invoices/route.ts",
+        change: "added",
+      },
+    ],
+  };
+  const plan = {
+    appProfile: { summary: "" },
+    journeys: [],
+    items: [
+      {
+        id: "T1",
+        group: "ui",
+        title: "Invoice totals show tax",
+        priority: "P1",
+        scenario: "…",
+        changeRefs: ["totalWithTax"],
+      },
+      {
+        id: "T2",
+        group: "api",
+        title: "Create invoice API",
+        priority: "P1",
+        scenario: "…",
+        api: { method: "POST", path: "/api/invoices", expectedStatus: 201 },
+      },
+      {
+        id: "T3",
+        group: "ui",
+        title: "Disabled item",
+        priority: "P3",
+        scenario: "…",
+        changeRefs: ["unusedHelper"],
+        enabled: false,
+      },
+    ],
+  } as unknown as QaTestPlan;
+  const ledger: QaGeneratedTest[] = [
+    {
+      planItemId: "T1",
+      group: "ui",
+      testId: "test-1",
+      name: "Invoice totals show tax",
+      status: "passed",
+    },
+    {
+      planItemId: "T2",
+      group: "api",
+      testId: "test-2",
+      name: "Create invoice API",
+      status: "generated",
+    },
+  ];
+
+  it("joins changeRefs and api-path fallbacks to a per-change verdict", () => {
+    const coverage = computePrCoverage(pr, plan, ledger);
+    const byRef = new Map(coverage.entries.map((e) => [e.ref, e]));
+    expect(byRef.get("totalWithTax")?.status).toBe("passed");
+    expect(byRef.get("totalWithTax")?.testIds).toEqual(["test-1"]);
+    // No changeRefs on T2 — matched through api.method+path.
+    expect(byRef.get("POST /api/invoices")?.status).toBe("generated");
+    // Disabled items don't count.
+    expect(byRef.get("unusedHelper")?.status).toBe("uncovered");
+    expect(coverage.coveredCount).toBe(2);
+  });
+
+  it("reports planned when an item matches but has no test yet", () => {
+    const coverage = computePrCoverage(pr, plan, []);
+    const byRef = new Map(coverage.entries.map((e) => [e.ref, e]));
+    expect(byRef.get("totalWithTax")?.status).toBe("planned");
+  });
+});

--- a/src/lib/qa-agent/pr-check.ts
+++ b/src/lib/qa-agent/pr-check.ts
@@ -1,0 +1,383 @@
+import type {
+  QaGeneratedTest,
+  QaPrChangedFile,
+  QaPrChanges,
+  QaPrCoverage,
+  QaPrCoverageEntry,
+  QaPrEndpoint,
+  QaPrSymbol,
+  QaTestPlan,
+} from "@/lib/db/schema";
+import type { CompareResult } from "@/lib/github/content";
+import { apiRouteUrlPath, type QaDeclaredEndpoint } from "./code-check";
+
+/**
+ * QA Agent PR check — branch-aware static analysis. Diffs the working branch
+ * against the base branch and extracts the specific functions, components,
+ * and API endpoints the branch adds or modifies, so the planner can target
+ * them and the summary can report whether each one ended up covered by a
+ * test. Extraction is deterministic (regex over unified-diff hunks), matching
+ * the code-check module's style — no AST, no AI.
+ */
+
+const MAX_FILES = 60;
+const MAX_SYMBOLS = 60;
+const MAX_ENDPOINTS = 40;
+
+const HTTP_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE"]);
+
+/** Declaration patterns matched at column 0 of an added diff line. Nested
+ *  helpers are indented in real code, so anchoring to column 0 keeps the
+ *  extraction to top-level (usually exported) declarations. */
+const DECLARATION_PATTERNS: RegExp[] = [
+  /^export\s+(?:default\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)/,
+  /^export\s+(?:default\s+)?(?:abstract\s+)?class\s+([A-Za-z_$][\w$]*)/,
+  /^export\s+const\s+([A-Za-z_$][\w$]*)\s*(?::[^=]+)?=/,
+  /^(?:async\s+)?function\s+([A-Za-z_$][\w$]*)/,
+  /^class\s+([A-Za-z_$][\w$]*)/,
+];
+
+/** GitHub/git hunk headers carry the enclosing declaration as context:
+ *  `@@ -10,6 +10,8 @@ export async function createInvoice(...)`. */
+const HUNK_CONTEXT = /^@@ [^@]+@@ (.+)$/;
+
+const SOURCE_FILE = /\.(ts|tsx|js|jsx|mjs|cjs)$/;
+
+function symbolKind(
+  name: string,
+  file: string,
+): QaPrSymbol["kind"] | "endpoint-method" {
+  if (HTTP_METHODS.has(name)) return "endpoint-method";
+  if (/^[A-Z]/.test(name) && /\.(tsx|jsx)$/.test(file)) return "component";
+  return "function";
+}
+
+function matchDeclaration(
+  line: string,
+): { name: string; isClass: boolean } | null {
+  for (const pattern of DECLARATION_PATTERNS) {
+    const m = line.match(pattern);
+    if (m) return { name: m[1], isClass: /\bclass\s/.test(line) };
+  }
+  return null;
+}
+
+interface PatchSymbols {
+  added: Map<string, boolean>; // name → isClass
+  modified: Map<string, boolean>;
+  /** HTTP-method handlers touched (route files): method → added|modified. */
+  methods: Map<string, "added" | "modified">;
+}
+
+/** Extract top-level declarations a unified-diff patch adds (`+` lines) or
+ *  modifies (hunk-header context lines). */
+export function parsePatchSymbols(patch: string): PatchSymbols {
+  const added = new Map<string, boolean>();
+  const modified = new Map<string, boolean>();
+  const methods = new Map<string, "added" | "modified">();
+  for (const raw of patch.split("\n")) {
+    let decl: { name: string; isClass: boolean } | null = null;
+    let change: "added" | "modified" | null = null;
+    if (raw.startsWith("+") && !raw.startsWith("+++")) {
+      decl = matchDeclaration(raw.slice(1));
+      change = "added";
+    } else {
+      const ctx = raw.match(HUNK_CONTEXT);
+      if (ctx) {
+        decl = matchDeclaration(ctx[1]);
+        change = "modified";
+      }
+    }
+    if (!decl || !change) continue;
+    if (HTTP_METHODS.has(decl.name)) {
+      // Added wins over modified when a handler shows up both ways.
+      if (change === "added" || !methods.has(decl.name)) {
+        methods.set(decl.name, change);
+      }
+      continue;
+    }
+    if (change === "added") {
+      added.set(decl.name, decl.isClass);
+      modified.delete(decl.name);
+    } else if (!added.has(decl.name)) {
+      modified.set(decl.name, decl.isClass);
+    }
+  }
+  return { added, modified, methods };
+}
+
+/** Canonical ref string for a symbol/endpoint — the join key between the
+ *  planner digest, plan-item changeRefs, and the coverage report. */
+export function symbolRef(s: QaPrSymbol): string {
+  return s.name;
+}
+
+export function endpointRef(e: Pick<QaPrEndpoint, "method" | "path">): string {
+  return `${e.method} ${e.path}`;
+}
+
+/**
+ * Turn a branch comparison into the structured change set. `declaredEndpoints`
+ * (from the code check, head-branch tree) refines endpoint methods for
+ * changed route files whose patch didn't show the handler declaration.
+ */
+export function computePrChanges(
+  compare: Pick<CompareResult, "files" | "baseBranch" | "headBranch">,
+  declaredEndpoints: QaDeclaredEndpoint[] = [],
+): QaPrChanges {
+  const relevant = compare.files.filter((f) =>
+    ["added", "modified", "removed", "renamed", "changed"].includes(f.status),
+  );
+  const files: QaPrChangedFile[] = relevant.slice(0, MAX_FILES).map((f) => ({
+    path: f.filename,
+    status:
+      f.status === "added"
+        ? "added"
+        : f.status === "removed"
+          ? "removed"
+          : f.status === "renamed"
+            ? "renamed"
+            : "modified",
+    additions: f.additions,
+    deletions: f.deletions,
+    ...(f.previousFilename ? { previousPath: f.previousFilename } : {}),
+  }));
+
+  const declaredByFile = new Map<string, QaDeclaredEndpoint[]>();
+  for (const e of declaredEndpoints) {
+    const list = declaredByFile.get(e.file) ?? [];
+    list.push(e);
+    declaredByFile.set(e.file, list);
+  }
+
+  const symbols: QaPrSymbol[] = [];
+  const endpoints: QaPrEndpoint[] = [];
+  const seenEndpoints = new Set<string>();
+  const pushEndpoint = (e: QaPrEndpoint) => {
+    const key = endpointRef(e);
+    if (seenEndpoints.has(key) || endpoints.length >= MAX_ENDPOINTS) return;
+    seenEndpoints.add(key);
+    endpoints.push(e);
+  };
+
+  for (const f of relevant.slice(0, MAX_FILES)) {
+    if (!SOURCE_FILE.test(f.filename)) continue;
+    const routePath = apiRouteUrlPath(f.filename);
+    const fileChange: QaPrEndpoint["change"] =
+      f.status === "added"
+        ? "added"
+        : f.status === "removed"
+          ? "removed"
+          : "modified";
+    const parsed = f.patch ? parsePatchSymbols(f.patch) : null;
+
+    if (routePath) {
+      // Route file: report endpoints, not raw GET/POST symbol names.
+      const methods = new Map<string, QaPrEndpoint["change"]>();
+      if (parsed) {
+        for (const [method, change] of parsed.methods) {
+          methods.set(method, f.status === "removed" ? "removed" : change);
+        }
+      }
+      // Patch didn't show a handler declaration (body-only edit, no patch for
+      // huge files) → fall back to the head tree's declared methods.
+      if (methods.size === 0) {
+        for (const d of declaredByFile.get(f.filename) ?? []) {
+          methods.set(d.method, fileChange);
+        }
+      }
+      if (methods.size === 0) methods.set("GET", fileChange);
+      for (const [method, change] of methods) {
+        pushEndpoint({ method, path: routePath, file: f.filename, change });
+      }
+      continue;
+    }
+
+    if (!parsed || f.status === "removed") continue;
+    for (const [collection, change] of [
+      [parsed.added, "added"],
+      [parsed.modified, "modified"],
+    ] as const) {
+      for (const [name, isClass] of collection) {
+        if (symbols.length >= MAX_SYMBOLS) break;
+        // Skip re-reporting the same symbol from a rename's new file.
+        if (symbols.some((s) => s.name === name && s.file === f.filename)) {
+          continue;
+        }
+        symbols.push({
+          name,
+          kind: isClass
+            ? "class"
+            : (symbolKind(name, f.filename) as QaPrSymbol["kind"]),
+          file: f.filename,
+          change,
+        });
+      }
+    }
+  }
+
+  return {
+    baseBranch: compare.baseBranch,
+    headBranch: compare.headBranch,
+    files,
+    symbols,
+    endpoints,
+    ...(relevant.length > MAX_FILES || symbols.length >= MAX_SYMBOLS
+      ? { truncated: true }
+      : {}),
+  };
+}
+
+const MAX_DIGEST_FILES = 30;
+
+/** Planner-digest section for the branch diff. Ref strings are emitted
+ *  verbatim so the planner can copy them into items' changeRefs. */
+export function buildPrChangesDigest(pr: QaPrChanges): string {
+  const lines: string[] = [
+    `## Changes on branch \`${pr.headBranch}\` vs \`${pr.baseBranch}\` (branch/PR diff — PRIORITIZE covering these)`,
+  ];
+  if (pr.files.length) {
+    lines.push(
+      `Files changed (${pr.files.length}${pr.truncated ? "+, truncated" : ""}): ` +
+        pr.files
+          .slice(0, MAX_DIGEST_FILES)
+          .map(
+            (f) => `${f.path} (${f.status}, +${f.additions}/−${f.deletions})`,
+          )
+          .join("; "),
+    );
+  }
+  if (pr.symbols.length) {
+    lines.push(
+      "Functions/components this branch adds or modifies:",
+      ...pr.symbols.map(
+        (s) => `- [ref: ${symbolRef(s)}] ${s.change} ${s.kind} in ${s.file}`,
+      ),
+    );
+  }
+  if (pr.endpoints.length) {
+    lines.push(
+      "API endpoints this branch touches:",
+      ...pr.endpoints.map(
+        (e) => `- [ref: ${endpointRef(e)}] ${e.change} (${e.file})`,
+      ),
+    );
+  }
+  lines.push(
+    'COVERAGE REQUIREMENT: every user-observable change listed above must be exercised by at least one plan item. On each covering item set "changeRefs" to the exact ref strings it covers (copy them verbatim from the [ref: …] tags). Changes with no user-facing surface (build config, internal refactors) may be left uncovered.',
+  );
+  return lines.join("\n");
+}
+
+const ENTRY_STATUS_RANK: Record<QaPrCoverageEntry["status"], number> = {
+  passed: 4,
+  covered: 3,
+  generated: 2,
+  planned: 1,
+  uncovered: 0,
+};
+
+function ledgerStatus(entries: QaGeneratedTest[]): QaPrCoverageEntry["status"] {
+  let best: QaPrCoverageEntry["status"] = "planned";
+  for (const g of entries) {
+    let s: QaPrCoverageEntry["status"];
+    if (g.status === "passed" || g.status === "healed") s = "passed";
+    else if (g.status === "covered") s = "covered";
+    else if (g.testId) s = "generated";
+    else s = "planned";
+    if (ENTRY_STATUS_RANK[s] > ENTRY_STATUS_RANK[best]) best = s;
+  }
+  return best;
+}
+
+/** Strip `:param`/`:rest*` segments for endpoint-path comparison. */
+function normalizeApiPath(path: string): string {
+  return path
+    .replace(/^https?:\/\/[^/]+/i, "")
+    .split("?")[0]
+    .replace(/\/+$/, "")
+    .split("/")
+    .map((seg) => (seg.startsWith(":") || /^\{.+\}$/.test(seg) ? ":p" : seg))
+    .join("/")
+    .toLowerCase();
+}
+
+/**
+ * Join the branch changes against the plan + generation ledger and report,
+ * per changed symbol/endpoint, whether a test covers it. Matching is by the
+ * planner's explicit `changeRefs` first; endpoint entries additionally match
+ * api-items whose api.path hits the same normalized path (fallback for plans
+ * where the AI skipped the refs).
+ */
+export function computePrCoverage(
+  pr: QaPrChanges,
+  plan: QaTestPlan,
+  ledger: QaGeneratedTest[],
+): QaPrCoverage {
+  const items = plan.items.filter((i) => i.enabled !== false);
+  const ledgerByItem = new Map(ledger.map((g) => [g.planItemId, g]));
+
+  const refsOf = (itemRefs: string[] | undefined) =>
+    new Set((itemRefs ?? []).map((r) => r.trim().toLowerCase()));
+
+  const entries: QaPrCoverageEntry[] = [];
+
+  const collect = (
+    ref: string,
+    kind: QaPrCoverageEntry["kind"],
+    file: string,
+    change: QaPrCoverageEntry["change"],
+    extraMatch?: (item: QaTestPlan["items"][number]) => boolean,
+  ) => {
+    const needle = ref.trim().toLowerCase();
+    const matched = items.filter(
+      (i) => refsOf(i.changeRefs).has(needle) || (extraMatch?.(i) ?? false),
+    );
+    const ledgerEntries = matched
+      .map((i) => ledgerByItem.get(i.id))
+      .filter((g): g is QaGeneratedTest => Boolean(g));
+    entries.push({
+      ref,
+      kind,
+      file,
+      change,
+      planItemIds: matched.map((i) => i.id),
+      testIds: [
+        ...new Set(
+          ledgerEntries
+            .map((g) => g.testId)
+            .filter((t): t is string => Boolean(t)),
+        ),
+      ],
+      status:
+        matched.length === 0
+          ? "uncovered"
+          : ledgerEntries.length === 0
+            ? "planned"
+            : ledgerStatus(ledgerEntries),
+    });
+  };
+
+  for (const s of pr.symbols) {
+    collect(symbolRef(s), "symbol", s.file, s.change);
+  }
+  for (const e of pr.endpoints) {
+    const normalized = normalizeApiPath(e.path);
+    collect(endpointRef(e), "endpoint", e.file, e.change, (item) =>
+      Boolean(
+        item.api &&
+        item.api.method === e.method &&
+        normalizeApiPath(item.api.path) === normalized,
+      ),
+    );
+  }
+
+  return {
+    baseBranch: pr.baseBranch,
+    headBranch: pr.headBranch,
+    coveredCount: entries.filter((e) =>
+      ["passed", "covered", "generated"].includes(e.status),
+    ).length,
+    entries,
+  };
+}

--- a/src/lib/scheduling/scheduler.ts
+++ b/src/lib/scheduling/scheduler.ts
@@ -31,6 +31,11 @@ export function ensureSchedulerStarted() {
       console.error("[scheduler] Error processing due schedules:", error);
     }
     try {
+      await processDueQaTriggers();
+    } catch (error) {
+      console.error("[scheduler] Error processing QA agent triggers:", error);
+    }
+    try {
       await processLaunchCohorts();
     } catch (error) {
       console.error("[scheduler] Error processing launch cohorts:", error);
@@ -103,5 +108,56 @@ async function processDueSchedules() {
     }
   } finally {
     processing = false;
+  }
+}
+
+let qaProcessing = false;
+
+/** Fire due QA agent cron triggers. Mirrors processDueSchedules: nextRunAt is
+ *  advanced BEFORE starting so a slow run can't double-fire; a busy agent
+ *  means the fire is skipped (startQaAgentFromTrigger reports why). */
+async function processDueQaTriggers() {
+  if (qaProcessing) return;
+  qaProcessing = true;
+
+  try {
+    const due = await queries.getDueQaAgentTriggers();
+
+    for (const trigger of due) {
+      try {
+        if (!trigger.cronExpression) continue;
+        const nextRunAt = getNextRunTime(trigger.cronExpression, new Date());
+        await queries.markQaAgentTriggerFired(trigger.id, { nextRunAt });
+
+        // Import dynamically to avoid circular dependencies
+        const { startQaAgentFromTrigger } =
+          await import("@/server/actions/qa-agent");
+        const result = await startQaAgentFromTrigger({
+          repositoryId: trigger.repositoryId,
+          teamId: trigger.teamId,
+          trigger: "schedule",
+          mode: trigger.scheduleMode,
+        });
+
+        if (result.sessionId) {
+          await queries.markQaAgentTriggerFired(trigger.id, {
+            nextRunAt,
+            lastRunAt: new Date(),
+            lastSessionId: result.sessionId,
+          });
+          console.log(
+            `[scheduler] Started scheduled QA agent session ${result.sessionId}`,
+          );
+        } else if (result.skipped) {
+          console.log(
+            `[scheduler] QA agent trigger skipped: ${result.skipped}`,
+          );
+        }
+      } catch (error) {
+        console.error("[scheduler] Failed to fire QA agent trigger:", error);
+      }
+    }
+  } finally {
+    qaProcessing = false;
   }
 }

--- a/src/server/actions/qa-agent.ts
+++ b/src/server/actions/qa-agent.ts
@@ -44,6 +44,7 @@ import {
   buildPlannerUserPrompt,
   computeQaSummary,
   enabledPlanItems,
+  explainInvalidQaPlan,
   isQaTestPlan,
   itemGroups,
   itemPlaywrightOverrides,
@@ -483,11 +484,13 @@ async function runQaLogin(
   const allowRegistration = session.metadata.qaAllowRegistration !== false;
 
   const SUB_EXISTING = 0;
-  const SUB_CREDS = 1;
-  const SUB_REGISTER = 2;
-  const SUB_RESOLVE = 3;
+  const SUB_SETUP_RUN = 1;
+  const SUB_CREDS = 2;
+  const SUB_REGISTER = 3;
+  const SUB_RESOLVE = 4;
   const substeps: NonNullable<AgentStepState["substeps"]> = [
     { label: "Check existing setup", status: "running", agent: "orchestrator" },
+    { label: "Run existing setup test", status: "pending", agent: "ranger" },
     { label: "Test provided credentials", status: "pending", agent: "ranger" },
     { label: "Register test account", status: "pending", agent: "ranger" },
     {
@@ -607,12 +610,117 @@ async function runQaLogin(
     await updateSubsteps(sessionId, "qa_login", substeps);
     if (await isStopped(sessionId, signal)) return false;
 
+    // 1b) A setup test/script exists but no valid storage state — RUN it to
+    //     mint a fresh session. Discovery can't execute per-test setup steps
+    //     itself, so this is what makes "a setup test that works is already
+    //     in place" usable for a post-login crawl.
+    let setupRunFailed = false;
+    if (!auth && (existing.setupTestId || existing.setupScriptId)) {
+      const stepName = existing.setupStepName ?? "setup step";
+      substeps[SUB_SETUP_RUN] = {
+        ...substeps[SUB_SETUP_RUN],
+        status: "running",
+        detail: `Running "${stepName}"`,
+      };
+      await updateSubsteps(sessionId, "qa_login", substeps);
+      const source = existing.setupTestId
+        ? await queries.getTest(existing.setupTestId).catch(() => null)
+        : await queries
+            .getSetupScript(existing.setupScriptId!)
+            .catch(() => null);
+      const code = source?.code;
+      if (!code) {
+        setupRunFailed = true;
+        substeps[SUB_SETUP_RUN] = {
+          ...substeps[SUB_SETUP_RUN],
+          status: "error",
+          detail: `"${stepName}" has no code — continuing`,
+        };
+      } else {
+        // Arbitrary setup code must not run in-process: captureStorageState
+        // executes it in its own disposable runner/EB; ours stays claimed for
+        // the validation probe right after.
+        const captured = await captureStorageState({
+          repositoryId,
+          baseUrl: targetUrl,
+          testCode: code,
+          name: `QA agent setup ${utcStamp()}`,
+        });
+        if (captured.captured && captured.storageStateId) {
+          let validated = false;
+          let deferred = !cdpUrl;
+          if (cdpUrl) {
+            const fresh = await queries
+              .getStorageState(captured.storageStateId)
+              .catch(() => null);
+            if (fresh?.storageStateJson) {
+              const check = await validateStorageStateOnEb(
+                cdpUrl,
+                fresh.storageStateJson,
+                targetUrl,
+              );
+              validated = check.validated;
+              deferred = check.deferred;
+            } else {
+              deferred = true;
+            }
+          }
+          if (validated || deferred) {
+            auth = {
+              strategy: "existing_setup",
+              validated,
+              storageStateId: captured.storageStateId,
+              setupTestId: existing.setupTestId,
+              defaultSetupInUse: existing.defaultSetupInUse,
+              notes: deferred
+                ? `Session refreshed by running "${stepName}" — validation deferred to discovery`
+                : `Session refreshed by running "${stepName}"`,
+            };
+            substeps[SUB_SETUP_RUN] = {
+              ...substeps[SUB_SETUP_RUN],
+              status: "done",
+              detail: validated
+                ? `Ran "${stepName}" — fresh session captured and validated`
+                : `Ran "${stepName}" — fresh session captured (validation deferred)`,
+            };
+          } else {
+            setupRunFailed = true;
+            substeps[SUB_SETUP_RUN] = {
+              ...substeps[SUB_SETUP_RUN],
+              status: "error",
+              detail: `"${stepName}" ran but the session did not authenticate`,
+            };
+          }
+        } else {
+          setupRunFailed = true;
+          substeps[SUB_SETUP_RUN] = {
+            ...substeps[SUB_SETUP_RUN],
+            status: "error",
+            detail: captured.failureReason ?? `"${stepName}" failed`,
+          };
+        }
+      }
+    } else {
+      substeps[SUB_SETUP_RUN] = {
+        ...substeps[SUB_SETUP_RUN],
+        status: "done",
+        detail: auth ? "Not needed" : "No setup test or script to run",
+      };
+    }
+    await updateSubsteps(sessionId, "qa_login", substeps);
+    if (await isStopped(sessionId, signal)) return false;
+
+    // A broken/uncapturable default setup shouldn't block the rest of the
+    // cascade — creds and registration may still produce a working session.
+    const defaultSetupCoversAuth =
+      existing.defaultSetupInUse && !setupRunFailed;
+
     // Discover the app's real login/signup links once (DOM only, no guessing) —
     // both the credential test and registration need them.
     if (
       !auth &&
       cdpUrl &&
-      (credentials || (allowRegistration && !existing.defaultSetupInUse))
+      (credentials || (allowRegistration && !defaultSetupCoversAuth))
     ) {
       authLinks = await findAuthLinksOnEb(cdpUrl, targetUrl);
     }
@@ -674,9 +782,10 @@ async function runQaLogin(
     if (await isStopped(sessionId, signal)) return false;
 
     // 3) Agent self-registration (opt-out). Signup URL strictly from the DOM;
-    //    skipped when the user gave creds or the repo already has setup steps.
+    //    skipped when the user gave creds or the repo's default setup already
+    //    produced/covers a working session (a failed setup run re-opens this).
     const canRegister =
-      !auth && !credentials && allowRegistration && !existing.defaultSetupInUse;
+      !auth && !credentials && allowRegistration && !defaultSetupCoversAuth;
     if (canRegister && authLinks.signupUrl) {
       substeps[SUB_REGISTER] = { ...substeps[SUB_REGISTER], status: "running" };
       await updateSubsteps(sessionId, "qa_login", substeps);
@@ -752,7 +861,7 @@ async function runQaLogin(
             ? "Skipped — credentials were provided"
             : !allowRegistration
               ? "Disabled for this run"
-              : existing.defaultSetupInUse
+              : defaultSetupCoversAuth
                 ? "Skipped — repo default setup already covers auth"
                 : "No sign-up link found in the app's DOM",
       };
@@ -768,8 +877,9 @@ async function runQaLogin(
           validated: false,
           setupTestId: existing.setupTestId,
           defaultSetupInUse: true,
-          notes:
-            "Repo default setup steps run before every test — validated at execution",
+          notes: setupRunFailed
+            ? "Repo default setup could not produce a session — discovery runs without login; execution still applies the default steps"
+            : "Repo default setup steps run before every test — validated at execution",
         };
       } else if (credentials) {
         auth = {
@@ -950,10 +1060,10 @@ async function runQaDiscover(
       crawled = await crawlTargetApp(eb.cdpUrl, targetUrl, {
         maxPages: MAX_CRAWL_PAGES,
         credentials,
-        prioritizeAuthLinks:
-          !qaAuth ||
-          qaAuth.strategy === "public_only" ||
-          qaAuth.strategy === "creds_untested",
+        loginUrl: qaAuth?.loginUrl,
+        // No injected session and no creds to try → make sure the crawl at
+        // least maps the login/signup surface itself.
+        prioritizeAuthLinks: !preAuthed && !credentials,
         signal,
         onPage: (snapshot, index) => {
           substeps[1] = {
@@ -1139,8 +1249,15 @@ async function runQaPlan(
     lastRaw = raw;
     plan = parseAiJson(raw, isQaTestPlan, { source: "qa-plan" });
     if (!plan) {
+      // Surface the specific validation failure (parsed shape when we could
+      // parse it, else a generic note) so the retry is a targeted correction.
+      const parsedShape = parseAiJson(raw, (x): x is unknown => true, {
+        source: "qa-plan-explain",
+      });
+      const reason =
+        explainInvalidQaPlan(parsedShape) ?? "the JSON was invalid";
       const retry = await callPlanner(
-        "Your previous response was not a valid plan JSON object. Respond with ONLY the JSON object described in the system prompt.",
+        `Your previous response was not a valid plan: ${reason}. Fix exactly that and respond with ONLY the JSON object described in the system prompt.`,
       );
       lastRaw = retry;
       plan = parseAiJson(retry, isQaTestPlan, { source: "qa-plan-retry" });
@@ -1776,6 +1893,30 @@ async function runQaHeal(
     return true;
   }
 
+  // Statement of each failing test's purpose, so the healer preserves it
+  // instead of loosening assertions (resilience injections, negative-input
+  // gates, and journey end-state proofs must survive the fix).
+  const plan = session?.metadata.qaPlan;
+  const planItemById = new Map(
+    (plan?.items ?? []).map((i) => [i.id, i] as const),
+  );
+  const healIntentFor = (entry: QaGeneratedTest): string | undefined => {
+    const item = planItemById.get(entry.planItemId);
+    const groups = (entry.groups?.length ? entry.groups : [entry.group]).join(
+      " + ",
+    );
+    const lines = [`Coverage groups: ${groups}.`];
+    const journey = item?.journeyId
+      ? plan?.journeys.find((j) => j.id === item.journeyId)
+      : undefined;
+    if (journey) {
+      lines.push(
+        `Business outcome: ${journey.businessOutcome}. Required end-state proof: ${journey.endStateVerification}.`,
+      );
+    }
+    return lines.join(" ");
+  };
+
   const substeps: NonNullable<AgentStepState["substeps"]> = failing.map(
     (g) => ({
       label: `Healing "${g.name}"`,
@@ -1817,6 +1958,7 @@ async function runQaHeal(
           const result = await agentHealTestCore(repositoryId, entry.testId!, {
             cdpEndpoint: eb.cdpUrl,
             signal: AbortSignal.any([signal, timeoutSignal]),
+            intent: healIntentFor(entry),
           });
           if (result.success && result.code) {
             await queries.updateTest(entry.testId!, { code: result.code });

--- a/src/server/actions/qa-agent.ts
+++ b/src/server/actions/qa-agent.ts
@@ -39,20 +39,27 @@ import {
   buildApiDefinition,
   buildDiscoveryDigest,
   buildExistingCoverageDigest,
+  buildExistingPlanDigest,
   buildGeneratorPrompt,
+  buildJourneyRefinerSystemPrompt,
+  buildJourneyRefinerUserPrompt,
   buildPlannerSystemPrompt,
   buildPlannerUserPrompt,
   computeQaSummary,
   enabledPlanItems,
   explainInvalidQaPlan,
+  explainInvalidRefinedJourneys,
   isQaTestPlan,
+  isRefinedJourneys,
   itemGroups,
   itemPlaywrightOverrides,
   matchPlanToExistingTests,
+  mergeRefinedJourneys,
   normalizeQaGroups,
   sanitizeQaPlan,
   QA_GROUPS,
   type ExistingTestSummary,
+  type RefinedJourneys,
 } from "@/lib/qa-agent/plan";
 import type {
   ActivityEventType,
@@ -334,6 +341,21 @@ function credentialsFrom(
     };
   }
   return undefined;
+}
+
+/** Whether this run's plan/tests target the AUTHENTICATED in-app surface.
+ *  This is auth AVAILABILITY, not "plaintext credentials were typed": qa_login
+ *  resolves auth via typed creds, a captured/existing storage state, or repo
+ *  default setup steps — any of which means the crawl ran signed-in and
+ *  generated tests start authenticated. Wiring the planner to credsProvided
+ *  alone made it plan "public surface only" on storage-state runs. Mirrors the
+ *  `preAuthenticated` calc in the generate step. */
+function isRunAuthenticated(metadata: AgentSessionMetadata): boolean {
+  return Boolean(
+    metadata.credsProvided ||
+    metadata.qaAuth?.storageStateId ||
+    metadata.qaAuth?.defaultSetupInUse,
+  );
 }
 
 /** Live (non-deleted) repo tests with their area names — the matcher's and
@@ -1180,20 +1202,11 @@ async function runQaPlan(
     return false;
   }
   const groups = normalizeQaGroups(session.metadata.qaGroups ?? []);
-  // Whether the plan should target the authenticated in-app surface. This is
-  // auth AVAILABILITY, not "plaintext credentials were typed": qa_login may
-  // resolve auth via a captured/existing storage state or repo default setup
-  // (existing_setup / registered / creds verified), in which case the crawl
-  // ran signed-in and generated tests start authenticated too. Mirrors the
-  // `preAuthenticated` calc in runQaPlanReview. Using credsProvided alone here
-  // wrongly told the planner "public surface only" on storage-state runs, so it
-  // discarded the whole authed digest and planned only login pages.
-  const qaAuth = session.metadata.qaAuth;
-  const authenticated = Boolean(
-    session.metadata.credsProvided ||
-    qaAuth?.storageStateId ||
-    qaAuth?.defaultSetupInUse,
-  );
+  // Target the authenticated in-app surface whenever qa_login resolved auth —
+  // NOT only when raw credentials were typed (see isRunAuthenticated). Passing
+  // credsProvided alone told the planner "public surface only" on storage-state
+  // runs, so it discarded the whole authed digest and planned only login pages.
+  const authenticated = isRunAuthenticated(session.metadata);
   const feedback = session.metadata.qaPlannerFeedback;
 
   const substeps: NonNullable<AgentStepState["substeps"]> = [
@@ -1619,12 +1632,17 @@ async function runQaGenerate(
               testName: item.title,
               baseUrl: targetUrl,
               routePath: item.pagePath,
+              preAuthenticated,
               userPrompt: buildGeneratorPrompt({
                 item,
                 plan,
                 targetUrl,
                 credentials: preAuthenticated ? undefined : credentials,
                 auth: { preAuthenticated },
+                loginContext: {
+                  loginUrl: qaAuth?.loginUrl,
+                  signupUrl: qaAuth?.signupUrl,
+                },
               }),
             },
             {
@@ -2424,6 +2442,128 @@ export async function rerunQaPlanner(
   );
   revalidatePath("/qa-agent");
   return { success: true };
+}
+
+/** Split a free-text blob of user journeys into individual journeys. Accepts
+ *  newline- or bullet-separated input; trims markers and empties. */
+function parseUserJourneys(raw: string): string[] {
+  return raw
+    .split(/\r?\n/)
+    .map((l) => l.replace(/^\s*(?:[-*•]|\d+[.)])\s*/, "").trim())
+    .filter((l) => l.length > 0)
+    .slice(0, 15);
+}
+
+const REFINER_TIMEOUT_MS = 3 * 60 * 1000;
+
+/**
+ * Refine plain-language journeys the reviewer supplied at the plan gate into
+ * structured, digest-grounded journeys + covering items, and MERGE them into
+ * the current plan (existing items and the reviewer's enable/disable choices
+ * are preserved — see mergeRefinedJourneys). The session STAYS paused at the
+ * review gate showing the augmented plan; nothing advances until the reviewer
+ * approves. Counters the "reduced context" quality gap by letting the human
+ * inject the journeys the condensed digest lost.
+ */
+export async function addQaUserJourneys(
+  sessionId: string,
+  journeysText: string,
+): Promise<{
+  success: boolean;
+  addedJourneys?: number;
+  addedItems?: number;
+  error?: string;
+}> {
+  const { session, teamId } = await requireQaSession(sessionId);
+  const plan = session.metadata.qaPlan;
+  const discovery = session.metadata.qaDiscovery;
+  if (!plan || !discovery) {
+    return { success: false, error: "No plan to add journeys to" };
+  }
+  const journeys = parseUserJourneys(journeysText);
+  if (journeys.length === 0) {
+    return { success: false, error: "No journeys were provided" };
+  }
+
+  const repositoryId = session.repositoryId;
+  const groups = normalizeQaGroups(session.metadata.qaGroups ?? []);
+  const authenticated = isRunAuthenticated(session.metadata);
+  const digest = buildDiscoveryDigest(discovery);
+  const systemPrompt = buildJourneyRefinerSystemPrompt();
+  const userPrompt = buildJourneyRefinerUserPrompt({
+    digest,
+    groups,
+    userJourneys: journeys,
+    existingPlanDigest: buildExistingPlanDigest(plan),
+    authenticated,
+  });
+
+  const callRefiner = async (extra?: string): Promise<string> => {
+    const settings = await queries.getAISettings(repositoryId);
+    const config = getAIConfig(settings);
+    return generateWithAI(
+      config,
+      extra ? `${userPrompt}\n\n${extra}` : userPrompt,
+      systemPrompt,
+      {
+        repositoryId,
+        actionType: "qa_plan",
+        responseFormat: "json_object",
+        signal: AbortSignal.timeout(REFINER_TIMEOUT_MS),
+      },
+    );
+  };
+
+  let refined: RefinedJourneys | null = null;
+  try {
+    const raw = await callRefiner();
+    refined = parseAiJson(raw, isRefinedJourneys, { source: "qa-refine" });
+    if (!refined) {
+      const shape = parseAiJson(raw, (x): x is unknown => true, {
+        source: "qa-refine-explain",
+      });
+      const reason =
+        explainInvalidRefinedJourneys(shape) ?? "the JSON was invalid";
+      const retry = await callRefiner(
+        `Your previous response was not valid: ${reason}. Respond with ONLY the JSON object described in the system prompt.`,
+      );
+      refined = parseAiJson(retry, isRefinedJourneys, {
+        source: "qa-refine-retry",
+      });
+    }
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : "Journey refiner failed",
+    };
+  }
+  if (!refined) {
+    return {
+      success: false,
+      error:
+        "The AI could not turn those journeys into a valid plan. Reword them and try again.",
+    };
+  }
+
+  const merged = mergeRefinedJourneys(plan, refined, groups);
+  await mergeMetadata(sessionId, {
+    qaPlan: merged.plan,
+    qaUserJourneys: [...(session.metadata.qaUserJourneys ?? []), ...journeys],
+  });
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "substep:update",
+    `Added ${merged.addedJourneys} journey${merged.addedJourneys === 1 ? "" : "s"} and ${merged.addedItems} test${merged.addedItems === 1 ? "" : "s"} from your input`,
+    { stepId: "qa_plan_review", agentType: "planner" },
+  );
+  revalidatePath("/qa-agent");
+  return {
+    success: true,
+    addedJourneys: merged.addedJourneys,
+    addedItems: merged.addedItems,
+  };
 }
 
 export async function pauseQaAgent(

--- a/src/server/actions/qa-agent.ts
+++ b/src/server/actions/qa-agent.ts
@@ -990,6 +990,7 @@ async function runQaDiscover(
     ghAccount?.accessToken && repo?.provider === "github" && repo.owner,
   );
   const branch = repo?.selectedBranch || repo?.defaultBranch || "main";
+  const baseBranch = repo?.defaultBranch || "main";
 
   // 1) Static routes: reuse a prior scan; else run the GitHub-tree scanner.
   let staticRoutes: Array<{ path: string; type: string }> = [];
@@ -1019,7 +1020,7 @@ async function runQaDiscover(
       ...substeps[0],
       status: "done",
       detail: githubConnected
-        ? `${staticRoutes.length} routes (${framework ?? "unknown"})`
+        ? `${staticRoutes.length} routes (${framework ?? "unknown"}) · branch ${branch}`
         : "skipped — GitHub not connected",
     };
   } catch (err) {
@@ -1056,7 +1057,6 @@ async function runQaDiscover(
       const token = ghAccount.accessToken;
       const owner = repo.owner ?? "";
       const name = repo.name ?? "";
-      const baseBranch = repo.defaultBranch || "main";
       const [intel, tree, comparison] = await Promise.all([
         gatherCodebaseIntelligence(token, owner, name, branch).catch(
           () => null,
@@ -1093,17 +1093,18 @@ async function runQaDiscover(
         const computed = computePrChanges(comparison, declaredEndpoints);
         if (computed.files.length > 0) prChanges = computed;
       }
+      // Always say which branch was analyzed and why there is / isn't a diff.
       const prDetail = prChanges
-        ? ` · branch diff vs ${prChanges.baseBranch}: ${prChanges.files.length} files, ${prChanges.symbols.length} functions, ${prChanges.endpoints.length} endpoints`
-        : "";
+        ? ` · diff ${branch} vs ${baseBranch}: ${prChanges.files.length} files, ${prChanges.symbols.length} functions, ${prChanges.endpoints.length} endpoints`
+        : branch === baseBranch
+          ? ` · branch ${branch} = base (no PR diff — select a feature branch on the repo to target PR changes)`
+          : ` · diff ${branch} vs ${baseBranch}: none available`;
       substeps[1] = {
         ...substeps[1],
         status: "done",
         detail: codeCheck
           ? `${codeCheck.declaredEndpoints.length} declared endpoints · ${codeCheck.framework ?? "stack unknown"}${prDetail}`
-          : prChanges
-            ? `no code intelligence available${prDetail}`
-            : "no code intelligence available",
+          : `no code intelligence available${prDetail}`,
       };
       emitActivity(
         teamId,
@@ -1267,6 +1268,7 @@ async function runQaDiscover(
     staticRoutes: staticRoutes.length > 0 ? staticRoutes : undefined,
     framework,
     githubConnected,
+    ...(githubConnected ? { branch, baseBranch } : {}),
     codeCheck,
     prChanges,
   };
@@ -1430,11 +1432,29 @@ async function runQaPlan(
   }
 
   const sanitized = sanitizeQaPlan(plan, groups);
+
+  // Annotate items a pre-existing test already covers so the review matrix
+  // shows what exists vs what this run would create. Same matcher the
+  // generate/summary steps use, run early for the human gate.
+  const existingNameById = new Map(existingTests.map((t) => [t.id, t.name]));
+  const preCovered = matchPlanToExistingTests(sanitized.items, existingTests);
+  for (const item of sanitized.items) {
+    const testId = preCovered.get(item.id);
+    if (testId) {
+      item.existingTestId = testId;
+      item.existingTestName = existingNameById.get(testId);
+    } else {
+      // Re-plans must not carry stale matches from a previous plan round.
+      delete item.existingTestId;
+      delete item.existingTestName;
+    }
+  }
+
   substeps[0] = {
     ...substeps[0],
     status: "done",
     durationMs: Date.now() - started,
-    outputSummary: `${sanitized.journeys.length} journeys, ${sanitized.items.length} test items`,
+    outputSummary: `${sanitized.journeys.length} journeys, ${sanitized.items.length} test items${preCovered.size > 0 ? `, ${preCovered.size} already covered by existing tests` : ""}`,
   };
   await updateSubsteps(sessionId, "qa_plan", substeps);
   await mergeMetadata(sessionId, {
@@ -1456,7 +1476,7 @@ async function runQaPlan(
     repositoryId,
     sessionId,
     "step:complete",
-    `Plan ready: ${sanitized.journeys.length} journeys, ${sanitized.items.length} tests across ${groups.length} groups`,
+    `Plan ready: ${sanitized.journeys.length} journeys, ${sanitized.items.length} tests across ${groups.length} groups${preCovered.size > 0 ? ` (${preCovered.size} already covered by existing tests)` : ""}`,
     { stepId: "qa_plan", agentType: "planner" },
   );
   return true;

--- a/src/server/actions/qa-agent.ts
+++ b/src/server/actions/qa-agent.ts
@@ -220,11 +220,13 @@ async function setStepFailed(
   sessionId: string,
   stepId: AgentStepId,
   error: string,
+  result?: Record<string, unknown>,
 ) {
   await updateStep(sessionId, stepId, {
     status: "failed",
     completedAt: new Date().toISOString(),
     error,
+    ...(result ? { result } : {}),
   });
   await queries.updateAgentSession(sessionId, {
     status: "failed",
@@ -659,13 +661,16 @@ async function runQaPlan(
   };
 
   let plan: QaTestPlan | null = null;
+  let lastRaw = "";
   try {
     const raw = await callPlanner();
+    lastRaw = raw;
     plan = parseAiJson(raw, isQaTestPlan, { source: "qa-plan" });
     if (!plan) {
       const retry = await callPlanner(
         "Your previous response was not a valid plan JSON object. Respond with ONLY the JSON object described in the system prompt.",
       );
+      lastRaw = retry;
       plan = parseAiJson(retry, isQaTestPlan, { source: "qa-plan-retry" });
     }
   } catch (err) {
@@ -677,12 +682,32 @@ async function runQaPlan(
   }
 
   if (!plan) {
-    substeps[0] = { ...substeps[0], status: "error" };
+    // The planner replied (twice) but neither reply parsed into a valid plan.
+    // Don't just fail with a bare message — surface the raw model output so the
+    // user can read/copy it and proceed manually (retry, or build tests by
+    // hand from what the planner produced). Cap the payload so a runaway reply
+    // can't bloat the session row.
+    const MAX_RAW_CHARS = 8_000;
+    const rawOutput =
+      lastRaw.length > MAX_RAW_CHARS
+        ? `${lastRaw.slice(0, MAX_RAW_CHARS)}\n…(truncated — ${lastRaw.length} chars total)`
+        : lastRaw;
+    substeps[0] = {
+      ...substeps[0],
+      status: "error",
+      rawError: "Planner output could not be parsed into a valid plan",
+    };
     await updateSubsteps(sessionId, "qa_plan", substeps);
     await setStepFailed(
       sessionId,
       "qa_plan",
-      "Planner did not produce a valid test plan (JSON parse/shape failure after retry)",
+      "The planner replied but its output couldn't be parsed into a valid test plan after an automatic retry.",
+      {
+        manual: true,
+        rawOutput,
+        manualHint:
+          "Start a new run to retry, or use the raw output below to build the suite manually (record a test, or create tests by hand). If this keeps happening, check the AI provider in Settings — its replies aren't valid JSON.",
+      },
     );
     return false;
   }

--- a/src/server/actions/qa-agent.ts
+++ b/src/server/actions/qa-agent.ts
@@ -969,6 +969,7 @@ async function runQaDiscover(
 
   const substeps: NonNullable<AgentStepState["substeps"]> = [
     { label: "Static route scan", status: "running", agent: "scout" },
+    { label: "Code analysis", status: "pending", agent: "diver" },
     { label: "Live crawl", status: "pending", agent: "ranger" },
   ];
   await updateSubsteps(sessionId, "qa_discover", substeps);
@@ -981,19 +982,19 @@ async function runQaDiscover(
     { stepId: "qa_discover", agentType: "scout" },
   );
 
+  const repo = await queries.getRepository(repositoryId);
+  const ghAccount = await queries
+    .getGithubAccountByTeam(teamId)
+    .catch(() => undefined);
+  const githubConnected = Boolean(
+    ghAccount?.accessToken && repo?.provider === "github" && repo.owner,
+  );
+  const branch = repo?.selectedBranch || repo?.defaultBranch || "main";
+
   // 1) Static routes: reuse a prior scan; else run the GitHub-tree scanner.
   let staticRoutes: Array<{ path: string; type: string }> = [];
   let framework: string | undefined;
-  let githubConnected = false;
   try {
-    const repo = await queries.getRepository(repositoryId);
-    const ghAccount = await queries
-      .getGithubAccountByTeam(teamId)
-      .catch(() => undefined);
-    githubConnected = Boolean(
-      ghAccount?.accessToken && repo?.provider === "github" && repo.owner,
-    );
-
     const existing = await queries.getRoutesByRepo(repositoryId);
     if (existing.length > 0) {
       staticRoutes = existing.map((r) => ({ path: r.path, type: r.type }));
@@ -1005,7 +1006,7 @@ async function runQaDiscover(
         accessToken: ghAccount.accessToken,
         owner: repo.owner ?? "",
         repo: repo.name ?? "",
-        branch: repo.selectedBranch || repo.defaultBranch || "main",
+        branch,
       });
       const result = await scanner.scan();
       staticRoutes = result.routes.map((r) => ({
@@ -1032,8 +1033,84 @@ async function runQaDiscover(
 
   if (await isStopped(sessionId, signal)) return false;
 
-  // 2) Live crawl on an Embedded Browser (streamed to the page live view).
+  // 2) Code check (repo-aware mode): stack intelligence + endpoints declared
+  //    in code — facts the crawl can't see, feeding the planner digest.
+  let codeCheck: QaDiscovery["codeCheck"];
   substeps[1] = { ...substeps[1], status: "running" };
+  await updateSubsteps(sessionId, "qa_discover", substeps);
+  if (githubConnected && repo && ghAccount?.accessToken) {
+    try {
+      const [{ gatherCodebaseIntelligence }, { getRepoTree, getFileContent }] =
+        await Promise.all([
+          import("@/lib/ai/codebase-intelligence"),
+          import("@/lib/github/content"),
+        ]);
+      const { extractDeclaredEndpoints } =
+        await import("@/lib/qa-agent/code-check");
+      const token = ghAccount.accessToken;
+      const owner = repo.owner ?? "";
+      const name = repo.name ?? "";
+      const [intel, tree] = await Promise.all([
+        gatherCodebaseIntelligence(token, owner, name, branch).catch(
+          () => null,
+        ),
+        getRepoTree(token, owner, name, branch).catch(() => null),
+      ]);
+      const declaredEndpoints = tree
+        ? await extractDeclaredEndpoints(tree.tree, (path) =>
+            getFileContent(token, owner, name, path, branch),
+          )
+        : [];
+      if (intel || declaredEndpoints.length > 0) {
+        codeCheck = {
+          framework: intel?.framework,
+          authMechanism: intel?.authMechanism,
+          apiLayer: intel?.apiLayer,
+          projectDescription: intel?.projectDescription,
+          testingNotes: [
+            ...(intel?.keyDeps.map(
+              (d) => `${d.name}: ${d.testingImplication}`,
+            ) ?? []),
+            ...(intel?.testingRecommendations ?? []),
+          ].slice(0, 12),
+          declaredEndpoints,
+        };
+      }
+      substeps[1] = {
+        ...substeps[1],
+        status: "done",
+        detail: codeCheck
+          ? `${codeCheck.declaredEndpoints.length} declared endpoints · ${codeCheck.framework ?? "stack unknown"}`
+          : "no code intelligence available",
+      };
+      emitActivity(
+        teamId,
+        repositoryId,
+        sessionId,
+        "substep:update",
+        `Code analysis: ${codeCheck?.declaredEndpoints.length ?? 0} declared endpoints, stack ${codeCheck?.framework ?? "unknown"}`,
+        { stepId: "qa_discover", agentType: "diver" },
+      );
+    } catch (err) {
+      substeps[1] = {
+        ...substeps[1],
+        status: "error",
+        detail: err instanceof Error ? err.message : "code analysis failed",
+      };
+    }
+  } else {
+    substeps[1] = {
+      ...substeps[1],
+      status: "done",
+      detail: "skipped — GitHub not connected",
+    };
+  }
+  await updateSubsteps(sessionId, "qa_discover", substeps);
+
+  if (await isStopped(sessionId, signal)) return false;
+
+  // 3) Live crawl on an Embedded Browser (streamed to the page live view).
+  substeps[2] = { ...substeps[2], status: "running" };
   await updateSubsteps(sessionId, "qa_discover", substeps);
 
   let runnerId: string | undefined;
@@ -1046,8 +1123,8 @@ async function runQaDiscover(
       mergeMetadata(sessionId, { queuedForBrowser: true }).catch(() => {});
     });
     if (!eb) {
-      substeps[1] = {
-        ...substeps[1],
+      substeps[2] = {
+        ...substeps[2],
         status: "error",
         detail: "No embedded browser available",
       };
@@ -1088,8 +1165,8 @@ async function runQaDiscover(
         prioritizeAuthLinks: !preAuthed && !credentials,
         signal,
         onPage: (snapshot, index) => {
-          substeps[1] = {
-            ...substeps[1],
+          substeps[2] = {
+            ...substeps[2],
             detail: `${index + 1} pages mapped — ${snapshot.finalUrl}`,
           };
           updateSubsteps(sessionId, "qa_discover", substeps).catch(() => {});
@@ -1103,8 +1180,8 @@ async function runQaDiscover(
           );
         },
       });
-      substeps[1] = {
-        ...substeps[1],
+      substeps[2] = {
+        ...substeps[2],
         status: crawled.pages.length > 0 ? "done" : "error",
         detail:
           crawled.pages.length > 0
@@ -1142,8 +1219,8 @@ async function runQaDiscover(
       }
     }
   } catch (err) {
-    substeps[1] = {
-      ...substeps[1],
+    substeps[2] = {
+      ...substeps[2],
       status: "error",
       detail: err instanceof Error ? err.message : "crawl failed",
     };
@@ -1168,6 +1245,7 @@ async function runQaDiscover(
     staticRoutes: staticRoutes.length > 0 ? staticRoutes : undefined,
     framework,
     githubConnected,
+    codeCheck,
   };
   await mergeMetadata(sessionId, { qaDiscovery: discovery });
   await setStepCompleted(sessionId, "qa_discover", {
@@ -1251,6 +1329,7 @@ async function runQaPlan(
         groups,
         authenticated,
         existingCoverage,
+        docsDigest: session.metadata.qaDocsDigest || undefined,
         feedback:
           [feedback, extraFeedback].filter(Boolean).join("\n") || undefined,
       }),
@@ -2246,6 +2325,9 @@ export interface StartQaAgentInput {
   targetUrl: string;
   /** full (default) | refresh_spec | fill_gaps — see QaRunMode. */
   mode?: QaRunMode;
+  /** Product documentation uploads (.md/.txt/.pdf/.docx, base64) — the
+   *  planner treats their content as authoritative for intended behavior. */
+  docs?: Array<{ name: string; contentBase64: string }>;
   groups: QaTestGroup[];
   email?: string;
   password?: string;
@@ -2290,6 +2372,17 @@ export async function startQaAgent(
   const credsProvided = Boolean(input.email?.trim() && input.password);
   const steps = buildStepsForMode(mode);
 
+  // Decode uploaded product docs into the planner's documentation digest.
+  // Only the digest + per-file summaries persist — never the raw upload.
+  let docsSeed: Partial<AgentSessionMetadata> = {};
+  if (input.docs?.length) {
+    const { processUploadedDocs } = await import("@/lib/qa-agent/docs");
+    const { summaries, digest } = await processUploadedDocs(input.docs);
+    if (digest) {
+      docsSeed = { qaDocs: summaries, qaDocsDigest: digest };
+    }
+  }
+
   // fill_gaps reuses the newest stored plan (from any prior full/refresh run)
   // instead of re-discovering and re-planning.
   let planSeed: Partial<AgentSessionMetadata> = {};
@@ -2328,6 +2421,7 @@ export async function startQaAgent(
       credsProvided,
       authMode: credsProvided ? "login" : "public_only",
       ...planSeed,
+      ...docsSeed,
       ...(credsProvided
         ? {
             quickstartEmail: input.email!.trim(),

--- a/src/server/actions/qa-agent.ts
+++ b/src/server/actions/qa-agent.ts
@@ -18,6 +18,24 @@ import { toProxyStreamUrl } from "@/lib/eb/stream-url";
 import { appendStreamToken } from "@/lib/eb/stream-token";
 import { crawlTargetApp } from "@/lib/qa-agent/crawl";
 import {
+  findAuthLinksOnEb,
+  findExistingAuthSetup,
+  loginWithCredsOnEb,
+  probeAndCaptureOnEb,
+  validateStorageStateOnEb,
+  type ExistingAuthSetup,
+} from "@/lib/qa-agent/auth";
+import { injectStorageStateIntoEb } from "@/lib/eb/inject-storage-state";
+import { captureStorageState } from "@/lib/quickstart/storage-capture";
+import {
+  renderAuthLoginCode,
+  renderAuthSetupCode,
+  renderQuickstartEmail,
+  renderQuickstartPassword,
+  slugify,
+  utcStamp,
+} from "@/lib/playwright/quickstart-templates";
+import {
   buildApiDefinition,
   buildDiscoveryDigest,
   buildExistingCoverageDigest,
@@ -42,19 +60,24 @@ import type {
   AgentStepId,
   AgentStepState,
   PwAgentType,
+  QaAuthState,
   QaDiscovery,
   QaGeneratedTest,
   QaPlanItem,
   QaRunMode,
   QaTestGroup,
   QaTestPlan,
+  TestSetupOverrides,
 } from "@/lib/db/schema";
 
 /**
  * QA Agent — the dedicated comprehensive-suite builder behind the /qa-agent
- * page. Orchestrates specialist subagents through an eight-phase pipeline:
+ * page. Orchestrates specialist subagents through a nine-phase pipeline:
  *
  *   qa_setup       orchestrator  preflight (AI provider, GitHub, target URL)
+ *   qa_login       orchestrator  resolve auth: existing setup/storage state →
+ *                                provided creds (verified live) → agent
+ *                                self-registration → public-only fallback
  *   qa_discover    scout         static route scan + live EB crawl (DOM,
  *                                selectors, observed API endpoints)
  *   qa_plan        planner       best-practices test plan grounded in discovery
@@ -82,6 +105,12 @@ const QA_STEP_DEFINITIONS: Array<{
     id: "qa_setup",
     label: "Preflight",
     description: "Validate target URL, AI provider, and GitHub connection",
+  },
+  {
+    id: "qa_login",
+    label: "Login",
+    description:
+      "Resolve authentication — existing setup, provided credentials, or an agent-registered account",
   },
   {
     id: "qa_discover",
@@ -404,6 +433,395 @@ async function runQaSetup(
   return true;
 }
 
+// ── Step: qa_login ───────────────────────────────────────────────────────────
+
+/** Create (or refresh) the repo's reusable QA login setup test so the
+ *  captured session can be re-established by the executor when it expires. */
+async function upsertQaLoginSetupTest(
+  repositoryId: string,
+  opts: { email: string; password: string; loginUrl: string },
+): Promise<string | undefined> {
+  try {
+    const name = "QA agent — auth login";
+    const code = renderAuthLoginCode(opts);
+    const tests = await queries.getTestsByRepo(repositoryId);
+    const existing = tests.find((t) => t.name === name);
+    if (existing) {
+      await queries.updateTest(existing.id, { code });
+      return existing.id;
+    }
+    const created = await queries.createTest({ repositoryId, name, code });
+    return created.id;
+  } catch (err) {
+    console.warn("[QaAgent] login setup test upsert failed:", err);
+    return undefined;
+  }
+}
+
+/**
+ * Resolve how this run authenticates, cheapest-and-safest option first:
+ *   1. existing repo setup (default setup steps / storage states), validated
+ *      live on an EB when possible;
+ *   2. user-provided credentials — verified with a real login, session
+ *      captured as a storage state for discovery + generated tests;
+ *   3. agent self-registration (opt-out) — signup URL strictly from the DOM;
+ *   4. fallback: creds tested inline during discovery, or public-only with
+ *      the auth surface itself mapped by the crawl.
+ * The step never fails the pipeline — every unresolved path degrades.
+ */
+async function runQaLogin(
+  sessionId: string,
+  teamId: string,
+  repositoryId: string,
+  signal: AbortSignal,
+): Promise<boolean> {
+  await setStepActive(sessionId, "qa_login");
+  const session = await queries.getAgentSession(sessionId);
+  if (!session?.metadata.qaTargetUrl) return false;
+  const targetUrl = session.metadata.qaTargetUrl;
+  const credentials = credentialsFrom(session.metadata);
+  const allowRegistration = session.metadata.qaAllowRegistration !== false;
+
+  const SUB_EXISTING = 0;
+  const SUB_CREDS = 1;
+  const SUB_REGISTER = 2;
+  const SUB_RESOLVE = 3;
+  const substeps: NonNullable<AgentStepState["substeps"]> = [
+    { label: "Check existing setup", status: "running", agent: "orchestrator" },
+    { label: "Test provided credentials", status: "pending", agent: "ranger" },
+    { label: "Register test account", status: "pending", agent: "ranger" },
+    {
+      label: "Resolve auth strategy",
+      status: "pending",
+      agent: "orchestrator",
+    },
+  ];
+  await updateSubsteps(sessionId, "qa_login", substeps);
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:start",
+    "Resolving login — existing setup, credentials, or registration",
+    { stepId: "qa_login", agentType: "orchestrator" },
+  );
+
+  const existing = await findExistingAuthSetup(repositoryId).catch(
+    (): ExistingAuthSetup => ({ defaultSetupInUse: false }),
+  );
+
+  let auth: QaAuthState | null = null;
+  let authLinks: { loginUrl?: string; signupUrl?: string } = {};
+  let runnerId: string | undefined;
+
+  try {
+    // One EB for validation, link discovery, and the live credential test.
+    // Unavailability is NOT fatal: resolution degrades and discovery (which
+    // claims its own EB later) picks up the deferred validation.
+    let cdpUrl: string | undefined;
+    const eb = await claimEmbeddedBrowserForAgent(EB_CLAIM_TIMEOUT_MS, () => {
+      mergeMetadata(sessionId, { queuedForBrowser: true }).catch(() => {});
+    }).catch(() => undefined);
+    await mergeMetadata(sessionId, {
+      queuedForBrowser: false,
+      ...(eb ? { streamUrl: proxiedStream(eb.streamUrl) } : {}),
+    });
+    if (eb) {
+      runnerId = eb.runnerId;
+      cdpUrl = eb.cdpUrl;
+    }
+
+    // 1) Existing setup infrastructure (setup steps / storage states).
+    if (existing.storageStateId) {
+      const row = await queries
+        .getStorageState(existing.storageStateId)
+        .catch(() => null);
+      const stateName = existing.storageStateName ?? "storage state";
+      if (!row?.storageStateJson) {
+        substeps[SUB_EXISTING] = {
+          ...substeps[SUB_EXISTING],
+          status: "done",
+          detail: `"${stateName}" could not be loaded — continuing`,
+        };
+      } else if (!cdpUrl) {
+        // Accept unvalidated; discovery validates after injecting it.
+        auth = {
+          strategy: "existing_setup",
+          validated: false,
+          storageStateId: existing.storageStateId,
+          setupTestId: existing.setupTestId,
+          defaultSetupInUse: existing.defaultSetupInUse,
+          notes: "No browser available — validation deferred to discovery",
+        };
+        substeps[SUB_EXISTING] = {
+          ...substeps[SUB_EXISTING],
+          status: "done",
+          detail: `"${stateName}" found (validation deferred — no browser)`,
+        };
+      } else {
+        const check = await validateStorageStateOnEb(
+          cdpUrl,
+          row.storageStateJson,
+          targetUrl,
+        );
+        if (check.validated || check.deferred) {
+          auth = {
+            strategy: "existing_setup",
+            validated: check.validated,
+            storageStateId: existing.storageStateId,
+            setupTestId: existing.setupTestId,
+            defaultSetupInUse: existing.defaultSetupInUse,
+            notes: check.deferred
+              ? "IndexedDB-only capture — validation deferred to discovery"
+              : undefined,
+          };
+          substeps[SUB_EXISTING] = {
+            ...substeps[SUB_EXISTING],
+            status: "done",
+            detail: check.validated
+              ? `"${stateName}" validated live — reusing it`
+              : `"${stateName}" accepted (IndexedDB-only, validation deferred)`,
+          };
+        } else {
+          substeps[SUB_EXISTING] = {
+            ...substeps[SUB_EXISTING],
+            status: "done",
+            detail: `"${stateName}" session is stale — continuing`,
+          };
+        }
+      }
+    } else if (existing.defaultSetupInUse) {
+      substeps[SUB_EXISTING] = {
+        ...substeps[SUB_EXISTING],
+        status: "done",
+        detail:
+          "Repo default setup steps found (test/script) — they run before every test",
+      };
+    } else {
+      substeps[SUB_EXISTING] = {
+        ...substeps[SUB_EXISTING],
+        status: "done",
+        detail: "No setup tests, scripts, or storage states in this repo",
+      };
+    }
+    await updateSubsteps(sessionId, "qa_login", substeps);
+    if (await isStopped(sessionId, signal)) return false;
+
+    // Discover the app's real login/signup links once (DOM only, no guessing) —
+    // both the credential test and registration need them.
+    if (
+      !auth &&
+      cdpUrl &&
+      (credentials || (allowRegistration && !existing.defaultSetupInUse))
+    ) {
+      authLinks = await findAuthLinksOnEb(cdpUrl, targetUrl);
+    }
+
+    // 2) User-provided credentials — verify with a real login and capture the
+    //    session so discovery and generated tests start authenticated.
+    if (!auth && credentials && cdpUrl) {
+      substeps[SUB_CREDS] = { ...substeps[SUB_CREDS], status: "running" };
+      await updateSubsteps(sessionId, "qa_login", substeps);
+      const login = await loginWithCredsOnEb({
+        cdpUrl,
+        targetUrl,
+        loginUrl: authLinks.loginUrl,
+        credentials,
+      });
+      if (login.ok && login.storageStateJson) {
+        const persisted = await queries.createStorageState({
+          repositoryId,
+          name: `QA agent login ${utcStamp()}`,
+          storageStateJson: login.storageStateJson,
+        });
+        const setupTestId = await upsertQaLoginSetupTest(repositoryId, {
+          email: credentials.email,
+          password: credentials.password,
+          loginUrl: authLinks.loginUrl ?? targetUrl,
+        });
+        auth = {
+          strategy: "user_creds",
+          validated: true,
+          storageStateId: persisted.id,
+          setupTestId,
+          defaultSetupInUse: existing.defaultSetupInUse,
+          loginUrl: authLinks.loginUrl,
+        };
+        substeps[SUB_CREDS] = {
+          ...substeps[SUB_CREDS],
+          status: "done",
+          detail: "Logged in — session captured for reuse",
+        };
+      } else {
+        substeps[SUB_CREDS] = {
+          ...substeps[SUB_CREDS],
+          status: "error",
+          detail: `Could not verify credentials${login.detail ? ` — ${login.detail}` : ""}; discovery will retry inline`,
+        };
+      }
+    } else {
+      substeps[SUB_CREDS] = {
+        ...substeps[SUB_CREDS],
+        status: "done",
+        detail: auth
+          ? "Not needed"
+          : credentials
+            ? "No browser available — credentials will be tested during discovery"
+            : "No credentials provided",
+      };
+    }
+    await updateSubsteps(sessionId, "qa_login", substeps);
+    if (await isStopped(sessionId, signal)) return false;
+
+    // 3) Agent self-registration (opt-out). Signup URL strictly from the DOM;
+    //    skipped when the user gave creds or the repo already has setup steps.
+    const canRegister =
+      !auth && !credentials && allowRegistration && !existing.defaultSetupInUse;
+    if (canRegister && authLinks.signupUrl) {
+      substeps[SUB_REGISTER] = { ...substeps[SUB_REGISTER], status: "running" };
+      await updateSubsteps(sessionId, "qa_login", substeps);
+      // captureStorageState runs the signup in its own disposable runner/EB
+      // (1-job-1-EB) — release ours before it claims.
+      if (runnerId) {
+        await mergeMetadata(sessionId, { streamUrl: undefined }).catch(
+          () => {},
+        );
+        await releasePoolEB(runnerId).catch(() => {});
+        runnerId = undefined;
+        cdpUrl = undefined;
+      }
+      const repo = await queries.getRepository(repositoryId);
+      const team = await queries.getTeam(teamId).catch(() => undefined);
+      const stamp = utcStamp();
+      const slug = slugify(repo?.name ?? "qa-agent");
+      const template =
+        team?.quickstartEmailTemplate ?? "viktor+{slug}{stamp}@lastest.cloud";
+      const email = renderQuickstartEmail(template, slug, stamp);
+      const password = renderQuickstartPassword(stamp);
+      const code = renderAuthSetupCode({
+        email,
+        password,
+        registerUrl: authLinks.signupUrl,
+      });
+      const setupTest = await queries.createTest({
+        repositoryId,
+        name: `QA agent — auth signup ${stamp}`,
+        code,
+      });
+      const captured = await captureStorageState({
+        repositoryId,
+        baseUrl: targetUrl,
+        testCode: code,
+        name: `QA agent signup ${slug} ${stamp}`,
+      });
+      if (captured.captured && captured.storageStateId) {
+        // Store the fresh account like user creds so credentialsFrom() and the
+        // generator fallback keep working; encrypted at rest by the query layer.
+        await mergeMetadata(sessionId, {
+          quickstartEmail: email,
+          quickstartPassword: password,
+          credsProvided: true,
+        });
+        auth = {
+          strategy: "self_registered",
+          validated: true,
+          storageStateId: captured.storageStateId,
+          setupTestId: setupTest.id,
+          registeredEmail: email,
+          signupUrl: authLinks.signupUrl,
+        };
+        substeps[SUB_REGISTER] = {
+          ...substeps[SUB_REGISTER],
+          status: "done",
+          detail: `Registered ${email} — session captured`,
+        };
+      } else {
+        substeps[SUB_REGISTER] = {
+          ...substeps[SUB_REGISTER],
+          status: "error",
+          detail: captured.failureReason ?? "signup did not complete",
+        };
+      }
+    } else {
+      substeps[SUB_REGISTER] = {
+        ...substeps[SUB_REGISTER],
+        status: "done",
+        detail: auth
+          ? "Not needed"
+          : credentials
+            ? "Skipped — credentials were provided"
+            : !allowRegistration
+              ? "Disabled for this run"
+              : existing.defaultSetupInUse
+                ? "Skipped — repo default setup already covers auth"
+                : "No sign-up link found in the app's DOM",
+      };
+    }
+    await updateSubsteps(sessionId, "qa_login", substeps);
+    if (await isStopped(sessionId, signal)) return false;
+
+    // 4) Fallback — never fails the pipeline.
+    if (!auth) {
+      if (existing.defaultSetupInUse) {
+        auth = {
+          strategy: "existing_setup",
+          validated: false,
+          setupTestId: existing.setupTestId,
+          defaultSetupInUse: true,
+          notes:
+            "Repo default setup steps run before every test — validated at execution",
+        };
+      } else if (credentials) {
+        auth = {
+          strategy: "creds_untested",
+          validated: false,
+          notes: "Credentials will be tested inline during discovery",
+        };
+      } else {
+        auth = { strategy: "public_only", validated: false };
+      }
+    }
+    auth.loginUrl = auth.loginUrl ?? authLinks.loginUrl;
+    auth.signupUrl = auth.signupUrl ?? authLinks.signupUrl;
+
+    const strategyLabel: Record<QaAuthState["strategy"], string> = {
+      existing_setup: "reusing existing setup",
+      user_creds: "credentials verified",
+      self_registered: "account registered by the agent",
+      creds_untested: "credentials untested — discovery will try them",
+      public_only: "public surface only",
+    };
+    substeps[SUB_RESOLVE] = {
+      ...substeps[SUB_RESOLVE],
+      status: "done",
+      detail: strategyLabel[auth.strategy],
+    };
+    await updateSubsteps(sessionId, "qa_login", substeps);
+
+    await mergeMetadata(sessionId, {
+      qaAuth: auth,
+      authMode: auth.strategy === "public_only" ? "public_only" : "login",
+    });
+    await setStepCompleted(sessionId, "qa_login", {
+      strategy: auth.strategy,
+      validated: auth.validated,
+      ...(auth.storageStateId ? { storageStateId: auth.storageStateId } : {}),
+    });
+    emitActivity(
+      teamId,
+      repositoryId,
+      sessionId,
+      "step:complete",
+      `Login resolved: ${strategyLabel[auth.strategy]}`,
+      { stepId: "qa_login", agentType: "orchestrator" },
+    );
+    return true;
+  } finally {
+    await mergeMetadata(sessionId, { streamUrl: undefined }).catch(() => {});
+    if (runnerId) await releasePoolEB(runnerId).catch(() => {});
+  }
+}
+
 // ── Step: qa_discover ────────────────────────────────────────────────────────
 
 async function runQaDiscover(
@@ -508,10 +926,34 @@ async function runQaDiscover(
         queuedForBrowser: false,
         streamUrl: proxiedStream(eb.streamUrl),
       });
-      const credentials = credentialsFrom(session.metadata);
+
+      // Start the crawl from the post-login state when qa_login resolved a
+      // storage state; otherwise fall back to the inline first-page login
+      // ("creds tested during discovery"). Unresolved auth also prioritizes
+      // login/signup links so the auth surface itself gets mapped.
+      const qaAuth = session.metadata.qaAuth;
+      let preAuthed = false;
+      if (qaAuth?.storageStateId) {
+        const state = await queries
+          .getStorageState(qaAuth.storageStateId)
+          .catch(() => null);
+        if (state?.storageStateJson) {
+          preAuthed = await injectStorageStateIntoEb(
+            eb.cdpUrl,
+            state.storageStateJson,
+          );
+        }
+      }
+      const credentials = preAuthed
+        ? undefined
+        : credentialsFrom(session.metadata);
       crawled = await crawlTargetApp(eb.cdpUrl, targetUrl, {
         maxPages: MAX_CRAWL_PAGES,
         credentials,
+        prioritizeAuthLinks:
+          !qaAuth ||
+          qaAuth.strategy === "public_only" ||
+          qaAuth.strategy === "creds_untested",
         signal,
         onPage: (snapshot, index) => {
           substeps[1] = {
@@ -534,10 +976,38 @@ async function runQaDiscover(
         status: crawled.pages.length > 0 ? "done" : "error",
         detail:
           crawled.pages.length > 0
-            ? `${crawled.pages.length} pages, ${crawled.pages.reduce((n, p) => n + p.apiEndpoints.length, 0)} API calls observed${crawled.loginAttempted ? ", logged in" : ""}`
+            ? `${crawled.pages.length} pages, ${crawled.pages.reduce((n, p) => n + p.apiEndpoints.length, 0)} API calls observed${preAuthed ? ", pre-authenticated" : crawled.loginAttempted ? ", logged in" : ""}`
             : "No pages could be mapped",
       };
       await updateSubsteps(sessionId, "qa_discover", substeps);
+
+      // Post-crawl auth bookkeeping while we still hold the EB: upgrade a
+      // creds_untested resolution whose inline login worked (capture the
+      // session for generation), and settle deferred validation.
+      if (
+        qaAuth &&
+        ((qaAuth.strategy === "creds_untested" && crawled.loginAttempted) ||
+          (preAuthed && !qaAuth.validated))
+      ) {
+        const probe = await probeAndCaptureOnEb(eb.cdpUrl, targetUrl);
+        if (probe.authed) {
+          let upgraded = { ...qaAuth, validated: true };
+          if (qaAuth.strategy === "creds_untested" && probe.storageStateJson) {
+            const persisted = await queries.createStorageState({
+              repositoryId,
+              name: `QA agent login ${utcStamp()}`,
+              storageStateJson: probe.storageStateJson,
+            });
+            upgraded = {
+              ...upgraded,
+              strategy: "user_creds",
+              storageStateId: persisted.id,
+              notes: "Credentials verified during discovery",
+            };
+          }
+          await mergeMetadata(sessionId, { qaAuth: upgraded });
+        }
+      }
     }
   } catch (err) {
     substeps[1] = {
@@ -797,6 +1267,25 @@ async function runQaGenerate(
     return false;
   }
   const credentials = credentialsFrom(session.metadata);
+  // Auth resolved by qa_login: a storage state (or repo default setup) means
+  // generated tests start pre-authenticated via setup steps instead of
+  // scripting their own login with prompt-injected credentials.
+  const qaAuth = session.metadata.qaAuth;
+  const preAuthenticated = Boolean(
+    qaAuth?.storageStateId || qaAuth?.defaultSetupInUse,
+  );
+  const authSetupOverrides: TestSetupOverrides | undefined =
+    qaAuth?.storageStateId && !qaAuth.defaultSetupInUse
+      ? {
+          skippedDefaultStepIds: [],
+          extraSteps: [
+            {
+              stepType: "storage_state",
+              storageStateId: qaAuth.storageStateId,
+            },
+          ],
+        }
+      : undefined;
   const items = enabledPlanItems(plan);
   // Resume-safe: skip items that already produced a test in a prior attempt.
   const ledger: QaGeneratedTest[] = [
@@ -964,6 +1453,17 @@ async function runQaGenerate(
         streamUrl: proxiedStream(eb.streamUrl),
       });
 
+      // Pre-authenticate the generation EB too, so the generator verifies
+      // selectors against the same post-login state the tests will run in.
+      if (qaAuth?.storageStateId) {
+        const state = await queries
+          .getStorageState(qaAuth.storageStateId)
+          .catch(() => null);
+        if (state?.storageStateJson) {
+          await injectStorageStateIntoEb(eb.cdpUrl, state.storageStateJson);
+        }
+      }
+
       const { agentCreateTest } =
         await import("@/lib/playwright/generator-agent");
 
@@ -993,7 +1493,8 @@ async function runQaGenerate(
                 item,
                 plan,
                 targetUrl,
-                credentials,
+                credentials: preAuthenticated ? undefined : credentials,
+                auth: { preAuthenticated },
               }),
             },
             {
@@ -1009,6 +1510,11 @@ async function runQaGenerate(
               code: result.code,
               targetUrl,
               playwrightOverrides: itemPlaywrightOverrides(itemGroups(item)),
+              // Chain the captured login session; when repo defaults already
+              // cover auth this stays undefined (defaults apply to every test).
+              ...(authSetupOverrides
+                ? { setupOverrides: authSetupOverrides }
+                : {}),
               ...(qaBot ? { createdByBotId: qaBot.id } : {}),
             });
             substeps[subIdx] = {
@@ -1460,13 +1966,23 @@ const MODE_PIPELINES: Record<QaRunMode, AgentStepId[]> = {
   // reports which plan items the current suite already covers vs. the gaps.
   refresh_spec: [
     "qa_setup",
+    "qa_login",
     "qa_discover",
     "qa_plan",
     "qa_plan_review",
     "qa_summary",
   ],
-  // Reuse the latest plan/discovery; generate only uncovered items.
-  fill_gaps: ["qa_setup", "qa_generate", "qa_execute", "qa_heal", "qa_summary"],
+  // Reuse the latest plan/discovery; generate only uncovered items. qa_login
+  // still runs: generation/execution need auth context, and a prior capture
+  // may have expired — a still-valid one resolves in seconds via option (a).
+  fill_gaps: [
+    "qa_setup",
+    "qa_login",
+    "qa_generate",
+    "qa_execute",
+    "qa_heal",
+    "qa_summary",
+  ],
 };
 
 function buildStepsForMode(mode: QaRunMode): AgentStepState[] {
@@ -1504,6 +2020,9 @@ async function executeQaPipeline(
       switch (stepId) {
         case "qa_setup":
           ok = await runQaSetup(sessionId, teamId, repositoryId, signal);
+          break;
+        case "qa_login":
+          ok = await runQaLogin(sessionId, teamId, repositoryId, signal);
           break;
         case "qa_discover":
           ok = await runQaDiscover(sessionId, teamId, repositoryId, signal);
@@ -1558,6 +2077,9 @@ export interface StartQaAgentInput {
   email?: string;
   password?: string;
   autoApprove?: boolean;
+  /** Allow the qa_login step to self-register a throwaway account when no
+   *  creds/setup exist and a signup link is found in the DOM. Default true. */
+  allowRegistration?: boolean;
 }
 
 export async function startQaAgent(
@@ -1629,6 +2151,7 @@ export async function startQaAgent(
       qaMode: mode,
       qaGroups: normalizeQaGroups(input.groups),
       qaAutoApprove: Boolean(input.autoApprove),
+      qaAllowRegistration: input.allowRegistration ?? true,
       credsProvided,
       authMode: credsProvided ? "login" : "public_only",
       ...planSeed,

--- a/src/server/actions/qa-agent.ts
+++ b/src/server/actions/qa-agent.ts
@@ -26,8 +26,9 @@ import {
   buildPlannerUserPrompt,
   computeQaSummary,
   enabledPlanItems,
-  groupPlaywrightOverrides,
   isQaTestPlan,
+  itemGroups,
+  itemPlaywrightOverrides,
   matchPlanToExistingTests,
   normalizeQaGroups,
   sanitizeQaPlan,
@@ -43,6 +44,7 @@ import type {
   PwAgentType,
   QaDiscovery,
   QaGeneratedTest,
+  QaPlanItem,
   QaRunMode,
   QaTestGroup,
   QaTestPlan,
@@ -730,7 +732,7 @@ async function runQaPlan(
     byGroup: Object.fromEntries(
       QA_GROUPS.map((g) => [
         g.id,
-        sanitized.items.filter((i) => i.group === g.id).length,
+        sanitized.items.filter((i) => itemGroups(i).includes(g.id)).length,
       ]).filter(([, n]) => (n as number) > 0),
     ),
   });
@@ -819,6 +821,7 @@ async function runQaGenerate(
     ledger.push({
       planItemId: item.id,
       group: item.group,
+      groups: itemGroups(item),
       testId,
       name: item.title,
       status: "covered",
@@ -842,6 +845,8 @@ async function runQaGenerate(
 
   const groupLabel = (g: QaTestGroup) =>
     QA_GROUPS.find((m) => m.id === g)?.label ?? g;
+  const itemLabel = (item: QaPlanItem) =>
+    itemGroups(item).map(groupLabel).join(" + ");
 
   // Areas: one per group, flat, prefixed for recognizability in /tests.
   const areaIdByGroup = new Map<QaTestGroup, string>();
@@ -859,7 +864,7 @@ async function runQaGenerate(
 
   const substeps: NonNullable<AgentStepState["substeps"]> = pending.map(
     (item) => ({
-      label: `${groupLabel(item.group)}: ${item.title}`,
+      label: `${itemLabel(item)}: ${item.title}`,
       status: "pending",
       agent: "generator",
     }),
@@ -874,7 +879,9 @@ async function runQaGenerate(
   };
 
   // API items need no browser — build headless definitions directly.
-  const apiItems = pending.filter((i) => i.group === "api" && i.api);
+  const apiItems = pending.filter(
+    (i) => itemGroups(i).includes("api") && i.api,
+  );
   const browserItems = pending.filter((i) => !apiItems.includes(i));
 
   for (const item of apiItems) {
@@ -892,6 +899,7 @@ async function runQaGenerate(
       await upsertLedger({
         planItemId: item.id,
         group: item.group,
+        groups: itemGroups(item),
         name: item.title,
         status: "generation_failed",
         error: "Plan item had no API definition",
@@ -913,6 +921,7 @@ async function runQaGenerate(
     await upsertLedger({
       planItemId: item.id,
       group: item.group,
+      groups: itemGroups(item),
       testId: test.id,
       name: item.title,
       status: "generated",
@@ -969,7 +978,7 @@ async function runQaGenerate(
           repositoryId,
           sessionId,
           "substep:update",
-          `Generator working on "${item.title}" (${item.group})`,
+          `Generator working on "${item.title}" (${itemGroups(item).join(" + ")})`,
           { stepId: "qa_generate", agentType: "generator" },
         );
         try {
@@ -999,7 +1008,7 @@ async function runQaGenerate(
               name: item.title,
               code: result.code,
               targetUrl,
-              playwrightOverrides: groupPlaywrightOverrides(item.group),
+              playwrightOverrides: itemPlaywrightOverrides(itemGroups(item)),
               ...(qaBot ? { createdByBotId: qaBot.id } : {}),
             });
             substeps[subIdx] = {
@@ -1010,6 +1019,7 @@ async function runQaGenerate(
             await upsertLedger({
               planItemId: item.id,
               group: item.group,
+              groups: itemGroups(item),
               testId: test.id,
               name: item.title,
               status: "generated",
@@ -1019,7 +1029,7 @@ async function runQaGenerate(
               repositoryId,
               sessionId,
               "artifact:created",
-              `Generated test "${item.title}" (${item.group})`,
+              `Generated test "${item.title}" (${itemGroups(item).join(" + ")})`,
               {
                 stepId: "qa_generate",
                 agentType: "generator",
@@ -1040,6 +1050,7 @@ async function runQaGenerate(
             await upsertLedger({
               planItemId: item.id,
               group: item.group,
+              groups: itemGroups(item),
               name: item.title,
               status: "generation_failed",
               error: result.error,
@@ -1057,6 +1068,7 @@ async function runQaGenerate(
           await upsertLedger({
             planItemId: item.id,
             group: item.group,
+            groups: itemGroups(item),
             name: item.title,
             status: "generation_failed",
             error: msg,
@@ -1405,6 +1417,7 @@ async function runQaSummary(
       .map((i) => ({
         planItemId: i.id,
         group: i.group,
+        groups: itemGroups(i),
         testId: coveredBy.get(i.id),
         name: i.title,
         status: "covered" as const,

--- a/src/server/actions/qa-agent.ts
+++ b/src/server/actions/qa-agent.ts
@@ -73,6 +73,8 @@ import type {
   QaGeneratedTest,
   QaPlanItem,
   QaRunMode,
+  QaTask,
+  QaTaskSource,
   QaTestGroup,
   QaTestPlan,
   TestSetupOverrides,
@@ -2368,6 +2370,11 @@ async function executeQaPipeline(
     );
   } finally {
     activeControllers.delete(sessionId);
+    // Task-queue bookkeeping: if this session worked a queue task and ended
+    // terminally, write the agent's reply back and advance the queue.
+    await finalizeQaTaskAndDispatch(sessionId, teamId, repositoryId).catch(
+      (err) => console.error("[QaAgent] task finalize error:", err),
+    );
   }
 }
 
@@ -2471,6 +2478,7 @@ export async function startQaAgent(
       qaGroups: normalizeQaGroups(input.groups),
       qaAutoApprove: Boolean(input.autoApprove),
       qaAllowRegistration: input.allowRegistration ?? true,
+      qaTrigger: "manual",
       credsProvided,
       authMode: credsProvided ? "login" : "public_only",
       ...planSeed,
@@ -2604,32 +2612,27 @@ function parseUserJourneys(raw: string): string[] {
 const REFINER_TIMEOUT_MS = 3 * 60 * 1000;
 
 /**
- * Refine plain-language journeys the reviewer supplied at the plan gate into
- * structured, digest-grounded journeys + covering items, and MERGE them into
- * the current plan (existing items and the reviewer's enable/disable choices
- * are preserved — see mergeRefinedJourneys). The session STAYS paused at the
- * review gate showing the augmented plan; nothing advances until the reviewer
- * approves. Counters the "reduced context" quality gap by letting the human
- * inject the journeys the condensed digest lost.
+ * Refine plain-language journeys into structured, digest-grounded journeys +
+ * covering items and MERGE them into the session's current plan (existing
+ * items and enable/disable choices are preserved — see mergeRefinedJourneys).
+ * Shared by the reviewer's "add journeys" gate action and the task
+ * dispatcher (which merges a task directive into a fill-gaps run's plan).
  */
-export async function addQaUserJourneys(
-  sessionId: string,
-  journeysText: string,
+async function refineAndMergeJourneysIntoPlan(
+  session: AgentSession,
+  teamId: string,
+  journeys: string[],
 ): Promise<{
   success: boolean;
   addedJourneys?: number;
   addedItems?: number;
   error?: string;
 }> {
-  const { session, teamId } = await requireQaSession(sessionId);
+  const sessionId = session.id;
   const plan = session.metadata.qaPlan;
   const discovery = session.metadata.qaDiscovery;
   if (!plan || !discovery) {
     return { success: false, error: "No plan to add journeys to" };
-  }
-  const journeys = parseUserJourneys(journeysText);
-  if (journeys.length === 0) {
-    return { success: false, error: "No journeys were provided" };
   }
 
   const repositoryId = session.repositoryId;
@@ -2705,12 +2708,41 @@ export async function addQaUserJourneys(
     `Added ${merged.addedJourneys} journey${merged.addedJourneys === 1 ? "" : "s"} and ${merged.addedItems} test${merged.addedItems === 1 ? "" : "s"} from your input`,
     { stepId: "qa_plan_review", agentType: "planner" },
   );
-  revalidatePath("/qa-agent");
   return {
     success: true,
     addedJourneys: merged.addedJourneys,
     addedItems: merged.addedItems,
   };
+}
+
+/**
+ * Reviewer action at the plan gate: refine plain-language journeys and merge
+ * them into the plan. The session STAYS paused at the review gate showing the
+ * augmented plan; nothing advances until the reviewer approves. Counters the
+ * "reduced context" quality gap by letting the human inject the journeys the
+ * condensed digest lost.
+ */
+export async function addQaUserJourneys(
+  sessionId: string,
+  journeysText: string,
+): Promise<{
+  success: boolean;
+  addedJourneys?: number;
+  addedItems?: number;
+  error?: string;
+}> {
+  const { session, teamId } = await requireQaSession(sessionId);
+  const journeys = parseUserJourneys(journeysText);
+  if (journeys.length === 0) {
+    return { success: false, error: "No journeys were provided" };
+  }
+  const result = await refineAndMergeJourneysIntoPlan(
+    session,
+    teamId,
+    journeys,
+  );
+  if (result.success) revalidatePath("/qa-agent");
+  return result;
 }
 
 export async function pauseQaAgent(
@@ -2762,4 +2794,454 @@ export async function cancelQaAgent(
   );
   revalidatePath("/qa-agent");
   return { success: true };
+}
+
+/** Re-run a prior session with its stored configuration (target URL, mode,
+ *  groups, credentials, docs digest). Powers the run-history "Re-run" action —
+ *  credentials stay server-side (copied between encrypted metadata records). */
+export async function rerunQaSession(
+  sourceSessionId: string,
+): Promise<{ sessionId: string }> {
+  const { session: source, teamId } = await requireQaSession(sourceSessionId);
+  const m = source.metadata;
+  const targetUrl = m.qaTargetUrl;
+  if (!targetUrl) {
+    throw new Error("This run has no stored target URL to re-run against");
+  }
+  try {
+    await assertSafeOutboundUrl(targetUrl);
+  } catch (err) {
+    if (err instanceof SsrfBlockedError) {
+      throw new Error(`URL rejected: ${err.message}`);
+    }
+    throw err;
+  }
+
+  // One active QA session per repo — cancel a running one before starting.
+  const existing = await queries.getActiveAgentSession(
+    source.repositoryId,
+    "qa",
+  );
+  if (existing) {
+    activeControllers.get(existing.id)?.abort();
+    await queries.updateAgentSession(existing.id, {
+      status: "cancelled",
+      completedAt: new Date(),
+    });
+  }
+
+  const mode: QaRunMode = m.qaMode ?? "full";
+  let planSeed: Partial<AgentSessionMetadata> = {};
+  if (mode === "fill_gaps") {
+    if (!m.qaPlan) {
+      throw new Error("The original fill-gaps run has no stored plan");
+    }
+    planSeed = {
+      qaPlan: m.qaPlan,
+      qaDiscovery: m.qaDiscovery,
+      qaPlanSourceSessionId: source.id,
+    };
+  }
+
+  const session = await queries.createAgentSession({
+    repositoryId: source.repositoryId,
+    teamId,
+    kind: "qa",
+    status: "active",
+    currentStepId: "qa_setup",
+    steps: buildStepsForMode(mode),
+    metadata: {
+      qaTargetUrl: targetUrl,
+      qaMode: mode,
+      qaGroups: normalizeQaGroups(m.qaGroups ?? QA_GROUPS.map((g) => g.id)),
+      qaAutoApprove: Boolean(m.qaAutoApprove),
+      qaAllowRegistration: m.qaAllowRegistration ?? true,
+      credsProvided: Boolean(m.credsProvided),
+      authMode: m.credsProvided ? "login" : "public_only",
+      ...(m.credsProvided
+        ? {
+            quickstartEmail: m.quickstartEmail,
+            quickstartPassword: m.quickstartPassword,
+          }
+        : {}),
+      ...(m.qaDocsDigest
+        ? { qaDocs: m.qaDocs, qaDocsDigest: m.qaDocsDigest }
+        : {}),
+      ...planSeed,
+      qaTrigger: "rerun",
+    },
+  });
+
+  emitActivity(
+    teamId,
+    source.repositoryId,
+    session.id,
+    "session:start",
+    `QA agent re-run on ${targetUrl} (${mode.replace("_", " ")})`,
+  );
+  executeQaPipeline(session.id, teamId, source.repositoryId, "qa_setup").catch(
+    (err) => console.error("[QaAgent] unhandled:", err),
+  );
+  revalidatePath("/qa-agent");
+  return { sessionId: session.id };
+}
+
+// ── Direction queue (qa_tasks) ───────────────────────────────────────────────
+//
+// The team (and later, external agents via MCP) drops directives into a queue;
+// whenever no QA session is active the dispatcher claims the oldest queued
+// task, selects the protocol (fill-gaps against the stored plan when one
+// exists, else a full run with the directive fed to the planner), runs it with
+// the review gate auto-approved, and writes the agent's reply back onto the
+// task card.
+
+const TERMINAL_SESSION_STATUSES: AgentSession["status"][] = [
+  "completed",
+  "failed",
+  "cancelled",
+];
+
+const MAX_TASK_TITLE = 200;
+const MAX_TASK_DESCRIPTION = 2000;
+
+/** The agent's reply for a completed task run — the card's "done" comment. */
+function buildTaskReply(session: AgentSession): string {
+  const s = session.metadata.qaSummary;
+  if (!s) return "Run completed. Coverage dashboard updated.";
+  const genFailed = (session.metadata.qaGeneratedTests ?? []).filter(
+    (t) => t.status === "generation_failed",
+  ).length;
+  const parts = [
+    `planned ${s.planned}`,
+    `${s.covered} already covered`,
+    `${s.generated} generated`,
+    `${s.passed} passing`,
+  ];
+  if (s.healed > 0) parts.push(`${s.healed} healed`);
+  if (s.failed > 0) parts.push(`${s.failed} still failing`);
+  if (genFailed > 0) parts.push(`${genFailed} could not be generated`);
+  return `Done — ${parts.join(", ")}. Coverage dashboard updated.`;
+}
+
+/** Write a terminal session's outcome back onto its task card. */
+async function finalizeTask(
+  task: QaTask,
+  session: AgentSession | null,
+  teamId: string,
+  repositoryId: string,
+): Promise<void> {
+  if (session?.status === "completed") {
+    await queries.updateQaTask(task.id, {
+      status: "done",
+      agentReply: buildTaskReply(session),
+      completedAt: new Date(),
+    });
+    emitActivity(
+      teamId,
+      repositoryId,
+      session.id,
+      "task:completed",
+      `Task done: ${task.title}`,
+    );
+    return;
+  }
+  const failedStep = session?.steps.find((s) => s.status === "failed");
+  const reply = !session
+    ? "The session working this task is gone (server restart?). Retry to requeue it."
+    : session.status === "cancelled"
+      ? "The run was cancelled before this task finished. Retry to requeue it."
+      : `The run failed at ${failedStep?.label ?? "an unexpected point"}${
+          failedStep?.error ? `: ${failedStep.error}` : ""
+        }. Retry to requeue it.`;
+  await queries.updateQaTask(task.id, {
+    status: "needs_input",
+    agentReply: reply,
+    completedAt: new Date(),
+  });
+  emitActivity(
+    teamId,
+    repositoryId,
+    session?.id ?? task.id,
+    "task:failed",
+    `Task needs input: ${task.title}`,
+  );
+}
+
+/** Pipeline epilogue: settle the session's task (if any), then advance the
+ *  queue. Safe to call for non-task sessions — dispatch no-ops while any QA
+ *  session is active or paused. */
+async function finalizeQaTaskAndDispatch(
+  sessionId: string,
+  teamId: string,
+  repositoryId: string,
+): Promise<void> {
+  const session = await queries.getAgentSession(sessionId);
+  if (!session || !TERMINAL_SESSION_STATUSES.includes(session.status)) return;
+  const taskId = session.metadata.qaTaskId;
+  if (taskId) {
+    const task = await queries.getQaTask(taskId);
+    if (task && task.status === "working" && task.sessionId === sessionId) {
+      await finalizeTask(task, session, teamId, repositoryId);
+    }
+  }
+  await dispatchNextQaTask(teamId, repositoryId);
+}
+
+// Per-repo dispatch lock — poll-triggered kicks and pipeline epilogues can
+// race; only one claim may run at a time (in-process, same as the controller
+// registry).
+const dispatchingRepos = new Set<string>();
+
+/** Claim the oldest queued task and run a task-scoped session for it. */
+async function dispatchNextQaTask(
+  teamId: string,
+  repositoryId: string,
+): Promise<void> {
+  if (dispatchingRepos.has(repositoryId)) return;
+  dispatchingRepos.add(repositoryId);
+  try {
+    // One QA session per repo — an active/paused session owns the agent.
+    const active = await queries.getActiveAgentSession(repositoryId, "qa");
+    if (active) return;
+    const task = await queries.getNextQueuedQaTask(repositoryId);
+    if (!task) return;
+
+    const recent = await queries.getRecentAgentSessions(repositoryId, "qa", 10);
+    const planSource = recent.find((s) => s.metadata.qaPlan);
+    const targetUrl =
+      planSource?.metadata.qaTargetUrl ??
+      recent.find((s) => s.metadata.qaTargetUrl)?.metadata.qaTargetUrl;
+    if (!targetUrl) {
+      await queries.updateQaTask(task.id, {
+        status: "needs_input",
+        agentReply:
+          "I don't have a target URL yet — start one QA run from the form first, then retry this task.",
+        completedAt: new Date(),
+      });
+      emitActivity(
+        teamId,
+        repositoryId,
+        task.id,
+        "task:failed",
+        `Task needs input: ${task.title}`,
+      );
+      return;
+    }
+
+    // Protocol selection: with a stored plan the task becomes a targeted
+    // fill-gaps run (directive merged into the plan below); without one it's
+    // a full run with the directive fed straight to the planner.
+    const mode: QaRunMode = planSource ? "fill_gaps" : "full";
+    const directive = [task.title, task.description ?? ""]
+      .filter(Boolean)
+      .join("\n");
+    const credSession = recent.find((s) => credentialsFrom(s.metadata));
+    const creds = credSession
+      ? credentialsFrom(credSession.metadata)
+      : undefined;
+
+    const session = await queries.createAgentSession({
+      repositoryId,
+      teamId,
+      kind: "qa",
+      status: "active",
+      currentStepId: "qa_setup",
+      steps: buildStepsForMode(mode),
+      metadata: {
+        qaTargetUrl: targetUrl,
+        qaMode: mode,
+        qaGroups: normalizeQaGroups(
+          planSource?.metadata.qaGroups ?? QA_GROUPS.map((g) => g.id),
+        ),
+        // Queue runs are autonomous — no human at the review gate.
+        qaAutoApprove: true,
+        qaAllowRegistration: planSource?.metadata.qaAllowRegistration ?? true,
+        credsProvided: Boolean(creds),
+        authMode: creds ? "login" : "public_only",
+        ...(creds
+          ? {
+              quickstartEmail: creds.email,
+              quickstartPassword: creds.password,
+            }
+          : {}),
+        ...(planSource
+          ? {
+              qaPlan: planSource.metadata.qaPlan,
+              qaDiscovery: planSource.metadata.qaDiscovery,
+              qaPlanSourceSessionId: planSource.id,
+            }
+          : {
+              qaPlannerFeedback: `Directive from the team's task queue — the plan must cover it:\n${directive}`,
+            }),
+        qaTaskId: task.id,
+        qaTrigger: "task",
+      },
+    });
+
+    await queries.updateQaTask(task.id, {
+      status: "working",
+      sessionId: session.id,
+      startedAt: new Date(),
+    });
+    emitActivity(
+      teamId,
+      repositoryId,
+      session.id,
+      "task:started",
+      `QA agent picked up task: ${task.title}`,
+    );
+
+    // Merge the directive into the reused plan so fill-gaps generates the
+    // asked-for work, not just leftover gaps. Best-effort: plain fill-gaps IS
+    // the protocol for coverage_gap tasks, and still runs if the refiner fails.
+    if (mode === "fill_gaps" && task.source !== "coverage_gap") {
+      const fresh = await queries.getAgentSession(session.id);
+      if (fresh) {
+        const merged = await refineAndMergeJourneysIntoPlan(
+          fresh,
+          teamId,
+          parseUserJourneys(directive),
+        );
+        if (!merged.success) {
+          console.warn(
+            "[QaAgent] task directive merge failed:",
+            merged.error ?? "unknown",
+          );
+        }
+      }
+    }
+
+    executeQaPipeline(session.id, teamId, repositoryId, "qa_setup").catch(
+      (err) => console.error("[QaAgent] unhandled:", err),
+    );
+  } finally {
+    dispatchingRepos.delete(repositoryId);
+  }
+}
+
+async function requireQaTask(
+  taskId: string,
+): Promise<{ task: QaTask; teamId: string }> {
+  const { team } = await requireTeamAccess();
+  const task = await queries.getQaTask(taskId);
+  if (!task || task.teamId !== team.id) {
+    throw new Error("Task not found");
+  }
+  return { task, teamId: team.id };
+}
+
+/** Drop a directive into the QA agent's queue. The dispatcher picks it up as
+ *  soon as no session is running. */
+export async function addQaTask(input: {
+  repositoryId: string;
+  title: string;
+  description?: string;
+  source?: Extract<QaTaskSource, "user" | "coverage_gap">;
+}): Promise<{ taskId: string }> {
+  const { team, user } = await requireRepoAccess(input.repositoryId);
+  const title = input.title.trim().slice(0, MAX_TASK_TITLE);
+  if (!title) throw new Error("The task needs a title");
+  const task = await queries.createQaTask({
+    repositoryId: input.repositoryId,
+    teamId: team.id,
+    title,
+    description:
+      input.description?.trim().slice(0, MAX_TASK_DESCRIPTION) || null,
+    source: input.source ?? "user",
+    createdById: user.id,
+    createdByName: user.name || user.email || null,
+  });
+  emitActivity(
+    team.id,
+    input.repositoryId,
+    task.id,
+    "task:created",
+    `Task queued for the QA agent: ${title}`,
+  );
+  // Fire-and-forget: pickup can involve an AI refine call — don't block the
+  // composer on it.
+  dispatchNextQaTask(team.id, input.repositoryId).catch((err) =>
+    console.error("[QaAgent] dispatch error:", err),
+  );
+  revalidatePath("/qa-agent");
+  return { taskId: task.id };
+}
+
+/** Requeue a needs_input/cancelled task. */
+export async function retryQaTask(
+  taskId: string,
+): Promise<{ success: boolean }> {
+  const { task, teamId } = await requireQaTask(taskId);
+  if (task.status !== "needs_input" && task.status !== "cancelled") {
+    return { success: false };
+  }
+  await queries.updateQaTask(taskId, {
+    status: "queued",
+    sessionId: null,
+    agentReply: null,
+    startedAt: null,
+    completedAt: null,
+  });
+  dispatchNextQaTask(teamId, task.repositoryId).catch((err) =>
+    console.error("[QaAgent] dispatch error:", err),
+  );
+  revalidatePath("/qa-agent");
+  return { success: true };
+}
+
+/** Cancel a task; a working task's session is cancelled with it. */
+export async function dropQaTask(
+  taskId: string,
+): Promise<{ success: boolean }> {
+  const { task, teamId } = await requireQaTask(taskId);
+  if (task.status === "done" || task.status === "cancelled") {
+    return { success: false };
+  }
+  if (task.status === "working" && task.sessionId) {
+    activeControllers.get(task.sessionId)?.abort();
+    await queries.updateAgentSession(task.sessionId, {
+      status: "cancelled",
+      completedAt: new Date(),
+    });
+  }
+  await queries.updateQaTask(taskId, {
+    status: "cancelled",
+    completedAt: new Date(),
+  });
+  emitActivity(
+    teamId,
+    task.repositoryId,
+    task.sessionId ?? task.id,
+    "task:failed",
+    `Task cancelled: ${task.title}`,
+  );
+  revalidatePath("/qa-agent");
+  return { success: true };
+}
+
+/** Board state for the client. Also does lazy reconciliation: a "working"
+ *  task whose session ended without the in-process finalizer (server restart)
+ *  is settled here, and an orphaned queue gets the dispatcher kicked. */
+export async function listQaTasks(repositoryId: string): Promise<QaTask[]> {
+  const { team } = await requireRepoAccess(repositoryId);
+  let tasks = await queries.getQaTasksByRepo(repositoryId);
+
+  let changed = false;
+  for (const task of tasks) {
+    if (task.status !== "working" || !task.sessionId) continue;
+    const session = await queries.getAgentSession(task.sessionId);
+    if (!session || TERMINAL_SESSION_STATUSES.includes(session.status)) {
+      await finalizeTask(task, session ?? null, team.id, repositoryId);
+      changed = true;
+    }
+  }
+  if (changed) tasks = await queries.getQaTasksByRepo(repositoryId);
+
+  if (
+    tasks.some((t) => t.status === "queued") &&
+    !tasks.some((t) => t.status === "working")
+  ) {
+    dispatchNextQaTask(team.id, repositoryId).catch(() => {});
+  }
+  return tasks;
 }

--- a/src/server/actions/qa-agent.ts
+++ b/src/server/actions/qa-agent.ts
@@ -1180,7 +1180,20 @@ async function runQaPlan(
     return false;
   }
   const groups = normalizeQaGroups(session.metadata.qaGroups ?? []);
-  const credsProvided = Boolean(session.metadata.credsProvided);
+  // Whether the plan should target the authenticated in-app surface. This is
+  // auth AVAILABILITY, not "plaintext credentials were typed": qa_login may
+  // resolve auth via a captured/existing storage state or repo default setup
+  // (existing_setup / registered / creds verified), in which case the crawl
+  // ran signed-in and generated tests start authenticated too. Mirrors the
+  // `preAuthenticated` calc in runQaPlanReview. Using credsProvided alone here
+  // wrongly told the planner "public surface only" on storage-state runs, so it
+  // discarded the whole authed digest and planned only login pages.
+  const qaAuth = session.metadata.qaAuth;
+  const authenticated = Boolean(
+    session.metadata.credsProvided ||
+    qaAuth?.storageStateId ||
+    qaAuth?.defaultSetupInUse,
+  );
   const feedback = session.metadata.qaPlannerFeedback;
 
   const substeps: NonNullable<AgentStepState["substeps"]> = [
@@ -1223,7 +1236,7 @@ async function runQaPlan(
       buildPlannerUserPrompt({
         digest,
         groups,
-        credsProvided,
+        authenticated,
         existingCoverage,
         feedback:
           [feedback, extraFeedback].filter(Boolean).join("\n") || undefined,

--- a/src/server/actions/qa-agent.ts
+++ b/src/server/actions/qa-agent.ts
@@ -3,7 +3,11 @@
 import { revalidatePath } from "next/cache";
 import * as queries from "@/lib/db/queries";
 import { requireRepoAccess, requireTeamAccess } from "@/lib/auth";
-import { assertQaAgentAccess } from "@/lib/billing/feature-access";
+import {
+  assertQaAgentAccess,
+  hasQaAgentAccess,
+} from "@/lib/billing/feature-access";
+import { getNextRunTime, isValidCron } from "@/lib/scheduling/cron";
 import {
   assertSafeOutboundUrl,
   SsrfBlockedError,
@@ -74,6 +78,7 @@ import type {
   QaGeneratedTest,
   QaPlanItem,
   QaRunMode,
+  QaSessionTrigger,
   QaTask,
   QaTaskSource,
   QaTestGroup,
@@ -2995,6 +3000,39 @@ async function finalizeQaTaskAndDispatch(
 // registry).
 const dispatchingRepos = new Set<string>();
 
+/** Everything an autonomous run borrows from run history: target URL (env
+ *  config fallback), stored plan/discovery, groups, and credentials. Shared by
+ *  the task dispatcher and the schedule/PR/MCP trigger starts. */
+async function resolveQaRunSeed(repositoryId: string): Promise<{
+  targetUrl: string | undefined;
+  planSource: AgentSession | undefined;
+  groups: QaTestGroup[];
+  creds: { email: string; password: string } | undefined;
+  allowRegistration: boolean;
+}> {
+  const recent = await queries.getRecentAgentSessions(repositoryId, "qa", 10);
+  const planSource = recent.find((s) => s.metadata.qaPlan);
+  let targetUrl =
+    planSource?.metadata.qaTargetUrl ??
+    recent.find((s) => s.metadata.qaTargetUrl)?.metadata.qaTargetUrl;
+  if (!targetUrl) {
+    const env = await queries
+      .getEnvironmentConfig(repositoryId)
+      .catch(() => null);
+    targetUrl = env?.baseUrl || undefined;
+  }
+  const credSession = recent.find((s) => credentialsFrom(s.metadata));
+  return {
+    targetUrl,
+    planSource,
+    groups: normalizeQaGroups(
+      planSource?.metadata.qaGroups ?? QA_GROUPS.map((g) => g.id),
+    ),
+    creds: credSession ? credentialsFrom(credSession.metadata) : undefined,
+    allowRegistration: planSource?.metadata.qaAllowRegistration ?? true,
+  };
+}
+
 /** Claim the oldest queued task and run a task-scoped session for it. */
 async function dispatchNextQaTask(
   teamId: string,
@@ -3009,11 +3047,8 @@ async function dispatchNextQaTask(
     const task = await queries.getNextQueuedQaTask(repositoryId);
     if (!task) return;
 
-    const recent = await queries.getRecentAgentSessions(repositoryId, "qa", 10);
-    const planSource = recent.find((s) => s.metadata.qaPlan);
-    const targetUrl =
-      planSource?.metadata.qaTargetUrl ??
-      recent.find((s) => s.metadata.qaTargetUrl)?.metadata.qaTargetUrl;
+    const { targetUrl, planSource, groups, creds, allowRegistration } =
+      await resolveQaRunSeed(repositoryId);
     if (!targetUrl) {
       await queries.updateQaTask(task.id, {
         status: "needs_input",
@@ -3038,10 +3073,6 @@ async function dispatchNextQaTask(
     const directive = [task.title, task.description ?? ""]
       .filter(Boolean)
       .join("\n");
-    const credSession = recent.find((s) => credentialsFrom(s.metadata));
-    const creds = credSession
-      ? credentialsFrom(credSession.metadata)
-      : undefined;
 
     const session = await queries.createAgentSession({
       repositoryId,
@@ -3053,12 +3084,10 @@ async function dispatchNextQaTask(
       metadata: {
         qaTargetUrl: targetUrl,
         qaMode: mode,
-        qaGroups: normalizeQaGroups(
-          planSource?.metadata.qaGroups ?? QA_GROUPS.map((g) => g.id),
-        ),
+        qaGroups: groups,
         // Queue runs are autonomous — no human at the review gate.
         qaAutoApprove: true,
-        qaAllowRegistration: planSource?.metadata.qaAllowRegistration ?? true,
+        qaAllowRegistration: allowRegistration,
         credsProvided: Boolean(creds),
         authMode: creds ? "login" : "public_only",
         ...(creds
@@ -3140,12 +3169,15 @@ export async function addQaTask(input: {
   repositoryId: string;
   title: string;
   description?: string;
-  source?: Extract<QaTaskSource, "user" | "coverage_gap">;
+  /** "mcp" is passed by the v1 API when an external agent files the task —
+   *  the board renders it with a distinct actor chip. */
+  source?: QaTaskSource;
 }): Promise<{ taskId: string }> {
   const { team, user } = await requireRepoAccess(input.repositoryId);
   assertQaAgentAccess(team.plan);
   const title = input.title.trim().slice(0, MAX_TASK_TITLE);
   if (!title) throw new Error("The task needs a title");
+  const actorName = user.name || user.email || null;
   const task = await queries.createQaTask({
     repositoryId: input.repositoryId,
     teamId: team.id,
@@ -3154,7 +3186,8 @@ export async function addQaTask(input: {
       input.description?.trim().slice(0, MAX_TASK_DESCRIPTION) || null,
     source: input.source ?? "user",
     createdById: user.id,
-    createdByName: user.name || user.email || null,
+    createdByName:
+      input.source === "mcp" && actorName ? `${actorName} · MCP` : actorName,
   });
   emitActivity(
     team.id,
@@ -3249,4 +3282,181 @@ export async function listQaTasks(repositoryId: string): Promise<QaTask[]> {
     dispatchNextQaTask(team.id, repositoryId).catch(() => {});
   }
   return tasks;
+}
+
+// ── Automation triggers (schedule / PR / MCP) ────────────────────────────────
+
+/** Session-less start used by the scheduler tick, the PR webhook, and the v1
+ *  API (MCP). Borrows target URL / plan / groups / creds from run history via
+ *  resolveQaRunSeed, auto-approves the gate, and SKIPS (with an activity
+ *  event) when a session is already running — triggers never preempt.
+ *
+ *  NOT a UI action: callers are trusted server code that already resolved the
+ *  team (webhook signature, scheduler row, or bearer-authed v1 route). */
+export async function startQaAgentFromTrigger(opts: {
+  repositoryId: string;
+  teamId: string;
+  trigger: Extract<QaSessionTrigger, "schedule" | "pr" | "mcp">;
+  mode?: QaRunMode;
+  targetUrl?: string;
+  /** Extra context for the activity feed (e.g. "PR #12 sync", token owner). */
+  reason?: string;
+}): Promise<{ sessionId?: string; skipped?: string }> {
+  const { repositoryId, teamId } = opts;
+
+  // Triggers respect the same plan gate as the UI.
+  const team = await queries.getTeam(teamId);
+  if (!team || !hasQaAgentAccess(team.plan)) {
+    return { skipped: "QA agent not available on the team's plan" };
+  }
+
+  const active = await queries.getActiveAgentSession(repositoryId, "qa");
+  if (active) {
+    emitActivity(
+      teamId,
+      repositoryId,
+      active.id,
+      "substep:update",
+      `QA ${opts.trigger} trigger skipped — a session is already running${
+        opts.reason ? ` (${opts.reason})` : ""
+      }`,
+    );
+    return { skipped: "A QA session is already running" };
+  }
+
+  const seed = await resolveQaRunSeed(repositoryId);
+  const targetUrl =
+    opts.targetUrl?.trim().replace(/\/+$/, "") || seed.targetUrl;
+  if (!targetUrl) {
+    return {
+      skipped:
+        "No target URL — run the QA agent once from the UI (or pass targetUrl)",
+    };
+  }
+  try {
+    await assertSafeOutboundUrl(targetUrl);
+  } catch (err) {
+    if (err instanceof SsrfBlockedError) {
+      return { skipped: `URL rejected: ${err.message}` };
+    }
+    throw err;
+  }
+
+  // Mode default: reuse the stored plan cheaply when one exists (fill_gaps);
+  // otherwise a full autonomous run.
+  let mode: QaRunMode = opts.mode ?? (seed.planSource ? "fill_gaps" : "full");
+  if (mode === "fill_gaps" && !seed.planSource) mode = "full";
+
+  const session = await queries.createAgentSession({
+    repositoryId,
+    teamId,
+    kind: "qa",
+    status: "active",
+    currentStepId: "qa_setup",
+    steps: buildStepsForMode(mode),
+    metadata: {
+      qaTargetUrl: targetUrl,
+      qaMode: mode,
+      qaGroups: seed.groups,
+      qaAutoApprove: true,
+      qaAllowRegistration: seed.allowRegistration,
+      credsProvided: Boolean(seed.creds),
+      authMode: seed.creds ? "login" : "public_only",
+      ...(seed.creds
+        ? {
+            quickstartEmail: seed.creds.email,
+            quickstartPassword: seed.creds.password,
+          }
+        : {}),
+      ...(mode === "fill_gaps" && seed.planSource
+        ? {
+            qaPlan: seed.planSource.metadata.qaPlan,
+            qaDiscovery: seed.planSource.metadata.qaDiscovery,
+            qaPlanSourceSessionId: seed.planSource.id,
+          }
+        : {}),
+      qaTrigger: opts.trigger,
+    },
+  });
+
+  emitActivity(
+    teamId,
+    repositoryId,
+    session.id,
+    "session:start",
+    `QA agent started by ${opts.trigger} trigger on ${targetUrl} (${mode.replace("_", " ")})${
+      opts.reason ? ` — ${opts.reason}` : ""
+    }`,
+  );
+  executeQaPipeline(session.id, teamId, repositoryId, "qa_setup").catch((err) =>
+    console.error("[QaAgent] unhandled:", err),
+  );
+  return { sessionId: session.id };
+}
+
+const TRIGGER_MODES: QaRunMode[] = ["full", "refresh_spec", "fill_gaps"];
+
+export interface QaTriggerConfigInput {
+  scheduleEnabled?: boolean;
+  cronExpression?: string | null;
+  scheduleMode?: QaRunMode;
+  prEnabled?: boolean;
+  prMode?: QaRunMode;
+}
+
+/** Current automation config for the repo (null when never configured). */
+export async function getQaTriggerConfig(repositoryId: string) {
+  await requireRepoAccess(repositoryId);
+  return (await queries.getQaAgentTrigger(repositoryId)) ?? null;
+}
+
+/** Upsert the repo's automation config; recomputes nextRunAt on save. */
+export async function updateQaTriggerConfig(
+  repositoryId: string,
+  input: QaTriggerConfigInput,
+) {
+  const { team } = await requireRepoAccess(repositoryId);
+  assertQaAgentAccess(team.plan);
+
+  const patch: Parameters<typeof queries.upsertQaAgentTrigger>[2] = {};
+  if (input.scheduleEnabled !== undefined) {
+    patch.scheduleEnabled = input.scheduleEnabled;
+  }
+  if (input.cronExpression !== undefined) {
+    const cron = input.cronExpression?.trim() || null;
+    if (cron && !isValidCron(cron)) {
+      throw new Error("Invalid cron expression (5 fields expected)");
+    }
+    patch.cronExpression = cron;
+  }
+  if (input.scheduleMode !== undefined) {
+    if (!TRIGGER_MODES.includes(input.scheduleMode)) {
+      throw new Error("Invalid schedule mode");
+    }
+    patch.scheduleMode = input.scheduleMode;
+  }
+  if (input.prEnabled !== undefined) patch.prEnabled = input.prEnabled;
+  if (input.prMode !== undefined) {
+    if (!TRIGGER_MODES.includes(input.prMode)) {
+      throw new Error("Invalid PR mode");
+    }
+    patch.prMode = input.prMode;
+  }
+
+  // Recompute the next fire time from the effective (post-patch) state.
+  const existing = await queries.getQaAgentTrigger(repositoryId);
+  const effectiveEnabled =
+    patch.scheduleEnabled ?? existing?.scheduleEnabled ?? false;
+  const effectiveCron =
+    patch.cronExpression !== undefined
+      ? patch.cronExpression
+      : (existing?.cronExpression ?? null);
+  patch.nextRunAt =
+    effectiveEnabled && effectiveCron
+      ? getNextRunTime(effectiveCron, new Date())
+      : null;
+
+  const row = await queries.upsertQaAgentTrigger(repositoryId, team.id, patch);
+  revalidatePath("/qa-agent");
+  return row;
 }

--- a/src/server/actions/qa-agent.ts
+++ b/src/server/actions/qa-agent.ts
@@ -1034,27 +1034,39 @@ async function runQaDiscover(
   if (await isStopped(sessionId, signal)) return false;
 
   // 2) Code check (repo-aware mode): stack intelligence + endpoints declared
-  //    in code — facts the crawl can't see, feeding the planner digest.
+  //    in code — facts the crawl can't see, feeding the planner digest. When
+  //    the scanned branch differs from the base branch, also diff the two so
+  //    the planner knows exactly which functions/endpoints this branch (PR)
+  //    adds or changes and can target them.
   let codeCheck: QaDiscovery["codeCheck"];
+  let prChanges: QaDiscovery["prChanges"];
   substeps[1] = { ...substeps[1], status: "running" };
   await updateSubsteps(sessionId, "qa_discover", substeps);
   if (githubConnected && repo && ghAccount?.accessToken) {
     try {
-      const [{ gatherCodebaseIntelligence }, { getRepoTree, getFileContent }] =
-        await Promise.all([
-          import("@/lib/ai/codebase-intelligence"),
-          import("@/lib/github/content"),
-        ]);
+      const [
+        { gatherCodebaseIntelligence },
+        { getRepoTree, getFileContent, compareBranches },
+      ] = await Promise.all([
+        import("@/lib/ai/codebase-intelligence"),
+        import("@/lib/github/content"),
+      ]);
       const { extractDeclaredEndpoints } =
         await import("@/lib/qa-agent/code-check");
       const token = ghAccount.accessToken;
       const owner = repo.owner ?? "";
       const name = repo.name ?? "";
-      const [intel, tree] = await Promise.all([
+      const baseBranch = repo.defaultBranch || "main";
+      const [intel, tree, comparison] = await Promise.all([
         gatherCodebaseIntelligence(token, owner, name, branch).catch(
           () => null,
         ),
         getRepoTree(token, owner, name, branch).catch(() => null),
+        branch !== baseBranch
+          ? compareBranches(token, owner, name, baseBranch, branch).catch(
+              () => null,
+            )
+          : Promise.resolve(null),
       ]);
       const declaredEndpoints = tree
         ? await extractDeclaredEndpoints(tree.tree, (path) =>
@@ -1076,19 +1088,29 @@ async function runQaDiscover(
           declaredEndpoints,
         };
       }
+      if (comparison && comparison.files.length > 0) {
+        const { computePrChanges } = await import("@/lib/qa-agent/pr-check");
+        const computed = computePrChanges(comparison, declaredEndpoints);
+        if (computed.files.length > 0) prChanges = computed;
+      }
+      const prDetail = prChanges
+        ? ` · branch diff vs ${prChanges.baseBranch}: ${prChanges.files.length} files, ${prChanges.symbols.length} functions, ${prChanges.endpoints.length} endpoints`
+        : "";
       substeps[1] = {
         ...substeps[1],
         status: "done",
         detail: codeCheck
-          ? `${codeCheck.declaredEndpoints.length} declared endpoints · ${codeCheck.framework ?? "stack unknown"}`
-          : "no code intelligence available",
+          ? `${codeCheck.declaredEndpoints.length} declared endpoints · ${codeCheck.framework ?? "stack unknown"}${prDetail}`
+          : prChanges
+            ? `no code intelligence available${prDetail}`
+            : "no code intelligence available",
       };
       emitActivity(
         teamId,
         repositoryId,
         sessionId,
         "substep:update",
-        `Code analysis: ${codeCheck?.declaredEndpoints.length ?? 0} declared endpoints, stack ${codeCheck?.framework ?? "unknown"}`,
+        `Code analysis: ${codeCheck?.declaredEndpoints.length ?? 0} declared endpoints, stack ${codeCheck?.framework ?? "unknown"}${prDetail}`,
         { stepId: "qa_discover", agentType: "diver" },
       );
     } catch (err) {
@@ -1246,6 +1268,7 @@ async function runQaDiscover(
     framework,
     githubConnected,
     codeCheck,
+    prChanges,
   };
   await mergeMetadata(sessionId, { qaDiscovery: discovery });
   await setStepCompleted(sessionId, "qa_discover", {
@@ -2184,6 +2207,13 @@ async function runQaSummary(
   }
 
   const summary = computeQaSummary(plan, ledger);
+  // Branch-aware runs: report, per function/endpoint the branch changed,
+  // whether a test now covers it (the PR coverage panel).
+  const prChanges = session.metadata.qaDiscovery?.prChanges;
+  if (prChanges) {
+    const { computePrCoverage } = await import("@/lib/qa-agent/pr-check");
+    summary.prCoverage = computePrCoverage(prChanges, plan, ledger);
+  }
   await mergeMetadata(sessionId, { qaSummary: summary });
   await setStepCompleted(sessionId, "qa_summary", {
     planned: summary.planned,
@@ -2201,9 +2231,12 @@ async function runQaSummary(
     repositoryId,
     sessionId,
     "session:complete",
-    session.metadata.qaMode === "refresh_spec"
+    (session.metadata.qaMode === "refresh_spec"
       ? `Specification refreshed: ${summary.planned} planned, ${summary.covered} covered by existing tests, ${gaps} gaps`
-      : `QA suite build complete: ${summary.generated} tests generated, ${summary.covered} already covered, ${summary.passed} passing`,
+      : `QA suite build complete: ${summary.generated} tests generated, ${summary.covered} already covered, ${summary.passed} passing`) +
+      (summary.prCoverage
+        ? ` · branch changes covered: ${summary.prCoverage.coveredCount}/${summary.prCoverage.entries.length}`
+        : ""),
   );
   return true;
 }

--- a/src/server/actions/qa-agent.ts
+++ b/src/server/actions/qa-agent.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import * as queries from "@/lib/db/queries";
 import { requireRepoAccess, requireTeamAccess } from "@/lib/auth";
+import { assertQaAgentAccess } from "@/lib/billing/feature-access";
 import {
   assertSafeOutboundUrl,
   SsrfBlockedError,
@@ -2401,6 +2402,7 @@ export async function startQaAgent(
   input: StartQaAgentInput,
 ): Promise<{ sessionId: string }> {
   const { team } = await requireRepoAccess(input.repositoryId);
+  assertQaAgentAccess(team.plan);
 
   const targetUrl = input.targetUrl.trim().replace(/\/+$/, "");
   if (!/^https?:\/\//i.test(targetUrl)) {
@@ -2513,6 +2515,7 @@ async function requireQaSession(sessionId: string): Promise<{
   teamId: string;
 }> {
   const { team } = await requireTeamAccess();
+  assertQaAgentAccess(team.plan);
   const session = await queries.getAgentSession(sessionId);
   if (!session || session.kind !== "qa") {
     throw new Error("QA session not found");
@@ -3123,6 +3126,7 @@ async function requireQaTask(
   taskId: string,
 ): Promise<{ task: QaTask; teamId: string }> {
   const { team } = await requireTeamAccess();
+  assertQaAgentAccess(team.plan);
   const task = await queries.getQaTask(taskId);
   if (!task || task.teamId !== team.id) {
     throw new Error("Task not found");
@@ -3139,6 +3143,7 @@ export async function addQaTask(input: {
   source?: Extract<QaTaskSource, "user" | "coverage_gap">;
 }): Promise<{ taskId: string }> {
   const { team, user } = await requireRepoAccess(input.repositoryId);
+  assertQaAgentAccess(team.plan);
   const title = input.title.trim().slice(0, MAX_TASK_TITLE);
   if (!title) throw new Error("The task needs a title");
   const task = await queries.createQaTask({

--- a/src/server/actions/qa-agent.ts
+++ b/src/server/actions/qa-agent.ts
@@ -20,6 +20,7 @@ import { crawlTargetApp } from "@/lib/qa-agent/crawl";
 import {
   buildApiDefinition,
   buildDiscoveryDigest,
+  buildExistingCoverageDigest,
   buildGeneratorPrompt,
   buildPlannerSystemPrompt,
   buildPlannerUserPrompt,
@@ -27,9 +28,11 @@ import {
   enabledPlanItems,
   groupPlaywrightOverrides,
   isQaTestPlan,
+  matchPlanToExistingTests,
   normalizeQaGroups,
   sanitizeQaPlan,
   QA_GROUPS,
+  type ExistingTestSummary,
 } from "@/lib/qa-agent/plan";
 import type {
   ActivityEventType,
@@ -40,6 +43,7 @@ import type {
   PwAgentType,
   QaDiscovery,
   QaGeneratedTest,
+  QaRunMode,
   QaTestGroup,
   QaTestPlan,
 } from "@/lib/db/schema";
@@ -296,6 +300,47 @@ function credentialsFrom(
     };
   }
   return undefined;
+}
+
+/** Live (non-deleted) repo tests with their area names — the matcher's and
+ *  planner's view of what coverage already exists. */
+async function loadExistingTests(
+  repositoryId: string,
+): Promise<ExistingTestSummary[]> {
+  const [tests, areas] = await Promise.all([
+    queries.getTestsByRepo(repositoryId),
+    queries.getFunctionalAreasByRepo(repositoryId).catch(() => []),
+  ]);
+  const areaName = new Map(areas.map((a) => [a.id, a.name]));
+  return tests.map((t) => ({
+    id: t.id,
+    name: t.name,
+    testType: t.testType,
+    functionalAreaName: t.functionalAreaId
+      ? (areaName.get(t.functionalAreaId) ?? null)
+      : null,
+  }));
+}
+
+/** Prior run's ledger for coverage matching: the fill_gaps source session's,
+ *  else the newest earlier session that has one. */
+async function loadPriorLedger(
+  session: AgentSession,
+): Promise<QaGeneratedTest[] | undefined> {
+  if (session.metadata.qaPlanSourceSessionId) {
+    const source = await queries
+      .getAgentSession(session.metadata.qaPlanSourceSessionId)
+      .catch(() => null);
+    if (source?.metadata.qaGeneratedTests) {
+      return source.metadata.qaGeneratedTests;
+    }
+  }
+  const recent = await queries
+    .getRecentAgentSessions(session.repositoryId, "qa", 10)
+    .catch(() => []);
+  return recent.find(
+    (s) => s.id !== session.id && s.metadata.qaGeneratedTests?.length,
+  )?.metadata.qaGeneratedTests;
 }
 
 // ── Step: qa_setup ───────────────────────────────────────────────────────────
@@ -576,6 +621,15 @@ async function runQaPlan(
   const systemPrompt = buildPlannerSystemPrompt();
   const started = Date.now();
 
+  // Coverage-aware planning: the planner always sees what already exists so
+  // repeat runs (after code or manual test changes) refresh the spec instead
+  // of redesigning it from scratch.
+  const existingTests = await loadExistingTests(repositoryId).catch(() => []);
+  const existingCoverage =
+    existingTests.length > 0
+      ? buildExistingCoverageDigest(existingTests)
+      : undefined;
+
   const callPlanner = async (extraFeedback?: string): Promise<string> => {
     const settings = await queries.getAISettings(repositoryId);
     const config = getAIConfig(settings);
@@ -586,6 +640,7 @@ async function runQaPlan(
         digest,
         groups,
         credsProvided,
+        existingCoverage,
         feedback:
           [feedback, extraFeedback].filter(Boolean).join("\n") || undefined,
       }),
@@ -723,6 +778,32 @@ async function runQaGenerate(
   const doneItemIds = new Set(
     ledger.filter((g) => g.testId).map((g) => g.planItemId),
   );
+
+  // Gap awareness: items already satisfied by a live test (from a prior run's
+  // ledger or a name-matching manual test) are marked covered and skipped —
+  // this is what makes repeat runs fill gaps instead of duplicating the suite.
+  const [existingTests, priorLedger] = await Promise.all([
+    loadExistingTests(repositoryId).catch(() => []),
+    loadPriorLedger(session).catch(() => undefined),
+  ]);
+  const coveredBy = matchPlanToExistingTests(items, existingTests, priorLedger);
+  for (const item of items) {
+    if (doneItemIds.has(item.id)) continue;
+    const testId = coveredBy.get(item.id);
+    if (!testId) continue;
+    ledger.push({
+      planItemId: item.id,
+      group: item.group,
+      testId,
+      name: item.title,
+      status: "covered",
+    });
+    doneItemIds.add(item.id);
+  }
+  if (coveredBy.size > 0) {
+    await mergeMetadata(sessionId, { qaGeneratedTests: [...ledger] });
+  }
+
   const pending = items.filter((i) => !doneItemIds.has(i.id));
 
   emitActivity(
@@ -730,7 +811,7 @@ async function runQaGenerate(
     repositoryId,
     sessionId,
     "step:start",
-    `Generating ${pending.length} tests (${items.length - pending.length} already done)`,
+    `Generating ${pending.length} tests (${items.length - pending.length} already covered or done)`,
     { stepId: "qa_generate", agentType: "generator" },
   );
 
@@ -964,8 +1045,11 @@ async function runQaGenerate(
     if (runnerId) await releasePoolEB(runnerId).catch(() => {});
   }
 
-  const generatedCount = ledger.filter((g) => g.testId).length;
-  if (generatedCount === 0) {
+  const generatedCount = ledger.filter(
+    (g) => g.testId && g.status !== "covered",
+  ).length;
+  const coveredCount = ledger.filter((g) => g.status === "covered").length;
+  if (generatedCount === 0 && coveredCount === 0) {
     await setStepFailed(
       sessionId,
       "qa_generate",
@@ -975,6 +1059,7 @@ async function runQaGenerate(
   }
   await setStepCompleted(sessionId, "qa_generate", {
     generated: generatedCount,
+    covered: coveredCount,
     failed: ledger.filter((g) => g.status === "generation_failed").length,
   });
   emitActivity(
@@ -982,7 +1067,7 @@ async function runQaGenerate(
     repositoryId,
     sessionId,
     "step:complete",
-    `Generated ${generatedCount}/${items.length} tests`,
+    `Generated ${generatedCount}/${items.length} tests (${coveredCount} already covered)`,
     { stepId: "qa_generate", agentType: "generator" },
   );
   return true;
@@ -1048,8 +1133,21 @@ async function runQaExecute(
   await setStepActive(sessionId, "qa_execute");
   const session = await queries.getAgentSession(sessionId);
   const ledger = [...(session?.metadata.qaGeneratedTests ?? [])];
-  const runnable = ledger.filter((g) => g.testId);
+  // Only newly generated tests run here (plus prior failures on a resume) —
+  // "covered" entries belong to the standing suite and run via normal builds.
+  const runnable = ledger.filter(
+    (g) => g.testId && (g.status === "generated" || g.status === "failed"),
+  );
   if (runnable.length === 0) {
+    const anyCovered = ledger.some((g) => g.status === "covered");
+    if (anyCovered) {
+      await setStepSkipped(
+        sessionId,
+        "qa_execute",
+        "Nothing new to run — every plan item is covered by an existing test",
+      );
+      return true;
+    }
     await setStepFailed(sessionId, "qa_execute", "No generated tests to run");
     return false;
   }
@@ -1086,8 +1184,9 @@ async function runQaExecute(
   if (!statuses) return false; // stopped
 
   let passed = 0;
+  const ranIds = new Set(runnable.map((g) => g.testId));
   for (const entry of ledger) {
-    if (!entry.testId) continue;
+    if (!entry.testId || !ranIds.has(entry.testId)) continue;
     const status = statuses.get(entry.testId);
     entry.status = status === "passed" ? "passed" : "failed";
     if (status === "passed") passed += 1;
@@ -1260,33 +1359,89 @@ async function runQaSummary(
     await setStepFailed(sessionId, "qa_summary", "Missing plan");
     return false;
   }
-  const summary = computeQaSummary(
-    plan,
-    session.metadata.qaGeneratedTests ?? [],
-  );
+
+  // Spec-refresh runs skip generation, so their ledger is empty — build it
+  // here from existing-coverage matches so the summary shows exactly which
+  // plan items the current suite covers and which are gaps (fill_gaps input).
+  let ledger = session.metadata.qaGeneratedTests ?? [];
+  if (ledger.length === 0) {
+    const [existingTests, priorLedger] = await Promise.all([
+      loadExistingTests(repositoryId).catch(() => []),
+      loadPriorLedger(session).catch(() => undefined),
+    ]);
+    const items = enabledPlanItems(plan);
+    const coveredBy = matchPlanToExistingTests(
+      items,
+      existingTests,
+      priorLedger,
+    );
+    ledger = items
+      .filter((i) => coveredBy.has(i.id))
+      .map((i) => ({
+        planItemId: i.id,
+        group: i.group,
+        testId: coveredBy.get(i.id),
+        name: i.title,
+        status: "covered" as const,
+      }));
+    await mergeMetadata(sessionId, { qaGeneratedTests: ledger });
+  }
+
+  const summary = computeQaSummary(plan, ledger);
   await mergeMetadata(sessionId, { qaSummary: summary });
   await setStepCompleted(sessionId, "qa_summary", {
     planned: summary.planned,
     generated: summary.generated,
+    covered: summary.covered,
     passed: summary.passed,
   });
   await queries.updateAgentSession(sessionId, {
     status: "completed",
     completedAt: new Date(),
   });
+  const gaps = summary.planned - summary.covered - summary.generated;
   emitActivity(
     teamId,
     repositoryId,
     sessionId,
     "session:complete",
-    `QA suite build complete: ${summary.generated} tests generated, ${summary.passed} passing`,
+    session.metadata.qaMode === "refresh_spec"
+      ? `Specification refreshed: ${summary.planned} planned, ${summary.covered} covered by existing tests, ${gaps} gaps`
+      : `QA suite build complete: ${summary.generated} tests generated, ${summary.covered} already covered, ${summary.passed} passing`,
   );
   return true;
 }
 
 // ── Pipeline ─────────────────────────────────────────────────────────────────
 
-const QA_PIPELINE: AgentStepId[] = QA_STEP_DEFINITIONS.map((s) => s.id);
+/** Step lists per run mode — a session's `steps` array IS its pipeline; the
+ *  executor walks it in order, so segmented modes just build shorter lists. */
+const MODE_PIPELINES: Record<QaRunMode, AgentStepId[]> = {
+  full: QA_STEP_DEFINITIONS.map((s) => s.id),
+  // Re-discover + re-plan against existing coverage; no generation. Summary
+  // reports which plan items the current suite already covers vs. the gaps.
+  refresh_spec: [
+    "qa_setup",
+    "qa_discover",
+    "qa_plan",
+    "qa_plan_review",
+    "qa_summary",
+  ],
+  // Reuse the latest plan/discovery; generate only uncovered items.
+  fill_gaps: ["qa_setup", "qa_generate", "qa_execute", "qa_heal", "qa_summary"],
+};
+
+function buildStepsForMode(mode: QaRunMode): AgentStepState[] {
+  return MODE_PIPELINES[mode].map((id, i) => {
+    const def = QA_STEP_DEFINITIONS.find((d) => d.id === id)!;
+    return {
+      id,
+      status: i === 0 ? ("active" as const) : ("pending" as const),
+      label: def.label,
+      description: def.description,
+    };
+  });
+}
 
 async function executeQaPipeline(
   sessionId: string,
@@ -1296,13 +1451,17 @@ async function executeQaPipeline(
 ) {
   const controller = getOrCreateController(sessionId);
   const signal = controller.signal;
-  const startIdx = QA_PIPELINE.indexOf(fromStep);
+  const session = await queries.getAgentSession(sessionId);
+  if (!session) return;
+  // The session's own steps define the pipeline (mode-dependent).
+  const pipeline = session.steps.map((s) => s.id);
+  const startIdx = pipeline.indexOf(fromStep);
   if (startIdx === -1) return;
 
   try {
-    for (let i = startIdx; i < QA_PIPELINE.length; i++) {
+    for (let i = startIdx; i < pipeline.length; i++) {
       if (await isStopped(sessionId, signal)) return;
-      const stepId = QA_PIPELINE[i];
+      const stepId = pipeline[i];
       let ok = false;
       switch (stepId) {
         case "qa_setup":
@@ -1355,6 +1514,8 @@ async function executeQaPipeline(
 export interface StartQaAgentInput {
   repositoryId: string;
   targetUrl: string;
+  /** full (default) | refresh_spec | fill_gaps — see QaRunMode. */
+  mode?: QaRunMode;
   groups: QaTestGroup[];
   email?: string;
   password?: string;
@@ -1392,13 +1553,31 @@ export async function startQaAgent(
     });
   }
 
+  const mode: QaRunMode = input.mode ?? "full";
   const credsProvided = Boolean(input.email?.trim() && input.password);
-  const steps: AgentStepState[] = QA_STEP_DEFINITIONS.map((def, i) => ({
-    id: def.id,
-    status: i === 0 ? "active" : "pending",
-    label: def.label,
-    description: def.description,
-  }));
+  const steps = buildStepsForMode(mode);
+
+  // fill_gaps reuses the newest stored plan (from any prior full/refresh run)
+  // instead of re-discovering and re-planning.
+  let planSeed: Partial<AgentSessionMetadata> = {};
+  if (mode === "fill_gaps") {
+    const recent = await queries.getRecentAgentSessions(
+      input.repositoryId,
+      "qa",
+      10,
+    );
+    const source = recent.find((s) => s.metadata.qaPlan);
+    if (!source) {
+      throw new Error(
+        "No stored test plan to fill gaps from — run the agent (full or refresh specification) first",
+      );
+    }
+    planSeed = {
+      qaPlan: source.metadata.qaPlan,
+      qaDiscovery: source.metadata.qaDiscovery,
+      qaPlanSourceSessionId: source.id,
+    };
+  }
 
   const session = await queries.createAgentSession({
     repositoryId: input.repositoryId,
@@ -1409,10 +1588,12 @@ export async function startQaAgent(
     steps,
     metadata: {
       qaTargetUrl: targetUrl,
+      qaMode: mode,
       qaGroups: normalizeQaGroups(input.groups),
       qaAutoApprove: Boolean(input.autoApprove),
       credsProvided,
       authMode: credsProvided ? "login" : "public_only",
+      ...planSeed,
       ...(credsProvided
         ? {
             quickstartEmail: input.email!.trim(),
@@ -1427,7 +1608,7 @@ export async function startQaAgent(
     input.repositoryId,
     session.id,
     "session:start",
-    `QA agent started on ${targetUrl}`,
+    `QA agent started on ${targetUrl} (${mode.replace("_", " ")})`,
   );
 
   executeQaPipeline(session.id, team.id, input.repositoryId, "qa_setup").catch(
@@ -1491,12 +1672,13 @@ export async function approveQaPlan(
     { stepId: "qa_plan_review", agentType: "orchestrator" },
   );
 
-  executeQaPipeline(
-    sessionId,
-    teamId,
-    session.repositoryId,
-    "qa_generate",
-  ).catch((err) => console.error("[QaAgent] unhandled:", err));
+  // Continue with whatever follows the review gate in THIS session's
+  // pipeline — qa_generate on full runs, qa_summary on refresh_spec runs.
+  const reviewIdx = session.steps.findIndex((s) => s.id === "qa_plan_review");
+  const nextStep = session.steps[reviewIdx + 1]?.id ?? "qa_summary";
+  executeQaPipeline(sessionId, teamId, session.repositoryId, nextStep).catch(
+    (err) => console.error("[QaAgent] unhandled:", err),
+  );
   revalidatePath("/qa-agent");
   return { success: true };
 }

--- a/src/server/actions/qa-agent.ts
+++ b/src/server/actions/qa-agent.ts
@@ -1,0 +1,1580 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import * as queries from "@/lib/db/queries";
+import { requireRepoAccess, requireTeamAccess } from "@/lib/auth";
+import {
+  assertSafeOutboundUrl,
+  SsrfBlockedError,
+} from "@/lib/security/outbound-url";
+import { emitAndPersistActivityEvent } from "@/lib/db/queries/activity-events";
+import { generateWithAI } from "@/lib/ai";
+import { parseAiJson } from "@/lib/ai/json-parse";
+import { getAIConfig } from "@/lib/playwright/agent-context";
+import { claimEmbeddedBrowserForAgent } from "./ai";
+import { releasePoolEB } from "./embedded-sessions";
+import { runTestsCore } from "./runs";
+import { toProxyStreamUrl } from "@/lib/eb/stream-url";
+import { appendStreamToken } from "@/lib/eb/stream-token";
+import { crawlTargetApp } from "@/lib/qa-agent/crawl";
+import {
+  buildApiDefinition,
+  buildDiscoveryDigest,
+  buildGeneratorPrompt,
+  buildPlannerSystemPrompt,
+  buildPlannerUserPrompt,
+  computeQaSummary,
+  enabledPlanItems,
+  groupPlaywrightOverrides,
+  isQaTestPlan,
+  normalizeQaGroups,
+  sanitizeQaPlan,
+  QA_GROUPS,
+} from "@/lib/qa-agent/plan";
+import type {
+  ActivityEventType,
+  AgentSession,
+  AgentSessionMetadata,
+  AgentStepId,
+  AgentStepState,
+  PwAgentType,
+  QaDiscovery,
+  QaGeneratedTest,
+  QaTestGroup,
+  QaTestPlan,
+} from "@/lib/db/schema";
+
+/**
+ * QA Agent — the dedicated comprehensive-suite builder behind the /qa-agent
+ * page. Orchestrates specialist subagents through an eight-phase pipeline:
+ *
+ *   qa_setup       orchestrator  preflight (AI provider, GitHub, target URL)
+ *   qa_discover    scout         static route scan + live EB crawl (DOM,
+ *                                selectors, observed API endpoints)
+ *   qa_plan        planner       best-practices test plan grounded in discovery
+ *   qa_plan_review (human gate)  approve / adjust / request changes
+ *   qa_generate    generator     one test per plan item (EB + MCP verified
+ *                                selectors); api items become headless tests
+ *   qa_execute     orchestrator  run the generated suite
+ *   qa_heal        healer        fix failing tests, re-run them
+ *   qa_summary     orchestrator  coverage + journey traceability
+ *
+ * Each phase's AI work is a separate, narrowly-scoped subagent call: the
+ * planner sees a condensed discovery digest, each generator sees only its
+ * plan item + relevant selectors, the healer sees one failing test. That keeps
+ * every context window small while the session metadata carries the full
+ * state. The step machine runs detached (fire-and-forget) and the page polls
+ * /api/qa-agent/[sessionId], same as the play agent.
+ */
+
+const QA_STEP_DEFINITIONS: Array<{
+  id: AgentStepId;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: "qa_setup",
+    label: "Preflight",
+    description: "Validate target URL, AI provider, and GitHub connection",
+  },
+  {
+    id: "qa_discover",
+    label: "Discover",
+    description: "Scan source routes and crawl the live app for DOM/selectors",
+  },
+  {
+    id: "qa_plan",
+    label: "Plan",
+    description: "Design a risk-prioritized test plan from real discovery data",
+  },
+  {
+    id: "qa_plan_review",
+    label: "Review",
+    description: "Human review gate — approve or request plan changes",
+  },
+  {
+    id: "qa_generate",
+    label: "Generate",
+    description: "Generate tests per plan item with live selector verification",
+  },
+  {
+    id: "qa_execute",
+    label: "Execute",
+    description: "Run the generated suite against the target app",
+  },
+  {
+    id: "qa_heal",
+    label: "Heal",
+    description: "Fix failing tests and re-run them",
+  },
+  {
+    id: "qa_summary",
+    label: "Summary",
+    description: "Coverage matrix and journey traceability",
+  },
+];
+
+const EB_CLAIM_TIMEOUT_MS = 5 * 60 * 1000;
+const PLANNER_TIMEOUT_MS = 5 * 60 * 1000;
+const GENERATOR_TIMEOUT_MS = 8 * 60 * 1000;
+const HEAL_TIMEOUT_MS = 8 * 60 * 1000;
+const RUN_POLL_INTERVAL_MS = 3000;
+const RUN_TIMEOUT_MS = 20 * 60 * 1000;
+const MAX_CRAWL_PAGES = 6;
+
+// ── AbortController registry (per session, in-process) ──────────────────────
+
+const activeControllers = new Map<string, AbortController>();
+
+function getOrCreateController(sessionId: string): AbortController {
+  let controller = activeControllers.get(sessionId);
+  if (!controller || controller.signal.aborted) {
+    controller = new AbortController();
+    activeControllers.set(sessionId, controller);
+  }
+  return controller;
+}
+
+// ── Session helpers ──────────────────────────────────────────────────────────
+
+function emitActivity(
+  teamId: string,
+  repositoryId: string,
+  sessionId: string,
+  eventType: ActivityEventType,
+  summary: string,
+  opts?: {
+    stepId?: string;
+    agentType?: PwAgentType;
+    detail?: Record<string, unknown>;
+    artifactType?: "test" | "build";
+    artifactId?: string;
+    artifactLabel?: string;
+    durationMs?: number;
+  },
+) {
+  emitAndPersistActivityEvent({
+    teamId,
+    repositoryId,
+    sessionId,
+    sourceType: "qa_agent",
+    eventType,
+    summary,
+    stepId: opts?.stepId ?? null,
+    agentType: opts?.agentType ?? null,
+    detail: opts?.detail ?? null,
+    artifactType: opts?.artifactType ?? null,
+    artifactId: opts?.artifactId ?? null,
+    artifactLabel: opts?.artifactLabel ?? null,
+    durationMs: opts?.durationMs ?? null,
+    promptLogId: null,
+  }).catch((err) => console.error("[QaAgent] activity emit error:", err));
+}
+
+async function updateStep(
+  sessionId: string,
+  stepId: AgentStepId,
+  update: Partial<AgentStepState>,
+) {
+  const session = await queries.getAgentSession(sessionId);
+  if (!session) return;
+  const steps = [...session.steps];
+  const idx = steps.findIndex((s) => s.id === stepId);
+  if (idx === -1) return;
+  steps[idx] = { ...steps[idx], ...update };
+  await queries.updateAgentSession(sessionId, {
+    steps,
+    currentStepId:
+      update.status === "active"
+        ? stepId
+        : (session.currentStepId ?? undefined),
+  });
+}
+
+async function setStepActive(sessionId: string, stepId: AgentStepId) {
+  await updateStep(sessionId, stepId, {
+    status: "active",
+    startedAt: new Date().toISOString(),
+    error: undefined,
+  });
+  await queries.updateAgentSession(sessionId, { currentStepId: stepId });
+}
+
+async function setStepCompleted(
+  sessionId: string,
+  stepId: AgentStepId,
+  result?: Record<string, unknown>,
+) {
+  await updateStep(sessionId, stepId, {
+    status: "completed",
+    completedAt: new Date().toISOString(),
+    ...(result ? { result } : {}),
+  });
+}
+
+async function setStepFailed(
+  sessionId: string,
+  stepId: AgentStepId,
+  error: string,
+) {
+  await updateStep(sessionId, stepId, {
+    status: "failed",
+    completedAt: new Date().toISOString(),
+    error,
+  });
+  await queries.updateAgentSession(sessionId, {
+    status: "failed",
+    completedAt: new Date(),
+  });
+}
+
+async function setStepSkipped(
+  sessionId: string,
+  stepId: AgentStepId,
+  reason?: string,
+) {
+  await updateStep(sessionId, stepId, {
+    status: "skipped",
+    completedAt: new Date().toISOString(),
+    ...(reason ? { result: { reason } } : {}),
+  });
+}
+
+async function updateSubsteps(
+  sessionId: string,
+  stepId: AgentStepId,
+  substeps: AgentStepState["substeps"],
+) {
+  await updateStep(sessionId, stepId, { substeps: [...(substeps ?? [])] });
+}
+
+async function mergeMetadata(
+  sessionId: string,
+  patch: Partial<AgentSessionMetadata>,
+) {
+  const session = await queries.getAgentSession(sessionId);
+  if (!session) return;
+  await queries.updateAgentSession(sessionId, {
+    metadata: { ...session.metadata, ...patch },
+  });
+}
+
+function proxiedStream(raw: string | null | undefined): string | undefined {
+  if (!raw) return undefined;
+  const proxied = toProxyStreamUrl(raw) ?? raw;
+  return appendStreamToken(proxied, process.env.STREAM_AUTH_TOKEN) || undefined;
+}
+
+/** True when the session was cancelled in the DB or aborted in-process. */
+async function isStopped(
+  sessionId: string,
+  signal: AbortSignal,
+): Promise<boolean> {
+  if (signal.aborted) return true;
+  const session = await queries.getAgentSession(sessionId);
+  if (!session) return true;
+  if (session.status === "cancelled" || session.status === "paused") {
+    activeControllers.get(sessionId)?.abort();
+    return true;
+  }
+  return false;
+}
+
+function credentialsFrom(
+  metadata: AgentSessionMetadata,
+): { email: string; password: string } | undefined {
+  if (
+    metadata.credsProvided &&
+    typeof metadata.quickstartEmail === "string" &&
+    typeof metadata.quickstartPassword === "string" &&
+    metadata.quickstartEmail &&
+    metadata.quickstartPassword
+  ) {
+    return {
+      email: metadata.quickstartEmail,
+      password: metadata.quickstartPassword,
+    };
+  }
+  return undefined;
+}
+
+// ── Step: qa_setup ───────────────────────────────────────────────────────────
+
+async function runQaSetup(
+  sessionId: string,
+  teamId: string,
+  repositoryId: string,
+  _signal: AbortSignal,
+): Promise<boolean> {
+  await setStepActive(sessionId, "qa_setup");
+  emitActivity(teamId, repositoryId, sessionId, "step:start", "Preflight", {
+    stepId: "qa_setup",
+    agentType: "orchestrator",
+  });
+
+  const session = await queries.getAgentSession(sessionId);
+  if (!session) return false;
+  const targetUrl = session.metadata.qaTargetUrl;
+  if (!targetUrl) {
+    await setStepFailed(sessionId, "qa_setup", "No target URL configured");
+    return false;
+  }
+
+  const aiSettings = await queries.getAISettings(repositoryId);
+  if (!aiSettings.provider || aiSettings.provider === "none") {
+    await setStepFailed(
+      sessionId,
+      "qa_setup",
+      "No AI provider configured — set one under Settings → AI",
+    );
+    return false;
+  }
+
+  const ghAccount = await queries
+    .getGithubAccountByTeam(teamId)
+    .catch(() => undefined);
+  const repo = await queries.getRepository(repositoryId);
+  const githubConnected = Boolean(
+    ghAccount?.accessToken && repo?.provider === "github" && repo.owner,
+  );
+
+  await setStepCompleted(sessionId, "qa_setup", {
+    targetUrl,
+    aiProvider: aiSettings.provider,
+    githubConnected,
+    credsProvided: Boolean(session.metadata.credsProvided),
+  });
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:complete",
+    `Preflight OK — AI: ${aiSettings.provider}, GitHub: ${githubConnected ? "connected (repo-aware discovery)" : "not connected (live discovery only)"}`,
+    { stepId: "qa_setup", agentType: "orchestrator" },
+  );
+  return true;
+}
+
+// ── Step: qa_discover ────────────────────────────────────────────────────────
+
+async function runQaDiscover(
+  sessionId: string,
+  teamId: string,
+  repositoryId: string,
+  signal: AbortSignal,
+): Promise<boolean> {
+  await setStepActive(sessionId, "qa_discover");
+  const session = await queries.getAgentSession(sessionId);
+  if (!session?.metadata.qaTargetUrl) return false;
+  const targetUrl = session.metadata.qaTargetUrl;
+
+  const substeps: NonNullable<AgentStepState["substeps"]> = [
+    { label: "Static route scan", status: "running", agent: "scout" },
+    { label: "Live crawl", status: "pending", agent: "ranger" },
+  ];
+  await updateSubsteps(sessionId, "qa_discover", substeps);
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:start",
+    "Discovery started",
+    { stepId: "qa_discover", agentType: "scout" },
+  );
+
+  // 1) Static routes: reuse a prior scan; else run the GitHub-tree scanner.
+  let staticRoutes: Array<{ path: string; type: string }> = [];
+  let framework: string | undefined;
+  let githubConnected = false;
+  try {
+    const repo = await queries.getRepository(repositoryId);
+    const ghAccount = await queries
+      .getGithubAccountByTeam(teamId)
+      .catch(() => undefined);
+    githubConnected = Boolean(
+      ghAccount?.accessToken && repo?.provider === "github" && repo.owner,
+    );
+
+    const existing = await queries.getRoutesByRepo(repositoryId);
+    if (existing.length > 0) {
+      staticRoutes = existing.map((r) => ({ path: r.path, type: r.type }));
+      framework = existing[0]?.framework ?? undefined;
+    } else if (githubConnected && repo && ghAccount?.accessToken) {
+      const { RemoteRouteScanner } =
+        await import("@/lib/scanner/remote-scanner");
+      const scanner = new RemoteRouteScanner({
+        accessToken: ghAccount.accessToken,
+        owner: repo.owner ?? "",
+        repo: repo.name ?? "",
+        branch: repo.selectedBranch || repo.defaultBranch || "main",
+      });
+      const result = await scanner.scan();
+      staticRoutes = result.routes.map((r) => ({
+        path: r.path,
+        type: r.type,
+      }));
+      framework = result.framework;
+    }
+    substeps[0] = {
+      ...substeps[0],
+      status: "done",
+      detail: githubConnected
+        ? `${staticRoutes.length} routes (${framework ?? "unknown"})`
+        : "skipped — GitHub not connected",
+    };
+  } catch (err) {
+    substeps[0] = {
+      ...substeps[0],
+      status: "error",
+      detail: err instanceof Error ? err.message : "scan failed",
+    };
+  }
+  await updateSubsteps(sessionId, "qa_discover", substeps);
+
+  if (await isStopped(sessionId, signal)) return false;
+
+  // 2) Live crawl on an Embedded Browser (streamed to the page live view).
+  substeps[1] = { ...substeps[1], status: "running" };
+  await updateSubsteps(sessionId, "qa_discover", substeps);
+
+  let runnerId: string | undefined;
+  let crawled: Awaited<ReturnType<typeof crawlTargetApp>> = {
+    pages: [],
+    loginAttempted: false,
+  };
+  try {
+    const eb = await claimEmbeddedBrowserForAgent(EB_CLAIM_TIMEOUT_MS, () => {
+      mergeMetadata(sessionId, { queuedForBrowser: true }).catch(() => {});
+    });
+    if (!eb) {
+      substeps[1] = {
+        ...substeps[1],
+        status: "error",
+        detail: "No embedded browser available",
+      };
+      await updateSubsteps(sessionId, "qa_discover", substeps);
+    } else {
+      runnerId = eb.runnerId;
+      await mergeMetadata(sessionId, {
+        queuedForBrowser: false,
+        streamUrl: proxiedStream(eb.streamUrl),
+      });
+      const credentials = credentialsFrom(session.metadata);
+      crawled = await crawlTargetApp(eb.cdpUrl, targetUrl, {
+        maxPages: MAX_CRAWL_PAGES,
+        credentials,
+        signal,
+        onPage: (snapshot, index) => {
+          substeps[1] = {
+            ...substeps[1],
+            detail: `${index + 1} pages mapped — ${snapshot.finalUrl}`,
+          };
+          updateSubsteps(sessionId, "qa_discover", substeps).catch(() => {});
+          emitActivity(
+            teamId,
+            repositoryId,
+            sessionId,
+            "substep:update",
+            `Mapped ${snapshot.finalUrl}: ${snapshot.links.length} links, ${snapshot.forms.length} forms, ${snapshot.apiEndpoints.length} API calls`,
+            { stepId: "qa_discover", agentType: "ranger" },
+          );
+        },
+      });
+      substeps[1] = {
+        ...substeps[1],
+        status: crawled.pages.length > 0 ? "done" : "error",
+        detail:
+          crawled.pages.length > 0
+            ? `${crawled.pages.length} pages, ${crawled.pages.reduce((n, p) => n + p.apiEndpoints.length, 0)} API calls observed${crawled.loginAttempted ? ", logged in" : ""}`
+            : "No pages could be mapped",
+      };
+      await updateSubsteps(sessionId, "qa_discover", substeps);
+    }
+  } catch (err) {
+    substeps[1] = {
+      ...substeps[1],
+      status: "error",
+      detail: err instanceof Error ? err.message : "crawl failed",
+    };
+    await updateSubsteps(sessionId, "qa_discover", substeps);
+  } finally {
+    await mergeMetadata(sessionId, { streamUrl: undefined }).catch(() => {});
+    if (runnerId) await releasePoolEB(runnerId).catch(() => {});
+  }
+
+  if (crawled.pages.length === 0 && staticRoutes.length === 0) {
+    await setStepFailed(
+      sessionId,
+      "qa_discover",
+      "Discovery produced nothing — the target URL could not be crawled and no source routes were found",
+    );
+    return false;
+  }
+
+  const discovery: QaDiscovery = {
+    targetUrl,
+    crawledPages: crawled.pages,
+    staticRoutes: staticRoutes.length > 0 ? staticRoutes : undefined,
+    framework,
+    githubConnected,
+  };
+  await mergeMetadata(sessionId, { qaDiscovery: discovery });
+  await setStepCompleted(sessionId, "qa_discover", {
+    pagesCrawled: crawled.pages.length,
+    staticRoutes: staticRoutes.length,
+    apiEndpoints: crawled.pages.reduce((n, p) => n + p.apiEndpoints.length, 0),
+  });
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:complete",
+    `Discovery complete: ${crawled.pages.length} pages crawled, ${staticRoutes.length} source routes`,
+    { stepId: "qa_discover", agentType: "scout" },
+  );
+  return true;
+}
+
+// ── Step: qa_plan ────────────────────────────────────────────────────────────
+
+async function runQaPlan(
+  sessionId: string,
+  teamId: string,
+  repositoryId: string,
+  signal: AbortSignal,
+): Promise<boolean> {
+  await setStepActive(sessionId, "qa_plan");
+  const session = await queries.getAgentSession(sessionId);
+  const discovery = session?.metadata.qaDiscovery;
+  if (!session || !discovery) {
+    await setStepFailed(sessionId, "qa_plan", "Missing discovery data");
+    return false;
+  }
+  const groups = normalizeQaGroups(session.metadata.qaGroups ?? []);
+  const credsProvided = Boolean(session.metadata.credsProvided);
+  const feedback = session.metadata.qaPlannerFeedback;
+
+  const substeps: NonNullable<AgentStepState["substeps"]> = [
+    {
+      label: "Planner designing test plan",
+      status: "running",
+      agent: "planner",
+      inputSummary: `${discovery.crawledPages.length} pages, ${discovery.staticRoutes?.length ?? 0} routes, groups: ${groups.join(", ")}`,
+    },
+  ];
+  await updateSubsteps(sessionId, "qa_plan", substeps);
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:start",
+    "Planner designing the test plan",
+    { stepId: "qa_plan", agentType: "planner" },
+  );
+
+  const digest = buildDiscoveryDigest(discovery);
+  const systemPrompt = buildPlannerSystemPrompt();
+  const started = Date.now();
+
+  const callPlanner = async (extraFeedback?: string): Promise<string> => {
+    const settings = await queries.getAISettings(repositoryId);
+    const config = getAIConfig(settings);
+    const timeoutSignal = AbortSignal.timeout(PLANNER_TIMEOUT_MS);
+    return generateWithAI(
+      config,
+      buildPlannerUserPrompt({
+        digest,
+        groups,
+        credsProvided,
+        feedback:
+          [feedback, extraFeedback].filter(Boolean).join("\n") || undefined,
+      }),
+      systemPrompt,
+      {
+        repositoryId,
+        actionType: "qa_plan",
+        responseFormat: "json_object",
+        signal: AbortSignal.any([signal, timeoutSignal]),
+        onLogCreated: (logId) => {
+          substeps[0] = { ...substeps[0], promptLogId: logId };
+          updateSubsteps(sessionId, "qa_plan", substeps).catch(() => {});
+        },
+      },
+    );
+  };
+
+  let plan: QaTestPlan | null = null;
+  try {
+    const raw = await callPlanner();
+    plan = parseAiJson(raw, isQaTestPlan, { source: "qa-plan" });
+    if (!plan) {
+      const retry = await callPlanner(
+        "Your previous response was not a valid plan JSON object. Respond with ONLY the JSON object described in the system prompt.",
+      );
+      plan = parseAiJson(retry, isQaTestPlan, { source: "qa-plan-retry" });
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    substeps[0] = { ...substeps[0], status: "error", rawError: msg };
+    await updateSubsteps(sessionId, "qa_plan", substeps);
+    await setStepFailed(sessionId, "qa_plan", `Planner failed: ${msg}`);
+    return false;
+  }
+
+  if (!plan) {
+    substeps[0] = { ...substeps[0], status: "error" };
+    await updateSubsteps(sessionId, "qa_plan", substeps);
+    await setStepFailed(
+      sessionId,
+      "qa_plan",
+      "Planner did not produce a valid test plan (JSON parse/shape failure after retry)",
+    );
+    return false;
+  }
+
+  const sanitized = sanitizeQaPlan(plan, groups);
+  substeps[0] = {
+    ...substeps[0],
+    status: "done",
+    durationMs: Date.now() - started,
+    outputSummary: `${sanitized.journeys.length} journeys, ${sanitized.items.length} test items`,
+  };
+  await updateSubsteps(sessionId, "qa_plan", substeps);
+  await mergeMetadata(sessionId, {
+    qaPlan: sanitized,
+    qaPlannerFeedback: undefined,
+  });
+  await setStepCompleted(sessionId, "qa_plan", {
+    journeys: sanitized.journeys.length,
+    items: sanitized.items.length,
+    byGroup: Object.fromEntries(
+      QA_GROUPS.map((g) => [
+        g.id,
+        sanitized.items.filter((i) => i.group === g.id).length,
+      ]).filter(([, n]) => (n as number) > 0),
+    ),
+  });
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:complete",
+    `Plan ready: ${sanitized.journeys.length} journeys, ${sanitized.items.length} tests across ${groups.length} groups`,
+    { stepId: "qa_plan", agentType: "planner" },
+  );
+  return true;
+}
+
+// ── Step: qa_plan_review (human gate) ────────────────────────────────────────
+
+async function runQaPlanReview(
+  sessionId: string,
+  teamId: string,
+  repositoryId: string,
+): Promise<boolean> {
+  await setStepActive(sessionId, "qa_plan_review");
+  const session = await queries.getAgentSession(sessionId);
+  if (session?.metadata.qaAutoApprove) {
+    await updateStep(sessionId, "qa_plan_review", {
+      status: "completed",
+      completedAt: new Date().toISOString(),
+      userAction: "auto-approved",
+    });
+    return true;
+  }
+  await updateStep(sessionId, "qa_plan_review", {
+    status: "waiting_user",
+    userAction: "Review the test plan, then approve or request changes",
+  });
+  await queries.updateAgentSession(sessionId, { status: "paused" });
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:start",
+    "Waiting for plan review",
+    { stepId: "qa_plan_review", agentType: "orchestrator" },
+  );
+  return false; // pipeline resumes via approveQaPlan
+}
+
+// ── Step: qa_generate ────────────────────────────────────────────────────────
+
+async function runQaGenerate(
+  sessionId: string,
+  teamId: string,
+  repositoryId: string,
+  signal: AbortSignal,
+): Promise<boolean> {
+  await setStepActive(sessionId, "qa_generate");
+  const session = await queries.getAgentSession(sessionId);
+  const plan = session?.metadata.qaPlan;
+  const targetUrl = session?.metadata.qaTargetUrl;
+  if (!session || !plan || !targetUrl) {
+    await setStepFailed(sessionId, "qa_generate", "Missing approved plan");
+    return false;
+  }
+  const credentials = credentialsFrom(session.metadata);
+  const items = enabledPlanItems(plan);
+  // Resume-safe: skip items that already produced a test in a prior attempt.
+  const ledger: QaGeneratedTest[] = [
+    ...(session.metadata.qaGeneratedTests ?? []),
+  ];
+  const doneItemIds = new Set(
+    ledger.filter((g) => g.testId).map((g) => g.planItemId),
+  );
+  const pending = items.filter((i) => !doneItemIds.has(i.id));
+
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:start",
+    `Generating ${pending.length} tests (${items.length - pending.length} already done)`,
+    { stepId: "qa_generate", agentType: "generator" },
+  );
+
+  const groupLabel = (g: QaTestGroup) =>
+    QA_GROUPS.find((m) => m.id === g)?.label ?? g;
+
+  // Areas: one per group, flat, prefixed for recognizability in /tests.
+  const areaIdByGroup = new Map<QaTestGroup, string>();
+  for (const group of new Set(items.map((i) => i.group))) {
+    const area = await queries.getOrCreateFunctionalAreaByRepo(
+      repositoryId,
+      `QA: ${groupLabel(group)}`,
+    );
+    areaIdByGroup.set(group, area.id);
+  }
+
+  const qaBot = await queries
+    .getBotByKind(teamId, "play_agent")
+    .catch(() => undefined);
+
+  const substeps: NonNullable<AgentStepState["substeps"]> = pending.map(
+    (item) => ({
+      label: `${groupLabel(item.group)}: ${item.title}`,
+      status: "pending",
+      agent: "generator",
+    }),
+  );
+  await updateSubsteps(sessionId, "qa_generate", substeps);
+
+  const upsertLedger = async (entry: QaGeneratedTest) => {
+    const idx = ledger.findIndex((g) => g.planItemId === entry.planItemId);
+    if (idx === -1) ledger.push(entry);
+    else ledger[idx] = entry;
+    await mergeMetadata(sessionId, { qaGeneratedTests: [...ledger] });
+  };
+
+  // API items need no browser — build headless definitions directly.
+  const apiItems = pending.filter((i) => i.group === "api" && i.api);
+  const browserItems = pending.filter((i) => !apiItems.includes(i));
+
+  for (const item of apiItems) {
+    if (await isStopped(sessionId, signal)) return false;
+    const subIdx = pending.indexOf(item);
+    substeps[subIdx] = { ...substeps[subIdx], status: "running" };
+    await updateSubsteps(sessionId, "qa_generate", substeps);
+    const definition = buildApiDefinition(item, targetUrl);
+    if (!definition) {
+      substeps[subIdx] = {
+        ...substeps[subIdx],
+        status: "error",
+        detail: "No API endpoint on plan item",
+      };
+      await upsertLedger({
+        planItemId: item.id,
+        group: item.group,
+        name: item.title,
+        status: "generation_failed",
+        error: "Plan item had no API definition",
+      });
+      continue;
+    }
+    const test = await queries.createTest({
+      repositoryId,
+      functionalAreaId: areaIdByGroup.get(item.group),
+      name: item.title,
+      code: `// Headless API test — executed via apiDefinition (${definition.method} ${definition.url})`,
+      targetUrl,
+      testType: "api",
+      apiDefinition: definition,
+      ...(qaBot ? { createdByBotId: qaBot.id } : {}),
+    });
+    substeps[subIdx] = { ...substeps[subIdx], status: "done" };
+    await updateSubsteps(sessionId, "qa_generate", substeps);
+    await upsertLedger({
+      planItemId: item.id,
+      group: item.group,
+      testId: test.id,
+      name: item.title,
+      status: "generated",
+    });
+    emitActivity(
+      teamId,
+      repositoryId,
+      sessionId,
+      "artifact:created",
+      `Created API test "${item.title}"`,
+      {
+        stepId: "qa_generate",
+        agentType: "generator",
+        artifactType: "test",
+        artifactId: test.id,
+        artifactLabel: item.title,
+      },
+    );
+  }
+
+  // Browser items share one EB, generated sequentially so the live view is
+  // coherent and the pool isn't drained.
+  let runnerId: string | undefined;
+  try {
+    if (browserItems.length > 0) {
+      const eb = await claimEmbeddedBrowserForAgent(EB_CLAIM_TIMEOUT_MS, () => {
+        mergeMetadata(sessionId, { queuedForBrowser: true }).catch(() => {});
+      });
+      if (!eb) {
+        await setStepFailed(
+          sessionId,
+          "qa_generate",
+          "No embedded browser available for test generation",
+        );
+        return false;
+      }
+      runnerId = eb.runnerId;
+      await mergeMetadata(sessionId, {
+        queuedForBrowser: false,
+        streamUrl: proxiedStream(eb.streamUrl),
+      });
+
+      const { agentCreateTest } =
+        await import("@/lib/playwright/generator-agent");
+
+      for (const item of browserItems) {
+        if (await isStopped(sessionId, signal)) return false;
+        const subIdx = pending.indexOf(item);
+        const started = Date.now();
+        substeps[subIdx] = { ...substeps[subIdx], status: "running" };
+        await updateSubsteps(sessionId, "qa_generate", substeps);
+        emitActivity(
+          teamId,
+          repositoryId,
+          sessionId,
+          "substep:update",
+          `Generator working on "${item.title}" (${item.group})`,
+          { stepId: "qa_generate", agentType: "generator" },
+        );
+        try {
+          const timeoutSignal = AbortSignal.timeout(GENERATOR_TIMEOUT_MS);
+          const result = await agentCreateTest(
+            repositoryId,
+            {
+              testName: item.title,
+              baseUrl: targetUrl,
+              routePath: item.pagePath,
+              userPrompt: buildGeneratorPrompt({
+                item,
+                plan,
+                targetUrl,
+                credentials,
+              }),
+            },
+            {
+              signal: AbortSignal.any([signal, timeoutSignal]),
+              cdpEndpoint: eb.cdpUrl,
+            },
+          );
+          if (result.success && result.code) {
+            const test = await queries.createTest({
+              repositoryId,
+              functionalAreaId: areaIdByGroup.get(item.group),
+              name: item.title,
+              code: result.code,
+              targetUrl,
+              playwrightOverrides: groupPlaywrightOverrides(item.group),
+              ...(qaBot ? { createdByBotId: qaBot.id } : {}),
+            });
+            substeps[subIdx] = {
+              ...substeps[subIdx],
+              status: "done",
+              durationMs: Date.now() - started,
+            };
+            await upsertLedger({
+              planItemId: item.id,
+              group: item.group,
+              testId: test.id,
+              name: item.title,
+              status: "generated",
+            });
+            emitActivity(
+              teamId,
+              repositoryId,
+              sessionId,
+              "artifact:created",
+              `Generated test "${item.title}" (${item.group})`,
+              {
+                stepId: "qa_generate",
+                agentType: "generator",
+                artifactType: "test",
+                artifactId: test.id,
+                artifactLabel: item.title,
+                durationMs: Date.now() - started,
+              },
+            );
+          } else {
+            substeps[subIdx] = {
+              ...substeps[subIdx],
+              status: "error",
+              detail: result.error?.slice(0, 200),
+              rawError: result.error,
+              durationMs: Date.now() - started,
+            };
+            await upsertLedger({
+              planItemId: item.id,
+              group: item.group,
+              name: item.title,
+              status: "generation_failed",
+              error: result.error,
+            });
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          substeps[subIdx] = {
+            ...substeps[subIdx],
+            status: "error",
+            detail: msg.slice(0, 200),
+            rawError: msg,
+            durationMs: Date.now() - started,
+          };
+          await upsertLedger({
+            planItemId: item.id,
+            group: item.group,
+            name: item.title,
+            status: "generation_failed",
+            error: msg,
+          });
+        }
+        await updateSubsteps(sessionId, "qa_generate", substeps);
+      }
+    }
+  } finally {
+    await mergeMetadata(sessionId, { streamUrl: undefined }).catch(() => {});
+    if (runnerId) await releasePoolEB(runnerId).catch(() => {});
+  }
+
+  const generatedCount = ledger.filter((g) => g.testId).length;
+  if (generatedCount === 0) {
+    await setStepFailed(
+      sessionId,
+      "qa_generate",
+      "No tests could be generated — check the AI provider and embedded-browser pool",
+    );
+    return false;
+  }
+  await setStepCompleted(sessionId, "qa_generate", {
+    generated: generatedCount,
+    failed: ledger.filter((g) => g.status === "generation_failed").length,
+  });
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:complete",
+    `Generated ${generatedCount}/${items.length} tests`,
+    { stepId: "qa_generate", agentType: "generator" },
+  );
+  return true;
+}
+
+// ── Execution helper: run tests and resolve per-test results ────────────────
+
+async function runAndCollect(
+  sessionId: string,
+  repositoryId: string,
+  testIds: string[],
+  signal: AbortSignal,
+): Promise<Map<string, "passed" | "failed"> | null> {
+  // runTestsCore returns { runId, jobId } directly, or { runId: null, jobId }
+  // when the pool was busy and the run got queued as a pending background job.
+  const run = await runTestsCore(testIds, repositoryId, true);
+  const runId = run.runId ?? undefined;
+  const jobId = run.jobId;
+  if (runId) {
+    const current = await queries.getAgentSession(sessionId);
+    await mergeMetadata(sessionId, {
+      qaRunIds: [...(current?.metadata.qaRunIds ?? []), runId],
+    });
+  }
+
+  const deadline = Date.now() + RUN_TIMEOUT_MS;
+  for (;;) {
+    if (await isStopped(sessionId, signal)) return null;
+    if (Date.now() > deadline) break;
+    if (runId) {
+      const runRow = await queries.getTestRun(runId);
+      if (runRow?.status && runRow.status !== "running") break;
+    } else if (jobId) {
+      // The run was queued for a free browser; wait on the background job.
+      const job = await queries.getBackgroundJob(jobId);
+      if (job && job.status !== "pending" && job.status !== "running") break;
+      if (!job) break;
+    } else {
+      break;
+    }
+    await new Promise((r) => setTimeout(r, RUN_POLL_INTERVAL_MS));
+  }
+
+  // Resolve outcome per test from its latest result (robust for both the
+  // direct-run and queued paths).
+  const statuses = new Map<string, "passed" | "failed">();
+  for (const testId of testIds) {
+    const results = await queries.getTestResultsByTest(testId);
+    const latest = results[0];
+    statuses.set(testId, latest?.status === "passed" ? "passed" : "failed");
+  }
+  return statuses;
+}
+
+// ── Step: qa_execute ─────────────────────────────────────────────────────────
+
+async function runQaExecute(
+  sessionId: string,
+  teamId: string,
+  repositoryId: string,
+  signal: AbortSignal,
+): Promise<boolean> {
+  await setStepActive(sessionId, "qa_execute");
+  const session = await queries.getAgentSession(sessionId);
+  const ledger = [...(session?.metadata.qaGeneratedTests ?? [])];
+  const runnable = ledger.filter((g) => g.testId);
+  if (runnable.length === 0) {
+    await setStepFailed(sessionId, "qa_execute", "No generated tests to run");
+    return false;
+  }
+
+  await updateSubsteps(sessionId, "qa_execute", [
+    {
+      label: `Running ${runnable.length} tests`,
+      status: "running",
+      agent: "orchestrator",
+    },
+  ]);
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:start",
+    `Executing ${runnable.length} generated tests`,
+    { stepId: "qa_execute", agentType: "orchestrator" },
+  );
+
+  let statuses: Map<string, "passed" | "failed"> | null;
+  try {
+    statuses = await runAndCollect(
+      sessionId,
+      repositoryId,
+      runnable.map((g) => g.testId!) as string[],
+      signal,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    await setStepFailed(sessionId, "qa_execute", `Run failed: ${msg}`);
+    return false;
+  }
+  if (!statuses) return false; // stopped
+
+  let passed = 0;
+  for (const entry of ledger) {
+    if (!entry.testId) continue;
+    const status = statuses.get(entry.testId);
+    entry.status = status === "passed" ? "passed" : "failed";
+    if (status === "passed") passed += 1;
+  }
+  await mergeMetadata(sessionId, { qaGeneratedTests: [...ledger] });
+  await updateSubsteps(sessionId, "qa_execute", [
+    {
+      label: `Running ${runnable.length} tests`,
+      status: "done",
+      detail: `${passed} passed, ${runnable.length - passed} failed`,
+      agent: "orchestrator",
+    },
+  ]);
+  await setStepCompleted(sessionId, "qa_execute", {
+    total: runnable.length,
+    passed,
+    failed: runnable.length - passed,
+  });
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:complete",
+    `Suite executed: ${passed}/${runnable.length} passed`,
+    { stepId: "qa_execute", agentType: "orchestrator" },
+  );
+  return true;
+}
+
+// ── Step: qa_heal ────────────────────────────────────────────────────────────
+
+async function runQaHeal(
+  sessionId: string,
+  teamId: string,
+  repositoryId: string,
+  signal: AbortSignal,
+): Promise<boolean> {
+  await setStepActive(sessionId, "qa_heal");
+  const session = await queries.getAgentSession(sessionId);
+  const ledger = [...(session?.metadata.qaGeneratedTests ?? [])];
+  const failing = ledger.filter((g) => g.testId && g.status === "failed");
+  if (failing.length === 0) {
+    await setStepSkipped(sessionId, "qa_heal", "Nothing to heal — all passed");
+    return true;
+  }
+
+  const substeps: NonNullable<AgentStepState["substeps"]> = failing.map(
+    (g) => ({
+      label: `Healing "${g.name}"`,
+      status: "pending",
+      agent: "healer",
+    }),
+  );
+  await updateSubsteps(sessionId, "qa_heal", substeps);
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:start",
+    `Healer fixing ${failing.length} failing tests`,
+    { stepId: "qa_heal", agentType: "healer" },
+  );
+
+  let runnerId: string | undefined;
+  const healedTestIds: string[] = [];
+  try {
+    const eb = await claimEmbeddedBrowserForAgent(EB_CLAIM_TIMEOUT_MS, () => {
+      mergeMetadata(sessionId, { queuedForBrowser: true }).catch(() => {});
+    });
+    if (eb) {
+      runnerId = eb.runnerId;
+      await mergeMetadata(sessionId, {
+        queuedForBrowser: false,
+        streamUrl: proxiedStream(eb.streamUrl),
+      });
+      const { agentHealTestCore } =
+        await import("@/lib/playwright/healer-agent");
+      for (let i = 0; i < failing.length; i++) {
+        if (await isStopped(sessionId, signal)) return false;
+        const entry = failing[i];
+        substeps[i] = { ...substeps[i], status: "running" };
+        await updateSubsteps(sessionId, "qa_heal", substeps);
+        try {
+          const timeoutSignal = AbortSignal.timeout(HEAL_TIMEOUT_MS);
+          const result = await agentHealTestCore(repositoryId, entry.testId!, {
+            cdpEndpoint: eb.cdpUrl,
+            signal: AbortSignal.any([signal, timeoutSignal]),
+          });
+          if (result.success && result.code) {
+            await queries.updateTest(entry.testId!, { code: result.code });
+            healedTestIds.push(entry.testId!);
+            substeps[i] = { ...substeps[i], status: "done" };
+          } else {
+            substeps[i] = {
+              ...substeps[i],
+              status: "error",
+              detail: result.error?.slice(0, 200),
+            };
+          }
+        } catch (err) {
+          substeps[i] = {
+            ...substeps[i],
+            status: "error",
+            detail: err instanceof Error ? err.message.slice(0, 200) : "failed",
+          };
+        }
+        await updateSubsteps(sessionId, "qa_heal", substeps);
+      }
+    } else {
+      for (let i = 0; i < substeps.length; i++) {
+        substeps[i] = {
+          ...substeps[i],
+          status: "error",
+          detail: "No embedded browser available",
+        };
+      }
+      await updateSubsteps(sessionId, "qa_heal", substeps);
+    }
+  } finally {
+    await mergeMetadata(sessionId, { streamUrl: undefined }).catch(() => {});
+    if (runnerId) await releasePoolEB(runnerId).catch(() => {});
+  }
+
+  // Re-run only the healed tests to confirm the fixes.
+  let confirmed = 0;
+  if (healedTestIds.length > 0) {
+    if (await isStopped(sessionId, signal)) return false;
+    const statuses = await runAndCollect(
+      sessionId,
+      repositoryId,
+      healedTestIds,
+      signal,
+    ).catch(() => null);
+    if (statuses === null && signal.aborted) return false;
+    for (const entry of ledger) {
+      if (!entry.testId || !healedTestIds.includes(entry.testId)) continue;
+      const status = statuses?.get(entry.testId);
+      entry.status = status === "passed" ? "healed" : "failed";
+      if (status === "passed") confirmed += 1;
+    }
+    await mergeMetadata(sessionId, { qaGeneratedTests: [...ledger] });
+  }
+
+  await setStepCompleted(sessionId, "qa_heal", {
+    attempted: failing.length,
+    healed: confirmed,
+  });
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:complete",
+    `Healed ${confirmed}/${failing.length} failing tests`,
+    { stepId: "qa_heal", agentType: "healer" },
+  );
+  return true;
+}
+
+// ── Step: qa_summary ─────────────────────────────────────────────────────────
+
+async function runQaSummary(
+  sessionId: string,
+  teamId: string,
+  repositoryId: string,
+): Promise<boolean> {
+  await setStepActive(sessionId, "qa_summary");
+  const session = await queries.getAgentSession(sessionId);
+  const plan = session?.metadata.qaPlan;
+  if (!session || !plan) {
+    await setStepFailed(sessionId, "qa_summary", "Missing plan");
+    return false;
+  }
+  const summary = computeQaSummary(
+    plan,
+    session.metadata.qaGeneratedTests ?? [],
+  );
+  await mergeMetadata(sessionId, { qaSummary: summary });
+  await setStepCompleted(sessionId, "qa_summary", {
+    planned: summary.planned,
+    generated: summary.generated,
+    passed: summary.passed,
+  });
+  await queries.updateAgentSession(sessionId, {
+    status: "completed",
+    completedAt: new Date(),
+  });
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "session:complete",
+    `QA suite build complete: ${summary.generated} tests generated, ${summary.passed} passing`,
+  );
+  return true;
+}
+
+// ── Pipeline ─────────────────────────────────────────────────────────────────
+
+const QA_PIPELINE: AgentStepId[] = QA_STEP_DEFINITIONS.map((s) => s.id);
+
+async function executeQaPipeline(
+  sessionId: string,
+  teamId: string,
+  repositoryId: string,
+  fromStep: AgentStepId,
+) {
+  const controller = getOrCreateController(sessionId);
+  const signal = controller.signal;
+  const startIdx = QA_PIPELINE.indexOf(fromStep);
+  if (startIdx === -1) return;
+
+  try {
+    for (let i = startIdx; i < QA_PIPELINE.length; i++) {
+      if (await isStopped(sessionId, signal)) return;
+      const stepId = QA_PIPELINE[i];
+      let ok = false;
+      switch (stepId) {
+        case "qa_setup":
+          ok = await runQaSetup(sessionId, teamId, repositoryId, signal);
+          break;
+        case "qa_discover":
+          ok = await runQaDiscover(sessionId, teamId, repositoryId, signal);
+          break;
+        case "qa_plan":
+          ok = await runQaPlan(sessionId, teamId, repositoryId, signal);
+          break;
+        case "qa_plan_review":
+          ok = await runQaPlanReview(sessionId, teamId, repositoryId);
+          break;
+        case "qa_generate":
+          ok = await runQaGenerate(sessionId, teamId, repositoryId, signal);
+          break;
+        case "qa_execute":
+          ok = await runQaExecute(sessionId, teamId, repositoryId, signal);
+          break;
+        case "qa_heal":
+          ok = await runQaHeal(sessionId, teamId, repositoryId, signal);
+          break;
+        case "qa_summary":
+          ok = await runQaSummary(sessionId, teamId, repositoryId);
+          break;
+      }
+      if (!ok) return;
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error("[QaAgent] pipeline error:", err);
+    const session = await queries.getAgentSession(sessionId).catch(() => null);
+    const current = session?.currentStepId ?? fromStep;
+    await setStepFailed(sessionId, current, msg).catch(() => {});
+    emitActivity(
+      teamId,
+      repositoryId,
+      sessionId,
+      "session:error",
+      `QA agent failed: ${msg}`,
+    );
+  } finally {
+    activeControllers.delete(sessionId);
+  }
+}
+
+// ── Public actions ───────────────────────────────────────────────────────────
+
+export interface StartQaAgentInput {
+  repositoryId: string;
+  targetUrl: string;
+  groups: QaTestGroup[];
+  email?: string;
+  password?: string;
+  autoApprove?: boolean;
+}
+
+export async function startQaAgent(
+  input: StartQaAgentInput,
+): Promise<{ sessionId: string }> {
+  const { team } = await requireRepoAccess(input.repositoryId);
+
+  const targetUrl = input.targetUrl.trim().replace(/\/+$/, "");
+  if (!/^https?:\/\//i.test(targetUrl)) {
+    throw new Error("Target URL must start with http(s)://");
+  }
+  try {
+    await assertSafeOutboundUrl(targetUrl);
+  } catch (err) {
+    if (err instanceof SsrfBlockedError) {
+      throw new Error(`URL rejected: ${err.message}`);
+    }
+    throw err;
+  }
+
+  // One active QA session per repo — cancel a stale one before starting.
+  const existing = await queries.getActiveAgentSession(
+    input.repositoryId,
+    "qa",
+  );
+  if (existing) {
+    activeControllers.get(existing.id)?.abort();
+    await queries.updateAgentSession(existing.id, {
+      status: "cancelled",
+      completedAt: new Date(),
+    });
+  }
+
+  const credsProvided = Boolean(input.email?.trim() && input.password);
+  const steps: AgentStepState[] = QA_STEP_DEFINITIONS.map((def, i) => ({
+    id: def.id,
+    status: i === 0 ? "active" : "pending",
+    label: def.label,
+    description: def.description,
+  }));
+
+  const session = await queries.createAgentSession({
+    repositoryId: input.repositoryId,
+    teamId: team.id,
+    kind: "qa",
+    status: "active",
+    currentStepId: "qa_setup",
+    steps,
+    metadata: {
+      qaTargetUrl: targetUrl,
+      qaGroups: normalizeQaGroups(input.groups),
+      qaAutoApprove: Boolean(input.autoApprove),
+      credsProvided,
+      authMode: credsProvided ? "login" : "public_only",
+      ...(credsProvided
+        ? {
+            quickstartEmail: input.email!.trim(),
+            quickstartPassword: input.password!,
+          }
+        : {}),
+    },
+  });
+
+  emitActivity(
+    team.id,
+    input.repositoryId,
+    session.id,
+    "session:start",
+    `QA agent started on ${targetUrl}`,
+  );
+
+  executeQaPipeline(session.id, team.id, input.repositoryId, "qa_setup").catch(
+    (err) => console.error("[QaAgent] unhandled:", err),
+  );
+
+  revalidatePath("/qa-agent");
+  return { sessionId: session.id };
+}
+
+async function requireQaSession(sessionId: string): Promise<{
+  session: AgentSession;
+  teamId: string;
+}> {
+  const { team } = await requireTeamAccess();
+  const session = await queries.getAgentSession(sessionId);
+  if (!session || session.kind !== "qa") {
+    throw new Error("QA session not found");
+  }
+  if (session.teamId && session.teamId !== team.id) {
+    throw new Error("QA session not found");
+  }
+  return { session, teamId: team.id };
+}
+
+export async function approveQaPlan(
+  sessionId: string,
+  opts?: { disabledItemIds?: string[]; autoApprove?: boolean },
+): Promise<{ success: boolean }> {
+  const { session, teamId } = await requireQaSession(sessionId);
+  const plan = session.metadata.qaPlan;
+  if (!plan) return { success: false };
+
+  const disabled = new Set(opts?.disabledItemIds ?? []);
+  const updatedPlan: QaTestPlan = {
+    ...plan,
+    items: plan.items.map((i) => ({ ...i, enabled: !disabled.has(i.id) })),
+  };
+  if (enabledPlanItems(updatedPlan).length === 0) {
+    throw new Error("Cannot approve a plan with every test disabled");
+  }
+
+  await queries.updateAgentSession(sessionId, { status: "active" });
+  await mergeMetadata(sessionId, {
+    qaPlan: updatedPlan,
+    ...(opts?.autoApprove !== undefined
+      ? { qaAutoApprove: opts.autoApprove }
+      : {}),
+  });
+  await updateStep(sessionId, "qa_plan_review", {
+    status: "completed",
+    completedAt: new Date().toISOString(),
+    userAction: `approved (${enabledPlanItems(updatedPlan).length} tests)`,
+  });
+  emitActivity(
+    teamId,
+    session.repositoryId,
+    sessionId,
+    "step:complete",
+    `Plan approved with ${enabledPlanItems(updatedPlan).length} tests`,
+    { stepId: "qa_plan_review", agentType: "orchestrator" },
+  );
+
+  executeQaPipeline(
+    sessionId,
+    teamId,
+    session.repositoryId,
+    "qa_generate",
+  ).catch((err) => console.error("[QaAgent] unhandled:", err));
+  revalidatePath("/qa-agent");
+  return { success: true };
+}
+
+export async function rerunQaPlanner(
+  sessionId: string,
+  feedback: string,
+): Promise<{ success: boolean }> {
+  const { session, teamId } = await requireQaSession(sessionId);
+  await mergeMetadata(sessionId, {
+    qaPlannerFeedback: feedback.slice(0, 4000),
+  });
+  await updateStep(sessionId, "qa_plan", {
+    status: "pending",
+    completedAt: undefined,
+    error: undefined,
+    substeps: [],
+  });
+  await updateStep(sessionId, "qa_plan_review", {
+    status: "pending",
+    userAction: undefined,
+  });
+  await queries.updateAgentSession(sessionId, { status: "active" });
+
+  executeQaPipeline(sessionId, teamId, session.repositoryId, "qa_plan").catch(
+    (err) => console.error("[QaAgent] unhandled:", err),
+  );
+  revalidatePath("/qa-agent");
+  return { success: true };
+}
+
+export async function pauseQaAgent(
+  sessionId: string,
+): Promise<{ success: boolean }> {
+  const { session } = await requireQaSession(sessionId);
+  if (session.status !== "active") return { success: false };
+  activeControllers.get(sessionId)?.abort();
+  await queries.updateAgentSession(sessionId, { status: "paused" });
+  revalidatePath("/qa-agent");
+  return { success: true };
+}
+
+export async function resumeQaAgent(
+  sessionId: string,
+): Promise<{ success: boolean }> {
+  const { session, teamId } = await requireQaSession(sessionId);
+  if (session.status !== "paused") return { success: false };
+
+  // If we're paused at the review gate, resuming means "keep waiting" — the
+  // user should approve instead. Everything else re-runs the current step.
+  const current = session.currentStepId ?? "qa_setup";
+  if (current === "qa_plan_review" && !session.metadata.qaAutoApprove) {
+    return { success: false };
+  }
+  await queries.updateAgentSession(sessionId, { status: "active" });
+  executeQaPipeline(sessionId, teamId, session.repositoryId, current).catch(
+    (err) => console.error("[QaAgent] unhandled:", err),
+  );
+  revalidatePath("/qa-agent");
+  return { success: true };
+}
+
+export async function cancelQaAgent(
+  sessionId: string,
+): Promise<{ success: boolean }> {
+  const { session, teamId } = await requireQaSession(sessionId);
+  activeControllers.get(sessionId)?.abort();
+  await queries.updateAgentSession(sessionId, {
+    status: "cancelled",
+    completedAt: new Date(),
+  });
+  emitActivity(
+    teamId,
+    session.repositoryId,
+    sessionId,
+    "session:error",
+    "QA agent cancelled by user",
+  );
+  revalidatePath("/qa-agent");
+  return { success: true };
+}

--- a/src/server/actions/quickstart-agent.ts
+++ b/src/server/actions/quickstart-agent.ts
@@ -46,7 +46,7 @@ import { embeddedSessions } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { toProxyStreamUrl } from "@/lib/eb/stream-url";
 import { appendStreamToken } from "@/lib/eb/stream-token";
-import { chromium, type Browser } from "playwright";
+import { injectStorageStateIntoEb } from "@/lib/eb/inject-storage-state";
 import { readFile } from "fs/promises";
 import { resolveStoragePath } from "@/lib/storage/paths";
 import { computeDiffClusters } from "@/lib/diff/diff-clusters";
@@ -773,90 +773,6 @@ async function runQsAuthSetup(
     { stepId: "qs_auth_setup", agentType: "quickstart" },
   );
   return true;
-}
-
-/**
- * Inject a captured storage_state (cookies + localStorage) into the EB's default
- * browser context over CDP, so the authed scout starts already-signed-in. This
- * removes the LLM-driven login replay that made `qs_scout_authed` the slowest
- * step (~3.5min): the session was already captured 16s earlier in `qs_auth_setup`,
- * so re-driving the form through the model is pure waste.
- *
- * Targets `browser.contexts()[0]` — the persistent default context that
- * `@playwright/mcp --cdp-endpoint` reuses — NOT a fresh `newContext` (which MCP
- * would never see). `browser.close()` over connectOverCDP only disconnects the
- * CDP session; it does not terminate the EB's Chromium (mirrors play-agent.ts).
- *
- * Returns whether enough session material (cookies and/or localStorage) was
- * injected to consider the browser pre-authenticated. IndexedDB-only captures
- * (e.g. Firebase) inject nothing here → caller falls back to seed replay.
- */
-async function injectStorageStateIntoEb(
-  cdpUrl: string,
-  storageStateJson: string,
-): Promise<boolean> {
-  let browser: Browser | null = null;
-  try {
-    const parsed = JSON.parse(storageStateJson) as {
-      cookies?: Array<Record<string, unknown>>;
-      origins?: Array<{
-        origin?: string;
-        localStorage?: Array<{ name: string; value: string }>;
-      }>;
-    };
-    const cookies = Array.isArray(parsed.cookies) ? parsed.cookies : [];
-    const origins = Array.isArray(parsed.origins) ? parsed.origins : [];
-    const hasLocalStorage = origins.some(
-      (o) => Array.isArray(o.localStorage) && o.localStorage.length > 0,
-    );
-    // Nothing cookie/localStorage-shaped to inject (e.g. IndexedDB-only Firebase
-    // capture) — let the caller fall back to LLM seed replay.
-    if (cookies.length === 0 && !hasLocalStorage) return false;
-
-    browser = await chromium.connectOverCDP(cdpUrl);
-    const ctx = browser.contexts()[0];
-    if (!ctx) return false;
-
-    if (cookies.length > 0) {
-      // Cookies come straight from Playwright's own storageState() capture, so
-      // they already match addCookies' param shape — route through `unknown` to
-      // satisfy the structural check on the loosely-parsed JSON.
-      await ctx.addCookies(
-        cookies as unknown as Parameters<typeof ctx.addCookies>[0],
-      );
-    }
-    for (const o of origins) {
-      const ls = Array.isArray(o.localStorage) ? o.localStorage : [];
-      if (!o.origin || ls.length === 0) continue;
-      const page = await ctx.newPage();
-      try {
-        await page
-          .goto(o.origin, { waitUntil: "domcontentloaded", timeout: 10000 })
-          .catch(() => {});
-        await page.evaluate((items) => {
-          for (const it of items) {
-            try {
-              window.localStorage.setItem(it.name, it.value);
-            } catch {
-              /* quota / opaque origin — best effort */
-            }
-          }
-        }, ls);
-      } finally {
-        await page.close().catch(() => {});
-      }
-    }
-    return true;
-  } catch (err) {
-    console.warn(
-      `[QuickStart authed-scout] storage_state injection failed: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-    return false;
-  } finally {
-    if (browser) await browser.close().catch(() => {});
-  }
 }
 
 async function runQsScoutAuthed(


### PR DESCRIPTION
## Summary

Introduces the **QA Agent** — a dedicated, multi-phase orchestrator for building comprehensive test suites from live app discovery and AI-driven planning. The agent runs an eight-phase pipeline (setup → discover → plan → review → generate → execute → heal → summary) with narrowly-scoped subagent calls, keeping context windows small while the session metadata carries full state.

## Key Changes

### Core Orchestration
- **`src/server/actions/qa-agent.ts`** (1762 lines) — Main orchestrator implementing the eight-phase pipeline:
  - `qa_setup`: Validates target URL, AI provider, GitHub connection
  - `qa_discover`: Static route scan + live Embedded Browser crawl (DOM, selectors, API endpoints)
  - `qa_plan`: AI planner generates risk-prioritized test plan from discovery digest
  - `qa_plan_review`: Human gate for plan approval/adjustment
  - `qa_generate`: Generator creates one test per plan item with live selector verification
  - `qa_execute`: Runs generated suite against target app
  - `qa_heal`: Fixes failing tests and re-runs them
  - `qa_summary`: Coverage matrix and journey traceability
  - Session/step state management, activity event emission, AbortController registry for cancellation

### Planning & Discovery
- **`src/lib/qa-agent/plan.ts`** (619 lines) — Pure, deterministic planning helpers:
  - Test group definitions (journey, smoke, api, ui, hybrid, a11y, perf, resilience, negative)
  - Plan validation (`isQaTestPlan`), sanitization, matching to existing tests
  - Prompt builders for planner and generator subagents
  - Coverage digest and API definition builders
  - QA summary computation
  
- **`src/lib/qa-agent/crawl.ts`** (280 lines) — Live discovery crawl:
  - Connects to provisioned Embedded Browser over CDP
  - Extracts structured page map from live DOM (headings, forms, buttons, links, test IDs, selectors)
  - Records same-origin API endpoints observed during page loads
  - Optional login before crawl (fills password field in first form)
  - Deterministic, no AI involved; crawl is watchable via EB screencast

### UI Components
- **`src/components/qa-agent/qa-agent-client.tsx`** (723 lines) — Main client component:
  - Session status hero with live status badge
  - Phase timeline with step dots and substep details
  - Browser viewer integration for live EB stream
  - Controls: start, pause, resume, cancel, skip to next phase
  - Conditional rendering of plan review, generated tests, and summary panels

- **`src/components/qa-agent/qa-plan-review.tsx`** (262 lines) — Human review gate:
  - Displays plan grouped by test group with priority badges
  - Checkbox toggles to disable/enable plan items
  - Feedback textarea for requesting changes
  - Approve/request-changes actions

- **`src/components/qa-agent/qa-results-panel.tsx`** (314 lines) — Results display:
  - Generated tests panel grouped by test group with status badges
  - QA summary panel showing coverage matrix and journey traceability

- **`src/components/qa-agent/use-qa-agent.ts`** (219 lines) — Client hook:
  - Manages session state and polling (`/api/qa-agent/[sessionId]`)
  - Server action wrappers: `startQaAgent`, `approveQaPlan`, `rerunQaPlanner`, pause/resume/cancel
  - Per-repo session ID persistence in localStorage

### Page & API
- **`src/app/(app)/qa-agent/page.tsx`** (116 lines) — QA Agent page:
  - Loads selected repo, latest/recent agent sessions, GitHub account, AI settings
  - Renders `QaAgentClient` with initial session state
  - Repo/AI provider requirement checks

- **`src/app/api/qa-agent/[sessionId]/route.ts`** (37 lines) — Session fetch endpoint

https://claude.ai/code/session_01Dsh9xdWygJAQoGC8LhYe2s