### PR TITLE
Add interactive test playback & storage state evidence layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,4 +114,4 @@ docs/todo.md
 docs/olares-deploy-notes.md
 public/showcase/*
 appsumo-codes.csv
-docs/olares-deploy-notes.md
+.playback-demo/playback-demo.mp4

--- a/.playback-demo/explore.mjs
+++ b/.playback-demo/explore.mjs
@@ -1,0 +1,84 @@
+import { chromium } from "playwright";
+
+const OUT =
+  "/private/tmp/claude-501/-Users-ewyct-dev-lastest/f600801e-7f3a-4f05-9afd-55bfdbb67399/scratchpad";
+const TEST_ID = "f081ce67-db30-4901-8f5b-46008c509878";
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({
+  viewport: { width: 1500, height: 950 },
+});
+await ctx.addCookies([
+  {
+    name: "lastest_cookie_notice",
+    value: "true",
+    domain: "localhost",
+    path: "/",
+  },
+]);
+const page = await ctx.newPage();
+
+await page.goto("http://localhost:3000/login");
+await page.locator('input[type="email"]').fill("demo@lastest.local");
+await page.locator('input[type="password"]').fill("DemoPassw0rd!");
+await page.locator('button[type="submit"]').click();
+await page.waitForTimeout(4000);
+console.log("after login:", page.url());
+await page.screenshot({ path: `${OUT}/01-after-login.png` });
+
+const consent = page.getByRole("button", { name: /^Got it$/i });
+if (await consent.count())
+  await consent
+    .first()
+    .click()
+    .catch(() => {});
+await page.waitForTimeout(500);
+
+if (page.url().includes("/onboarding")) {
+  await page.getByRole("button", { name: /Skip setup/i }).click();
+  await page.waitForTimeout(4000);
+  console.log("after skip:", page.url());
+}
+
+await page.waitForTimeout(2000);
+// Pick the seeded repo in the sidebar so /tests/<id> resolves.
+const picker = page.locator('button:has-text("Select reposit")');
+if (await picker.count()) {
+  await picker.first().click();
+  await page.waitForTimeout(1200);
+  await page
+    .getByText(/lastest-local/i)
+    .first()
+    .click();
+  await page.waitForTimeout(3000);
+}
+console.log("before nav:", page.url());
+await page.goto(`http://localhost:3000/tests/${TEST_ID}`, {
+  waitUntil: "domcontentloaded",
+});
+await page.waitForLoadState("networkidle").catch(() => {});
+await page.waitForTimeout(2500);
+await page.screenshot({ path: `${OUT}/02-test-detail.png`, fullPage: true });
+
+// Open the Recordings tab — the primary spec-28 surface.
+await page
+  .getByRole("tab", { name: /^Recordings$/i })
+  .click()
+  .catch(async () => {
+    await page.locator('button:has-text("Recordings")').first().click();
+  });
+await page.waitForTimeout(3000);
+await page.screenshot({ path: `${OUT}/03-recordings.png`, fullPage: false });
+
+const segs = page.locator('[aria-label="Test steps"] button');
+console.log("segment ticks:", await segs.count());
+console.log("videos:", await page.locator("video").count());
+const texts = await page.locator("h2, h3, [role=tab], button").allInnerTexts();
+console.log(
+  "labels:",
+  JSON.stringify(
+    [...new Set(texts.map((t) => t.trim()).filter(Boolean))].slice(0, 60),
+  ),
+);
+
+await browser.close();

--- a/.playback-demo/record-demo.mjs
+++ b/.playback-demo/record-demo.mjs
@@ -1,0 +1,214 @@
+/**
+ * Records a demo of the spec-28 interactive playback UI driving a real test
+ * recording (test result 535dcb54… — 20 persisted step timings, 17.3s webm).
+ *
+ * Scene 1: test-detail Recordings card (annotated scrubber, click-to-seek,
+ *          active-step highlight, 8x rate presets).
+ * Scene 2: Verify focus mode Run pane with the same player embedded.
+ */
+import { chromium } from "playwright";
+
+const OUT = "/Users/ewyct/dev/lastest/.playback-demo";
+const TEST_ID = "f081ce67-db30-4901-8f5b-46008c509878";
+const BUILD_ID = "f3a8dc04-a87d-44c4-bb50-d3234e37db0a";
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({
+  viewport: { width: 1440, height: 900 },
+  recordVideo: { dir: `${OUT}/raw2`, size: { width: 1440, height: 900 } },
+});
+await ctx.addCookies([
+  {
+    name: "lastest_cookie_notice",
+    value: "true",
+    domain: "localhost",
+    path: "/",
+  },
+]);
+const page = await ctx.newPage();
+const log = (m) => console.log(`[demo] ${m}`);
+
+const state = async (label) => {
+  const s = await page.evaluate(() => {
+    const v = document.querySelector("video");
+    return v
+      ? {
+          t: +v.currentTime.toFixed(2),
+          dur: +(v.duration || 0).toFixed(2),
+          paused: v.paused,
+          rate: v.playbackRate,
+        }
+      : null;
+  });
+  log(`${label}: ${JSON.stringify(s)}`);
+  return s;
+};
+
+// ── sign in ───────────────────────────────────────────────────────────────
+await page.goto("http://localhost:3000/login");
+await page.locator('input[type="email"]').fill("demo@lastest.local");
+await page.locator('input[type="password"]').fill("DemoPassw0rd!");
+await page.locator('button[type="submit"]').click();
+await page.waitForTimeout(4000);
+
+const picker = page.locator('button:has-text("Select reposit")');
+if (await picker.count()) {
+  await picker.first().click();
+  await page.waitForTimeout(1000);
+  await page
+    .getByText(/lastest-local/i)
+    .first()
+    .click();
+  await page.waitForTimeout(2500);
+}
+
+// ── scene 1 ───────────────────────────────────────────────────────────────
+await page.goto(`http://localhost:3000/tests/${TEST_ID}`, {
+  waitUntil: "domcontentloaded",
+});
+await page.waitForTimeout(3500);
+await page
+  .getByRole("tab", { name: /^Recordings$/i })
+  .click()
+  .catch(async () => {
+    await page.locator('button:has-text("Recordings")').first().click();
+  });
+await page.waitForTimeout(2500);
+
+const video = page.locator("video").first();
+await video.scrollIntoViewIfNeeded();
+await page.mouse.wheel(0, 120);
+await page.waitForTimeout(1500);
+
+const box = await video.boundingBox();
+const centre = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+const wake = async () => {
+  await page.mouse.move(centre.x, centre.y + 40);
+  await page.mouse.move(centre.x, centre.y);
+};
+await wake();
+await page.waitForTimeout(1500);
+
+const segs = page.locator('[aria-label="Test steps"] button');
+const segCount = await segs.count();
+log(`segment ticks: ${segCount}`);
+for (let i = 0; i < Math.min(segCount, 20); i++) {
+  log(`  tick ${i}: ${await segs.nth(i).getAttribute("aria-label")}`);
+}
+
+// Hover ticks so the per-step tooltips/hover states show on camera.
+// (wake first: the control overlay auto-hides and the <video> then eats
+// pointer events; several steps are also zero-length so they overlap.)
+for (const i of [2, 4, 8]) {
+  if (i >= segCount) continue;
+  await wake();
+  await segs.nth(i).hover({ force: true });
+  await page.waitForTimeout(1100);
+}
+
+// Play with the control-bar button (not a click on the surface).
+await page.getByRole("button", { name: "Play" }).first().click();
+await page.waitForTimeout(1200);
+await state("after play");
+for (let i = 0; i < 8; i++) {
+  await page.waitForTimeout(1000);
+  await wake();
+}
+await state("after ~8s of playback");
+
+// Click a step tick mid-playback → seek to that step.
+if (segCount > 13) {
+  await wake();
+  await segs.nth(13).click({ force: true });
+  log(`seek via tick 13 → ${await segs.nth(13).getAttribute("aria-label")}`);
+  await page.waitForTimeout(800);
+  await state("after tick seek");
+  for (let i = 0; i < 4; i++) {
+    await page.waitForTimeout(1000);
+    await wake();
+  }
+}
+
+// Seek back to an earlier step to show the active highlight moving.
+if (segCount > 5) {
+  await wake();
+  await segs.nth(5).click({ force: true });
+  await page.waitForTimeout(800);
+  await state("after seeking back to step 6");
+  for (let i = 0; i < 3; i++) {
+    await page.waitForTimeout(1000);
+    await wake();
+  }
+}
+
+// Speed presets now reach 8x.
+const rate = page.locator('button[aria-label^="Playback speed"]').first();
+if (await rate.count()) {
+  await rate.click();
+  await page.waitForTimeout(1500);
+  const eight = page.getByRole("button", { name: "8x", exact: true });
+  if (await eight.count()) {
+    await eight.first().click();
+    log("selected 8x");
+  }
+  await page.waitForTimeout(1000);
+  await wake();
+  await page.waitForTimeout(2500);
+  await state("at 8x");
+}
+
+// ── scene 2: Verify focus mode Run pane ──────────────────────────────────
+await page.goto(`http://localhost:3000/verify/${BUILD_ID}`, {
+  waitUntil: "domcontentloaded",
+});
+await page.waitForTimeout(5000);
+await page.screenshot({ path: `${OUT}/04-verify-board.png` });
+
+const focusToggle = page.getByRole("button", { name: /^Focus$/ });
+if (await focusToggle.count()) {
+  await focusToggle
+    .first()
+    .click()
+    .catch(() => {});
+  await page.waitForTimeout(3000);
+}
+await page.screenshot({ path: `${OUT}/05-verify-focus.png` });
+
+const runTab = page.locator('button[aria-label^="Run —"]').first();
+if (await runTab.count()) {
+  await runTab.click().catch(() => {});
+  log("opened the Run evidence tab");
+  await page.waitForTimeout(3000);
+}
+await page.screenshot({
+  path: `${OUT}/06-verify-run-pane.png`,
+  fullPage: true,
+});
+
+const v2 = page.locator("video").first();
+if (await v2.count()) {
+  await v2.scrollIntoViewIfNeeded();
+  await page.waitForTimeout(1200);
+  const b2 = await v2.boundingBox();
+  if (b2) {
+    const c2 = { x: b2.x + b2.width / 2, y: b2.y + b2.height / 2 };
+    await page.mouse.move(c2.x, c2.y);
+    await page.waitForTimeout(800);
+    const play2 = page.getByRole("button", { name: "Play" }).first();
+    if (await play2.count()) await play2.click().catch(() => {});
+    await state("verify run pane");
+    for (let i = 0; i < 7; i++) {
+      await page.waitForTimeout(1000);
+      await page.mouse.move(c2.x, c2.y + 30);
+      await page.mouse.move(c2.x, c2.y);
+    }
+    await state("verify run pane end");
+  }
+} else {
+  log("no video element in the Verify Run pane");
+}
+
+await page.waitForTimeout(1500);
+await ctx.close();
+await browser.close();
+log("done");

--- a/docs/specs/12-early-adopter-mode.md
+++ b/docs/specs/12-early-adopter-mode.md
@@ -28,6 +28,15 @@ async function updateEarlyAdopterMode(enabled: boolean): Promise<void>;
 - Toast feedback on success/error
 - Located in Settings → Features card
 
+### Server-side Gates
+
+Not every gated feature is a nav item. Server components read
+`session.team.earlyAdopterMode` through a small flag module and pass a boolean
+down, so the gated code degrades by omission rather than by branching:
+
+- `isInteractivePlaybackEnabled()` (`src/lib/playback/feature-flag.ts`) — the
+  spec-28 annotated player. Env override: `INTERACTIVE_PLAYBACK_ENABLED=1`.
+
 ### Sidebar Filtering
 
 - **File**: `src/components/layout/sidebar.tsx`
@@ -37,8 +46,9 @@ async function updateEarlyAdopterMode(enabled: boolean): Promise<void>;
 
 ## Gated Features
 
-| Feature | Purpose                                          |
-| ------- | ------------------------------------------------ |
-| Compose | Build composition with test selection per branch |
-| Suites  | Ordered test suite management                    |
-| Compare | Side-by-side branch comparison                   |
+| Feature              | Purpose                                                          |
+| -------------------- | ---------------------------------------------------------------- |
+| Compose              | Build composition with test selection per branch                  |
+| Suites               | Ordered test suite management                                 |
+| Compare              | Side-by-side branch comparison                                |
+| Interactive playback | Spec-28 annotated player (step scrubber, playback↔evidence sync) |

--- a/docs/specs/27-verify-review-evidence-ux.md
+++ b/docs/specs/27-verify-review-evidence-ux.md
@@ -92,6 +92,32 @@ All additive:
 | `src/server/actions/layer-feedback.ts`               | `decideLayer` (line 69) — unchanged, verify only     |
 | `src/lib/verify/case-status.ts`                      | picks up the new layer via generic machinery         |
 
+## Implementation notes (v1, shipped)
+
+Deviations from the sections above, chosen during implementation:
+
+- **Tab counts**: the strip's existing per-layer delta text (`+2 −1`,
+  `3 new`, …) already carries the change magnitude, so no separate `(N)`
+  badge was added; the State layer got a matching delta. Keyboard cycling
+  shipped as `[` / `]`.
+- **Network pane**: the pane was already a single filterable table with a
+  Δ-vs-baseline summary (not two columns) — kept. Added sortable columns,
+  totals footer, density mini-timeline, and body download. A PREVIEW tab
+  for images was dropped: the EB only captures bodies for fetch/xhr/
+  document requests (16 KB cap), so there is nothing to preview.
+- **Step detail header** shows the step screenshot as the thumbnail; target
+  selector + click coordinates were dropped — step logs don't reliably
+  carry them today.
+- **State tab** covers Cookies + localStorage (what
+  `storageStateSnapshot` captures); sessionStorage/IndexedDB would need
+  capture-side work first. The storage layer emits `low` signal and can
+  never flip a verdict — it is informational by design, mode default `log`
+  with a `storage_mode` settings column + per-test override.
+- **Perf chart** overlays the baseline as dashed per-metric reference lines
+  from `step_comparisons.layers.perf.deltas` (metric-level, not per-step —
+  per-step baseline samples aren't in the verify payload). CLS renders as
+  its own mini-chart rather than a second y-axis.
+
 ## Out of scope / gotchas
 
 - **No changes to `decideLayer` semantics** or the Verified/Missed/Broken triage model — this is presentation + one new layer, not a new review flow.

--- a/docs/specs/27-verify-review-evidence-ux.md
+++ b/docs/specs/27-verify-review-evidence-ux.md
@@ -1,0 +1,101 @@
+# Feature Spec: Verify Review Screen — Evidence UX Upgrades
+
+## Overview
+
+Upgrades the Verify focus mode (`/verify/[buildId]`) from a "read the layer verdicts" screen into a full evidence-inspection surface, adopting the report-UX patterns from best-in-class E2E report tools (tabbed evidence report synchronized with playback, per-step action metadata, filterable network/perf/state panes) while keeping Lastest's baseline-vs-current review model untouched: case statuses (Verified/Missed/Broken), per-layer decisions via `decideLayer`, and check modes all stay exactly as they are.
+
+This spec covers the review-screen changes only. The interactive video player it embeds (step-annotated scrubber, playback↔evidence sync bus) is specified separately in `docs/specs/28-interactive-test-playback.md` and referenced here as a dependency.
+
+## Current state
+
+- `src/app/(app)/verify/[buildId]/focus-view.tsx` (~6550 lines) renders a 12-tab evidence strip — `COMPARE_TABS` (focus-view.tsx:182): Run / Visual / Text / DOM / Network / Console / A11y / Design / Perf / URL / Variables / API — with per-tab tone dots from `classifyLayer` + check modes (`src/lib/verify/check-modes.ts`).
+- Board mode lives in `board-view.tsx`; live data via `/api/builds/[buildId]/verify-status` (2s poll); decisions via `decideLayer` (`src/server/actions/layer-feedback.ts:69`).
+- There is **no video playback anywhere in verify or builds pages** — players exist only in test-detail and the `/r/` share page.
+- Evidence available on `test_results` (`src/lib/db/schema.ts`): `screenshots` (`CapturedScreenshot[]`, schema.ts:887 — `atMs` video offset at schema.ts:535 is the only persisted step→video anchor), `consoleErrors` (`string[]`, schema.ts:893 — no timestamps), `networkRequests` (`NetworkRequest[]`, schema.ts:894 — absolute-epoch `startTime`), `videoPath` (schema.ts:919), `urlTrajectory` (schema.ts:942), `webVitals` (schema.ts:944), `storageStateSnapshot` (schema.ts:946).
+- `step_comparisons` rows carry the per-step verdict + per-layer sub-summaries but **no timing fields**.
+
+## 1. Tab strip upgrades
+
+- **Per-tab change counts** next to the existing tone dots: `Network (3)`, `Console (2)`, `A11y (5)`. Counts come from the `step_comparisons.layers` sub-summaries already in the verify-status payload (added/removed/changed item counts per layer), summed across the selected case's steps — computed client-side, no new queries.
+- Counts respect check modes: a layer in `disable` mode shows no count (matching how its tone dot is already muted); `log` layers show counts in the muted style.
+- **Keyboard tab cycling**: `[` / `]` (or `Tab`/`Shift+Tab` within the strip) cycles `COMPARE_TABS`; existing shortcut help overlay gains the entries.
+
+## 2. Step detail header
+
+A per-step action-metadata panel at the top of focus mode (above the pane content), showing for the selected step:
+
+- Step kind badge + natural-language label (from the step's `CapturedScreenshot.label`/`title`, schema.ts:526).
+- Duration **and video time range** (`0:10.1 → 0:17.9`) sourced from spec 28's `stepTimings` (`test_results.step_timings`); hidden for legacy rows without timings.
+- Target descriptor + click coordinates when the step logs carry them (EB runs populate `test_results.logs`, schema.ts:914 — `[Nav]`/`[Shot]` probe lines; selector/coords parsed best-effort, omitted otherwise).
+- A cropped "component interacted" thumbnail: the step screenshot cropped around the interaction coordinates when available, else the full step thumbnail.
+- Live status chip while the build is still running (data already flows through the 2s verify-status poll).
+
+## 3. Network pane parity
+
+Keep the existing baseline↔current column layout and add:
+
+- **Type filter chips with counts** — All / API / Img / Doc / Other, bucketed from `NetworkRequest.resourceType` (schema.ts:36): `xhr`+`fetch` → API, `image` → Img, `document` → Doc, rest → Other. Chips filter both columns.
+- **Request-density mini-timeline** over the run duration (video-relative once spec 28 rebases `startTime`; falls back to first-request-relative for legacy rows). Clicking a bucket scrolls the table.
+- **Sortable columns**: URL, time, status, type, size (`responseSize`).
+- **Row click → side panel** with HEADERS / RESPONSE / PREVIEW tabs. Headers come from `requestHeaders`/`responseHeaders`; bodies are fetched on demand from the `network_bodies_path` sidecar (schema.ts:920) — never inlined into the poll payload. PREVIEW renders image responses with a download button.
+- **Totals footer**: `83 requests, 179.5 KB transferred` per side (count + summed `responseSize`).
+- **Auto-scroll follow** ("RESUME AUTO-SCROLL"): when the spec-28 player is mounted and playing, the table follows `currentTimeMs`; manual scrolling pauses following and surfaces the resume affordance.
+
+## 4. Perf pane parity
+
+Replace the static web-vitals list with a chart:
+
+- **Time-series chart** of `WebVitalsSample` values (schema.ts:834) across steps, x-axis = step index (or video time when spec 28 timings exist).
+- **Toggleable series chips**: LCP / CLS / INP / FCP / TBT / TTFB. CLS plots on a secondary unitless axis.
+- **Hover crosshair tooltip** showing the step/time plus every enabled series value; when the spec-28 player is mounted, the crosshair tracks `currentTimeMs`.
+- **Peak badges**: e.g. `Peak LCP 3.2s @ step 4`, computed per enabled series.
+- **Baseline overlay**: baseline run values (from `perfBaselines`) drawn dashed, current run solid — this is the Lastest twist on the pattern: the chart is a comparison, not a single-run monitor.
+
+## 5. New State tab
+
+A 13th `COMPARE_TABS` entry (`state`), the web analogue of a "files touched" pane:
+
+- **Storage areas as the tree**: Cookies / localStorage / sessionStorage / IndexedDB from `test_results.storageStateSnapshot` (schema.ts:946), with `+N` change badges per area.
+- **Diffed current vs baseline run** (not start-vs-end of one run — consistent with every other verify layer): per-area ADD / CHANGE / REMOVE entries with key-level detail, and a "No changes" fallback state.
+- **Range selector (phase 2)**: scoping the diff to a step range requires per-step snapshots, which don't exist yet; the initial version diffs end-of-run snapshots only and the UI reserves the range control.
+- **New layer plumbing**: add `"storage"` to `EvidenceLayer` (schema.ts:4172) and `CheckLayer` (check-modes.ts:19), default mode `log` in `DEFAULTS` (check-modes.ts:41), and a `storageState` sub-summary computed post-run into `step_comparisons.layers`. The check-modes settings dialog gains the row; `classifyLayer` + case-status derivation pick it up through the existing generic layer machinery. `decideLayer` needs no changes — the new layer is decidable like any other.
+
+## 6. Run/Info parity
+
+Extend the existing RunPane (the `run` tab):
+
+- **Copyable IDs**: test ID, test-result ID, build ID, one-click copy.
+- **CLI / MCP snippets**: ready-to-paste `lastest_get_test_run` MCP call and a rerun command for this test/build.
+- **Execution metadata**: viewport, browser, EB image, runner kind, started/finished timestamps — mirrors the "Info" tab pattern.
+
+## 7. Embedded playback
+
+RunPane mounts the spec-28 interactive player when `test_results.videoPath` is set (schema.ts:919). Playing through a step optionally selects it in the case rail (opt-in toggle). All sync behavior (scrubber segments, `usePlaybackSync`) is defined in spec 28 — this spec only reserves the mount point and the opt-in.
+
+## Data / schema changes
+
+All additive:
+
+- Per-tab counts, network chips/sort/footer, perf chart: **client-side only**, computed from payloads the verify screen already receives.
+- Network bodies: fetched on demand per-request via the existing `network_bodies_path` sidecar route — the slim `TestResultLite` projection used by the verify-status poll must stay slim.
+- State layer: new `EvidenceLayer`/`CheckLayer` value + post-run `storageState` diff written into `step_comparisons.layers`; verify-status payload grows by the per-layer sub-summary only (bounded), respecting the 2s-poll size budget.
+- Step detail video time range: reads spec 28's `step_timings` — no schema work in this spec.
+
+## Key files
+
+| File                                                | Purpose                                              |
+| --------------------------------------------------- | ---------------------------------------------------- |
+| `src/app/(app)/verify/[buildId]/focus-view.tsx`      | `COMPARE_TABS` (line 182), all panes, step header    |
+| `src/app/api/builds/[buildId]/verify-status/route.ts` | 2s poll payload; gains storage sub-summary          |
+| `src/lib/verify/check-modes.ts`                      | `CheckLayer` union + `DEFAULTS` gain `storage: "log"` |
+| `src/lib/db/schema.ts`                               | `EvidenceLayer` (line 4172), `test_results` evidence columns |
+| `src/server/actions/layer-feedback.ts`               | `decideLayer` (line 69) — unchanged, verify only     |
+| `src/lib/verify/case-status.ts`                      | picks up the new layer via generic machinery         |
+
+## Out of scope / gotchas
+
+- **No changes to `decideLayer` semantics** or the Verified/Missed/Broken triage model — this is presentation + one new layer, not a new review flow.
+- **Poll payload discipline**: heavy evidence (network bodies, image previews, storage snapshots) is fetched on demand per-tab; nothing heavy rides the 2s poll.
+- **Legacy rows**: every new affordance must degrade — no `step_timings` → hide time ranges and density-timeline video anchoring; no `storageStateSnapshot` on the baseline run → State tab shows "no baseline snapshot" instead of a fake all-ADD diff.
+- **focus-view.tsx size**: at ~6550 lines, new panes (State, network side panel, perf chart) should land as extracted components, not more inline JSX.
+- Check-modes dialog + `DEFAULT_*` settings constants must both gain the new layer (see CLAUDE.md Schema Changes checklist).

--- a/docs/specs/27-verify-review-evidence-ux.md
+++ b/docs/specs/27-verify-review-evidence-ux.md
@@ -113,6 +113,12 @@ Deviations from the sections above, chosen during implementation:
   capture-side work first. The storage layer emits `low` signal and can
   never flip a verdict — it is informational by design, mode default `log`
   with a `storage_mode` settings column + per-test override.
+- **Run-pane recording is Early Adopter gated** — the player itself is
+  spec 28's, so `RunPlaybackCard` renders only when
+  `isInteractivePlaybackEnabled(team)` (see
+  `docs/specs/28-interactive-test-playback.md`). Everything else in this
+  spec (step detail header, tab counts/cycling, network + perf panes, State
+  tab and the `storage` check layer) is ungated.
 - **Perf chart** overlays the baseline as dashed per-metric reference lines
   from `step_comparisons.layers.perf.deltas` (metric-level, not per-step —
   per-step baseline samples aren't in the verify payload). CLS renders as

--- a/docs/specs/28-interactive-test-playback.md
+++ b/docs/specs/28-interactive-test-playback.md
@@ -100,6 +100,28 @@ Per the CLAUDE.md Schema Changes checklist (schema.ts → `pnpm db:push` → que
 | `src/lib/share/captions.ts`                          | replace even-split `timingFor` (line 98)              |
 | `src/lib/share/video-fallback.ts`                    | reuse `resolveTestVideoUrl` in test-detail            |
 
+## Implementation notes (v1, shipped)
+
+Deviations from the sections above, chosen during implementation:
+
+- **Console entries are a separate column**, `test_results.console_entries`
+  (`ConsoleEntry[]`), instead of widening `consoleErrors` to a union type —
+  ~40 consumer files treat `consoleErrors` as `string[]` (diffing, triage,
+  issue bodies), and a union would have forced a normalizer into every one
+  of them for zero data gain. `consoleErrors` stays the diff/compat surface;
+  `consoleEntries` carries `{atMs, level, text}` for timeline consumers.
+- **Clock rebasing is additive, not in-place**: `NetworkRequest.atMs` and
+  `UrlTrajectoryStep.atMs` (video-clock ms) sit alongside the original
+  epoch `startTime` / test-start `capturedAtMs` rather than rewriting them.
+- **No `video_start_ms` column** — the EB rebases timings to the video clock
+  before shipping the payload, so persisting the anchor adds nothing.
+- The sync bus is `usePlaybackSync` + `SyncedVideoPlayer`
+  (`src/components/playback-sync.tsx`); for server-rendered share islands,
+  `ReplayPlayer` additionally broadcasts a throttled
+  `lastest:playback-time` document event that `ChapterRail` consumes.
+- The timing ladder helper is `resolveStepSegments`
+  (`src/lib/playback/step-timings.ts`).
+
 ## Out of scope
 
 - No changes to CDP live streaming (`packages/embedded-browser` streaming path) — this is post-run playback only.

--- a/docs/specs/28-interactive-test-playback.md
+++ b/docs/specs/28-interactive-test-playback.md
@@ -1,0 +1,108 @@
+# Feature Spec: Interactive Test Playback (Step-Synced Timeline)
+
+## Overview
+
+Turns passive webm playback into a step-annotated, evidence-synced timeline: per-step tick marks with action icons on the scrubber, click-a-step-to-seek, active-step highlighting during playback, speed presets up to 8x, and a bidirectional sync bus so evidence panes (network table, perf chart, step list, chapter rail) can both follow and drive the video. Surfaces: test-detail Recordings card (primary), the `/r/` public share player, and the Verify RunPane (per `docs/specs/27-verify-review-evidence-ux.md` §7).
+
+The foundational move is clock unification: today step timings, network requests, console entries, and URL trajectory live on three different time origins (video-relative, absolute epoch, test-start-relative) — and per-step timings aren't persisted at all. Everything gets rebased to **one clock: the video clock** (ms since recording start).
+
+## Current state
+
+- `src/components/video-player.tsx` — scrubber with hover frame preview, playback-rate popover, `durationMsFallback` (video-player.tsx:80 — works around webm files missing EBML duration), imperative `seek`/`seekAndPlay` handle (video-player.tsx:51).
+- `src/components/replay-player.tsx` — document-level `[data-seek]` click listener (replay-player.tsx:31); `src/components/chapter-rail.tsx` — screenshot thumbnails seek via that data attribute.
+- Per-step timings exist live: the EB emits `response:step_event` with `durationMs` from `finishCurrentStep` (`packages/embedded-browser/src/test-executor.ts:1677`), but they land only in the in-memory `src/lib/ws/step-state.ts` (30-min TTL) — **never persisted**.
+- `videoStartMs` is anchored when recording starts (EB test-executor.ts:660) but **not persisted**; the only durable step→video anchor is `CapturedScreenshot.atMs` (schema.ts:535).
+- `networkRequests[].startTime` is absolute epoch; `urlTrajectory[].capturedAtMs` is relative to test start; `consoleErrors` is `string[]` with no timestamps (schema.ts:893, captured at EB test-executor.ts:1087).
+- Known reliability gaps folded into this spec: `videoPath` persistence is a silent best-effort try/catch (`src/lib/execution/executor.ts:1288-1312`); the disk fallback `resolveTestVideoUrl` (`src/lib/share/video-fallback.ts`) is share-only; share captions use an even-split clock (`src/lib/share/captions.ts:98`) that drifts from the chapter rail's `atMs` anchors.
+
+## 1. Data model: persist step timings
+
+New jsonb column on `test_results`:
+
+```typescript
+stepTimings: jsonb("step_timings").$type<StepTiming[]>(),
+
+interface StepTiming {
+  stepIndex: number;
+  label: string;      // "Step N" structural key, matches CapturedScreenshot.label
+  stepType: string;   // navigate | click | fill | assert | shot | ...
+  status: "passed" | "failed";
+  startMs: number;    // relative to videoStartMs
+  endMs: number;
+}
+```
+
+- **Source**: the EB's existing `finishCurrentStep` events (test-executor.ts:1677) are accumulated **in the EB process** and returned in the final result payload alongside `screenshots` — not read back from the lossy in-memory ws `step-state.ts`. The executor (`src/lib/execution/executor.ts`) threads the array through to the insert exactly like `screenshots`.
+- **Clock**: the EB rebases each event to `videoStartMs` (test-executor.ts:660) before emitting the final array, so persisted values are already video-relative. `videoStartMs` itself is persisted on the payload envelope (or as `video_start_ms`) for forensics/legacy rebasing.
+- **Backfill ladder** for legacy rows (same ladder `collectChapters` uses today): `stepTimings` → `screenshots[].atMs` anchors (step spans between consecutive anchors) → even split across `durationMsFallback`.
+
+## 2. Clock rebasing (all evidence onto the video clock)
+
+- **Network**: rebase `NetworkRequest.startTime` (epoch) to video-relative ms at persist time; legacy rows rebase at read time using a screenshot's `(atMs, capturedAt)` pair when one exists, else remain unanchored (consumers hide time-sync affordances).
+- **URL trajectory**: `capturedAtMs` is test-start-relative; test start vs `videoStartMs` differs by context-creation time — rebase at persist time with the same offset the EB already knows.
+- **Console**: extend capture (EB test-executor.ts:1087) to `{ atMs, level, text }` (video-relative). The column type becomes the union `string[] | ConsoleEntry[]` — jsonb, no migration; readers use a small normalizer that maps legacy strings to `{ atMs: null, level: "error", text }`.
+
+## 3. Annotated scrubber
+
+Extend `VideoPlayer` (`src/components/video-player.tsx`) with an optional `segments` prop derived from `stepTimings`:
+
+- **Per-step segment ticks** under the existing Radix slider track, with step numbers below and pass/fail status coloring.
+- **Tiny action icons** per segment, chosen by `stepType` (lucide: navigate → globe, click → mouse-pointer, fill → keyboard, shot → camera, assert → check); a `+N` collapse when segments are too narrow.
+- **Click segment → seek** to `startMs`; **active segment highlight** driven by `timeupdate`.
+- **Speed presets up to 8x** in the existing rate popover (currently tops out lower); persisted per-session.
+- No `segments` prop → identical to today's player (share/legacy paths unaffected until wired).
+
+## 4. Bidirectional sync bus
+
+A small React context + event emitter, `usePlaybackSync`:
+
+- Player publishes `currentTimeMs` (throttled to ~4 Hz for consumers; scrubber stays on raw `timeupdate`).
+- Any pane publishes `seekTo(ms)`; the mounted player subscribes and calls its imperative `seekAndPlay`/`seek` handle.
+- Replaces the ad-hoc `[data-seek]` document listener for React consumers, but the **data-attribute path is kept** for server-rendered share HTML (replay-player.tsx:31 keeps listening; the bus is layered on top).
+
+## 5. Evidence sync consumers
+
+- **Chapter rail** (`chapter-rail.tsx`): auto-highlights the chapter containing `currentTimeMs`.
+- **Step lists** (test-detail steps, verify case rail): follow playback with auto-scroll; manual scroll pauses following and shows a "Resume auto-scroll" affordance.
+- **Network table**: row highlighting tracks `currentTimeMs` (rebased `startTime`); **perf chart** crosshair tracks it (spec 27 §3–4 consume this).
+- **Verify focus mode**: playing through a step selects it in the case rail — opt-in toggle, off by default (spec 27 §7).
+
+## 6. Surfaces
+
+1. **Test-detail Recordings card** — primary surface: annotated scrubber + step-list sync.
+2. **`/r/` share page** — player + ChapterRail gain scrubber ticks; **captions clock fix**: `timingFor` (captions.ts:98) switches from even-split to the same ladder as §1 (`stepTimings` → `atMs` → even split), fixing the documented drift between captions and chapter seeks.
+3. **Verify RunPane** — embeds the player per spec 27 §7.
+
+## 7. Reliability fixes folded in
+
+- **`videoPath` persistence made non-best-effort**: the silent catch in executor.ts:1288-1312 logs the error, retries the write once, and on final failure records a visible entry in `test_results.logs` — a missing video must be diagnosable, not silent.
+- **Disk fallback everywhere**: reuse `resolveTestVideoUrl` (`src/lib/share/video-fallback.ts`) in test-detail (currently share-only) so a row whose `videoPath` write failed but whose file exists on disk still plays.
+
+## 8. Schema changes
+
+Per the CLAUDE.md Schema Changes checklist (schema.ts → `pnpm db:push` → queries touch-ups; no reset):
+
+- `test_results.step_timings` jsonb (`StepTiming[]`), plus `video_start_ms` if not folded into the payload envelope.
+- `consoleErrors` type widened to the legacy union (type-only; jsonb needs no migration).
+- Rebased network/url timestamps are value-level changes, not schema changes.
+- Touch-ups in `src/lib/db/queries/tests.ts` selects and any `TestResultLite`-style projections that should expose `stepTimings` (it's small — safe to include in list payloads).
+
+## Key files
+
+| File                                                | Purpose                                               |
+| --------------------------------------------------- | ----------------------------------------------------- |
+| `src/components/video-player.tsx`                    | `segments` prop, ticks, icons, 8x rate, sync publish  |
+| `src/components/replay-player.tsx`                   | keeps `[data-seek]`; bus layered on top               |
+| `src/components/chapter-rail.tsx`                    | auto-highlight consumer                               |
+| `packages/embedded-browser/src/test-executor.ts`     | timing accumulation (line 1677), `videoStartMs` (660), console capture (1087) |
+| `src/lib/execution/executor.ts`                      | thread `stepTimings`; harden videoPath save (1288-1312) |
+| `src/lib/db/schema.ts`                               | `step_timings` column; `ConsoleEntry` union           |
+| `src/lib/share/captions.ts`                          | replace even-split `timingFor` (line 98)              |
+| `src/lib/share/video-fallback.ts`                    | reuse `resolveTestVideoUrl` in test-detail            |
+
+## Out of scope
+
+- No changes to CDP live streaming (`packages/embedded-browser` streaming path) — this is post-run playback only.
+- No mobile/device-frame chrome around the video.
+- No device-level FPS/CPU/RSS metrics — web vitals remain the perf series (spec 27 §4).
+- The 1-job-1-EB provisioning model is untouched.

--- a/docs/specs/28-interactive-test-playback.md
+++ b/docs/specs/28-interactive-test-playback.md
@@ -121,6 +121,22 @@ Deviations from the sections above, chosen during implementation:
   `lastest:playback-time` document event that `ChapterRail` consumes.
 - The timing ladder helper is `resolveStepSegments`
   (`src/lib/playback/step-timings.ts`).
+- **Ships behind Early Adopter mode** (`docs/specs/12-early-adopter-mode.md`)
+  via `isInteractivePlaybackEnabled()`
+  (`src/lib/playback/feature-flag.ts`, env override
+  `INTERACTIVE_PLAYBACK_ENABLED=1`). The gate is the `segments` prop: each
+  surface passes it only when enabled, and `<VideoPlayer>` without segments
+  renders exactly the pre-spec-28 scrubber. `ReplayPlayer` likewise only
+  broadcasts `lastest:playback-time` when it has segments, so the chapter
+  rail's follow-highlight is gated by the same switch. Verify's Run pane had
+  no player before this spec, so it renders no recording card when gated.
+  Capture (step timings, rebased clocks) is **not** gated — data keeps
+  accruing so promoting the flag needs no backfill.
+  Gate call sites: `src/app/(app)/verify/[buildId]/page.tsx`,
+  `src/app/(app)/tests/definition-page-client.tsx` (the only renderer of
+  `TestDetailClient`), and `src/app/(public)/r/[slug]/page.tsx` — the share
+  page is anonymous, so it reads the *publishing* team's flag through
+  `getShareOwnerTeamFlags()`.
 
 ## Out of scope
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1965,7 +1965,9 @@ export const teams = pgTable("teams", {
    *  This is the dedicated gate; it replaces inferring availability from whether
    *  an AI key/provider happens to be configured. */
   builtInAiEnabled: boolean("built_in_ai_enabled").default(false),
-  gamificationEnabled: boolean("gamification_enabled").default(true),
+  /** Leaderboard / seasons / Bug Blitz. Opt-in — new teams start with it off
+   *  and enable it in Settings → Features. */
+  gamificationEnabled: boolean("gamification_enabled").default(false),
   /** Verify phase (v1.14+) — when true, /verify is the primary surface and
    *  appears as the first sidebar entry. /run and /review are demoted. */
   verifyPhaseEnabled: boolean("verify_phase_enabled").default(true),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -32,6 +32,8 @@ import type {
   StorageStateSnapshot,
   UrlTrajectoryStep,
   WebVitalsSample,
+  StepTiming,
+  ConsoleEntry,
 } from "@lastest/eb-protocol";
 export type {
   DomSnapshotElement,
@@ -46,6 +48,8 @@ export type {
   StorageStateSnapshot,
   UrlTrajectoryStep,
   WebVitalsSample,
+  StepTiming,
+  ConsoleEntry,
 };
 
 export type TriageClassification =
@@ -71,6 +75,9 @@ export interface NetworkRequest {
   failed?: boolean;
   errorText?: string;
   startTime?: number;
+  /** ms since recording start (video clock). Set by EB runs; lets timeline
+   *  consumers place the request without epoch math. */
+  atMs?: number;
   requestHeaders?: Record<string, string>;
   responseHeaders?: Record<string, string>;
   postData?: string;
@@ -771,6 +778,9 @@ export const testResults = pgTable("test_results", {
   viewport: text("viewport"), // e.g., '1920x1080'
   browser: text("browser").default("chromium"),
   consoleErrors: jsonb("console_errors").$type<string[]>(),
+  // Timestamped console capture (video clock). Additive alongside
+  // consoleErrors — see ConsoleEntry.
+  consoleEntries: jsonb("console_entries").$type<ConsoleEntry[]>(),
   networkRequests: jsonb("network_requests").$type<NetworkRequest[]>(),
   downloads: jsonb("downloads").$type<DownloadRecord[]>(),
   a11yViolations: jsonb("a11y_violations").$type<A11yViolation[]>(),
@@ -826,6 +836,9 @@ export const testResults = pgTable("test_results", {
   storageStateSnapshot: jsonb(
     "storage_state_snapshot",
   ).$type<StorageStateSnapshot>(),
+  // Per-step start/end on the video clock — powers the annotated scrubber and
+  // step-synced evidence panes. Null for legacy/local runs.
+  stepTimings: jsonb("step_timings").$type<StepTiming[]>(),
 });
 
 // Repository provider type

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -328,6 +328,7 @@ export interface TestPlaywrightOverrides {
   perfMode?: "enforce" | "log" | "disable";
   urlMode?: "enforce" | "log" | "disable";
   apiMode?: "enforce" | "log" | "disable";
+  storageMode?: "enforce" | "log" | "disable";
   acceptAnyCertificate?: boolean;
   maxParallelTests?: number;
   baseUrl?: string;
@@ -1444,6 +1445,7 @@ export const playwrightSettings = pgTable("playwright_settings", {
   perfMode: text("perf_mode"), // web vitals capture
   urlMode: text("url_mode"), // URL trajectory comparison
   apiMode: text("api_mode"), // API-test request/response assertions (E1)
+  storageMode: text("storage_mode"), // end-of-run storage state diff (cookies + localStorage)
   createdAt: timestamp("created_at"),
   updatedAt: timestamp("updated_at"),
 });
@@ -4495,7 +4497,8 @@ export type EvidenceLayer =
   | "url"
   | "perf"
   | "variable"
-  | "api";
+  | "api"
+  | "storage";
 
 export interface EvidenceItem {
   layer: EvidenceLayer;
@@ -4624,6 +4627,25 @@ export interface VariableDiffSummary {
   }>;
 }
 
+/** One changed entry in the end-of-run storage state diff (State tab).
+ *  `key` is "domain path name" for cookies, "origin name" for localStorage.
+ *  Values are never included — snapshots carry hashes, not raw values. */
+export interface StorageStateDiffEntry {
+  key: string;
+  change: "added" | "removed" | "changed";
+  detail?: string;
+}
+
+/** Current run's end-of-run cookies + localStorage diffed against the
+ *  baseline run's snapshot (web analogue of a "files touched" pane). */
+export interface StorageStateDiffSummary {
+  cookies: StorageStateDiffEntry[];
+  localStorage: StorageStateDiffEntry[];
+  addedCount: number;
+  removedCount: number;
+  changedCount: number;
+}
+
 export interface StepComparisonEvidence {
   visual?: {
     pixelDifference: number;
@@ -4638,6 +4660,7 @@ export interface StepComparisonEvidence {
   url?: UrlTrajectoryDiffSummary;
   perf?: PerfDiffSummary;
   variable?: VariableDiffSummary;
+  storageState?: StorageStateDiffSummary;
 }
 
 export type StepIssueState = "open" | "auto" | "linked" | "closed";

--- a/packages/eb-protocol/src/index.ts
+++ b/packages/eb-protocol/src/index.ts
@@ -141,6 +141,31 @@ export interface UrlTrajectoryStep {
   redirectChain: string[];
   /** Wall-clock ms from test start when this step's URL was sampled. */
   capturedAtMs?: number;
+  /** ms since recording start (video clock). Set by EB runs. */
+  atMs?: number;
+}
+
+/** Per-step execution timing on the video clock (ms since recording start).
+ *  Mirrors `StepTiming` in the app schema — kept local so the protocol package
+ *  stays dependency-free. */
+export interface StepTiming {
+  stepIndex: number;
+  /** "Step N" structural key — matches CapturedScreenshot.label. */
+  label: string;
+  /** Action kind driving scrubber icons: navigate | click | fill | shot | assert | wait | other. */
+  stepType: string;
+  status: "passed" | "failed";
+  /** ms since recording start (test start when the run wasn't recorded). */
+  startMs: number;
+  endMs: number;
+}
+
+/** Console message with a video-clock timestamp. Mirrors `ConsoleEntry` in the
+ *  app schema. `atMs` is null when the run had no recording. */
+export interface ConsoleEntry {
+  atMs: number | null;
+  level: string;
+  text: string;
 }
 
 /** Web Vitals captured per page-state. Sampled at screenshot points and at
@@ -584,6 +609,10 @@ export interface TestResultPayload {
   selectorOutcomes?: SelectorOutcome[];
   /** Redacted cookies/localStorage capture taken after the test body ran. */
   storageStateSnapshot?: StorageStateSnapshot;
+  /** Per-step start/end on the video clock → testResults.stepTimings. */
+  stepTimings?: StepTiming[];
+  /** Timestamped console entries → testResults.consoleEntries. */
+  consoleEntries?: ConsoleEntry[];
 }
 
 export interface TestResultResponse extends BaseMessage {

--- a/packages/embedded-browser/src/index.ts
+++ b/packages/embedded-browser/src/index.ts
@@ -715,6 +715,7 @@ async function startup(): Promise<void> {
               duration: r.duration,
               resourceType: r.resourceType,
               startTime: r.startTime,
+              atMs: r.atMs,
               failed: r.failed,
               errorText: r.errorText,
               responseSize: r.responseSize,
@@ -767,6 +768,11 @@ async function startup(): Promise<void> {
                 webVitals: result.webVitals,
                 assertionResults: result.assertionResults,
                 storageStateSnapshot: result.storageStateSnapshot,
+                // Video-clock step timings + timestamped console entries —
+                // populate testResults.stepTimings / .consoleEntries (the
+                // annotated-scrubber + playback-sync source, spec 28).
+                stepTimings: result.stepTimings,
+                consoleEntries: result.consoleEntries,
               },
             });
 

--- a/packages/embedded-browser/src/multi-layer-capture.ts
+++ b/packages/embedded-browser/src/multi-layer-capture.ts
@@ -54,6 +54,7 @@ export class UrlTrajectoryRecorder {
     stepIndex: number,
     stepLabel: string | undefined,
     capturedAtMs: number,
+    atMs?: number,
   ): UrlTrajectoryStep {
     const newSlice = this.currentChain.slice(this.lastSampledLength);
     this.lastSampledLength = this.currentChain.length;
@@ -69,6 +70,7 @@ export class UrlTrajectoryRecorder {
       finalUrl,
       redirectChain: newSlice,
       capturedAtMs,
+      atMs,
     };
   }
 }

--- a/packages/embedded-browser/src/test-executor.ts
+++ b/packages/embedded-browser/src/test-executor.ts
@@ -88,6 +88,8 @@ export interface EmbeddedNetworkRequest {
   failed?: boolean;
   errorText?: string;
   startTime?: number;
+  /** ms since recording start (video clock). Unset when not recording. */
+  atMs?: number;
   requestHeaders?: Record<string, string>;
   responseHeaders?: Record<string, string>;
   postData?: string;
@@ -106,6 +108,26 @@ function titleFromScreenshotPath(path?: string): string | undefined {
   if (!m) return undefined;
   const words = m[1].replace(/[-_]+/g, " ").trim();
   return words ? words.charAt(0).toUpperCase() + words.slice(1) : undefined;
+}
+
+/** Per-step start/end on the video clock (ms since recording start; test
+ *  start when the run isn't recorded). Mirrors the host's StepTiming type
+ *  (src/lib/db/schema.ts) — the EB package duplicates host types. */
+export interface EmbeddedStepTiming {
+  stepIndex: number;
+  label: string;
+  stepType: string;
+  status: "passed" | "failed";
+  startMs: number;
+  endMs: number;
+}
+
+/** Console message with a video-clock timestamp (mirrors host ConsoleEntry).
+ *  atMs is null when the run wasn't recorded. */
+export interface EmbeddedConsoleEntry {
+  atMs: number | null;
+  level: string;
+  text: string;
 }
 
 export interface EmbeddedTestResult {
@@ -132,6 +154,8 @@ export interface EmbeddedTestResult {
    *  can pair them by replacing the extension. */
   texts?: Array<{ filename: string; data: string }>;
   consoleErrors?: string[];
+  /** Timestamped console capture (video clock), alongside consoleErrors. */
+  consoleEntries?: EmbeddedConsoleEntry[];
   networkRequests?: EmbeddedNetworkRequest[];
   softErrors?: string[];
   /** One entry per `expect(...)` call wrapped by `instrumentAssertionTracking`.
@@ -212,6 +236,8 @@ export interface EmbeddedTestResult {
   webVitals?: WebVitalsSample[];
   /** End-of-test cookie + localStorage snapshot. Token-shaped names redacted. */
   storageStateSnapshot?: StorageStateSnapshot;
+  /** Per-step start/end on the video clock — powers the annotated scrubber. */
+  stepTimings?: EmbeddedStepTiming[];
 }
 
 export interface EmbeddedSetupResult {
@@ -525,6 +551,8 @@ export class EmbeddedTestExecutor {
     > = [];
     const selectorOutcomes: SelectorOutcome[] = [];
     const consoleErrors: string[] = [];
+    const consoleEntries: EmbeddedConsoleEntry[] = [];
+    const stepTimings: EmbeddedStepTiming[] = [];
     let allNetworkRequests: EmbeddedNetworkRequest[] = [];
     const testTimeout = Math.max(command.timeout || 120000, 30000);
 
@@ -1116,6 +1144,14 @@ export class EmbeddedTestExecutor {
             return;
           }
           consoleErrors.push(text);
+          consoleEntries.push({
+            atMs:
+              videoStartMs != null
+                ? Math.max(0, Date.now() - videoStartMs)
+                : null,
+            level: "error",
+            text,
+          });
           logFn("warn", `Console error: ${text}`);
         }
       });
@@ -1126,13 +1162,16 @@ export class EmbeddedTestExecutor {
       // Network request capture (all requests, not just failures)
       const captureNetworkBodies = command.enableNetworkInterception ?? false;
       page.on("request", (req) => {
+        const now = Date.now();
         allNetworkRequests.push({
           url: req.url(),
           method: req.method(),
           status: 0,
           duration: 0,
           resourceType: req.resourceType(),
-          startTime: Date.now(),
+          startTime: now,
+          atMs:
+            videoStartMs != null ? Math.max(0, now - videoStartMs) : undefined,
           failed: false,
           ...(captureNetworkBodies
             ? {
@@ -1683,6 +1722,21 @@ export class EmbeddedTestExecutor {
       ) => {
         if (currentStepIdx < 0) return;
         const desc = stepDescriptors[currentStepIdx];
+        // Persist one timing row per step, on the video clock (test start
+        // when unrecorded). Steps advance monotonically, so a repeat call for
+        // the same index (e.g. the outer catch firing after the final step
+        // already finished as passed) is skipped — first finish wins.
+        if (stepTimings[stepTimings.length - 1]?.stepIndex !== currentStepIdx) {
+          const anchor = videoStartMs ?? startTime;
+          stepTimings.push({
+            stepIndex: currentStepIdx,
+            label: desc?.label ?? `Step ${currentStepIdx + 1}`,
+            stepType: desc?.type ?? "other",
+            status,
+            startMs: Math.max(0, currentStepStart - anchor),
+            endMs: Math.max(0, Date.now() - anchor),
+          });
+        }
         emitStep({
           stepIndex: currentStepIdx,
           totalSteps: totalStepsForEvents,
@@ -1714,6 +1768,9 @@ export class EmbeddedTestExecutor {
                   currentStepIdx,
                   stepDescriptors[currentStepIdx]?.label,
                   Date.now() - startTime,
+                  videoStartMs != null
+                    ? Math.max(0, Date.now() - videoStartMs)
+                    : undefined,
                 ),
               );
             } catch {
@@ -2899,6 +2956,9 @@ export class EmbeddedTestExecutor {
               currentStepIdx,
               stepDescriptors[currentStepIdx]?.label,
               Date.now() - startTime,
+              videoStartMs != null
+                ? Math.max(0, Date.now() - videoStartMs)
+                : undefined,
             ),
           );
         } catch {
@@ -2960,6 +3020,8 @@ export class EmbeddedTestExecutor {
         urlTrajectory: urlTrajectory.length > 0 ? urlTrajectory : undefined,
         webVitals: webVitals.length > 0 ? webVitals : undefined,
         storageStateSnapshot,
+        stepTimings: stepTimings.length > 0 ? stepTimings : undefined,
+        consoleEntries: consoleEntries.length > 0 ? consoleEntries : undefined,
       };
     } catch (error) {
       const durationMs = Date.now() - startTime;
@@ -2998,6 +3060,9 @@ export class EmbeddedTestExecutor {
             selectorOutcomes.length > 0 ? selectorOutcomes : undefined,
           urlTrajectory: urlTrajectory.length > 0 ? urlTrajectory : undefined,
           webVitals: webVitals.length > 0 ? webVitals : undefined,
+          stepTimings: stepTimings.length > 0 ? stepTimings : undefined,
+          consoleEntries:
+            consoleEntries.length > 0 ? consoleEntries : undefined,
         };
       } else {
         const isTimeout = errorMessage.includes("timed out");
@@ -3032,6 +3097,9 @@ export class EmbeddedTestExecutor {
                 outerCurrentStepIdx,
                 outerStepDescriptors[outerCurrentStepIdx]?.label,
                 Date.now() - startTime,
+                videoStartMs != null
+                  ? Math.max(0, Date.now() - videoStartMs)
+                  : undefined,
               ),
             );
           } catch {
@@ -3087,6 +3155,9 @@ export class EmbeddedTestExecutor {
           urlTrajectory: urlTrajectory.length > 0 ? urlTrajectory : undefined,
           webVitals: webVitals.length > 0 ? webVitals : undefined,
           storageStateSnapshot,
+          stepTimings: stepTimings.length > 0 ? stepTimings : undefined,
+          consoleEntries:
+            consoleEntries.length > 0 ? consoleEntries : undefined,
         };
       }
     } finally {

--- a/src/app/(app)/tests/[id]/test-detail-client.tsx
+++ b/src/app/(app)/tests/[id]/test-detail-client.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/components/ui/tooltip";
 import { Textarea } from "@/components/ui/textarea";
 import { ReplayPlayer } from "@/components/replay-player";
+import { resolveStepSegments } from "@/lib/playback/step-timings";
 import { ApiTestDialog } from "@/components/api-tests/api-test-dialog";
 import {
   networkRequestToApiTest,
@@ -182,6 +183,7 @@ interface TestResult {
   totalSteps: number | null;
   extractedVariables: Record<string, string> | null;
   assignedVariables: Record<string, string> | null;
+  stepTimings: import("@/lib/db/schema").StepTiming[] | null;
 }
 
 interface DefaultStepForUI {
@@ -2218,6 +2220,18 @@ export function TestDetailClient({
                                 durationMs: result.durationMs,
                               },
                             ]}
+                            segments={resolveStepSegments({
+                              stepTimings: result.stepTimings,
+                              screenshots: result.screenshots,
+                              durationMs: result.durationMs,
+                            }).map((t) => ({
+                              index: t.stepIndex,
+                              label: t.label,
+                              stepType: t.stepType,
+                              status: t.status,
+                              startMs: t.startMs,
+                              endMs: t.endMs,
+                            }))}
                           />
                         </div>
                       ))}

--- a/src/app/(app)/tests/[id]/test-detail-client.tsx
+++ b/src/app/(app)/tests/[id]/test-detail-client.tsx
@@ -229,6 +229,11 @@ interface TestDetailClientProps {
   stabilizationDefaults?: StabilizationSettings | null;
   banAiMode?: boolean;
   earlyAdopterMode?: boolean;
+  /** Early Adopter gate for the spec-28 annotated player. Off → recordings
+   *  render with the plain scrubber (pre-spec-28 behaviour). Kept separate
+   *  from `earlyAdopterMode` because the definitions-page embed forces that
+   *  one on. See `@/lib/playback/feature-flag`. */
+  interactivePlayback?: boolean;
   diffDefaults?: DiffSensitivitySettings | null;
   playwrightDefaults?: PlaywrightSettingsForDefaults | null;
   envBaseUrl?: string | null;
@@ -438,6 +443,7 @@ export function TestDetailClient({
   googleSheetsAccount = null,
   stabilizationDefaults,
   earlyAdopterMode = false,
+  interactivePlayback = false,
   diffDefaults,
   playwrightDefaults,
   envBaseUrl,
@@ -2220,18 +2226,24 @@ export function TestDetailClient({
                                 durationMs: result.durationMs,
                               },
                             ]}
-                            segments={resolveStepSegments({
-                              stepTimings: result.stepTimings,
-                              screenshots: result.screenshots,
-                              durationMs: result.durationMs,
-                            }).map((t) => ({
-                              index: t.stepIndex,
-                              label: t.label,
-                              stepType: t.stepType,
-                              status: t.status,
-                              startMs: t.startMs,
-                              endMs: t.endMs,
-                            }))}
+                            // Annotated scrubber is Early Adopter only —
+                            // omitting `segments` yields the plain player.
+                            segments={
+                              interactivePlayback
+                                ? resolveStepSegments({
+                                    stepTimings: result.stepTimings,
+                                    screenshots: result.screenshots,
+                                    durationMs: result.durationMs,
+                                  }).map((t) => ({
+                                    index: t.stepIndex,
+                                    label: t.label,
+                                    stepType: t.stepType,
+                                    status: t.status,
+                                    startMs: t.startMs,
+                                    endMs: t.endMs,
+                                  }))
+                                : undefined
+                            }
                           />
                         </div>
                       ))}

--- a/src/app/(app)/tests/definition-page-client.tsx
+++ b/src/app/(app)/tests/definition-page-client.tsx
@@ -208,6 +208,7 @@ export function DefinitionPageClient({
   repositoryId,
   selectedBranch,
   banAiMode,
+  earlyAdopterMode,
   areas,
   tests,
   routes,
@@ -1513,6 +1514,7 @@ export function DefinitionPageClient({
                     }
                     banAiMode={banAiMode}
                     earlyAdopterMode={true}
+                    interactivePlayback={earlyAdopterMode ?? false}
                     diffDefaults={openTestDetailData.diffDefaults}
                     playwrightDefaults={openTestDetailData.playwrightDefaults}
                     envBaseUrl={openTestDetailData.envBaseUrl}

--- a/src/app/(app)/verify/[buildId]/board-focus-client.tsx
+++ b/src/app/(app)/verify/[buildId]/board-focus-client.tsx
@@ -337,6 +337,7 @@ function BoardFocusInner(props: BoardFocusClientProps) {
     perf: CheckModeT;
     url: CheckModeT;
     api: CheckModeT;
+    storage: CheckModeT;
   };
   const DEFAULT_CHECK_MODES: CheckModeMapT = {
     visual: "enforce",
@@ -349,6 +350,7 @@ function BoardFocusInner(props: BoardFocusClientProps) {
     perf: "log",
     url: "log",
     api: "enforce",
+    storage: "log",
   };
   const [checkModes, setCheckModes] =
     useState<CheckModeMapT>(DEFAULT_CHECK_MODES);

--- a/src/app/(app)/verify/[buildId]/board-focus-client.tsx
+++ b/src/app/(app)/verify/[buildId]/board-focus-client.tsx
@@ -108,6 +108,7 @@ export interface VisualDiffLite {
 export interface TestResultLite {
   id: string;
   testId: string | null;
+  testRunId: string | null;
   status: string | null;
   errorMessage: string | null;
   durationMs: number | null;
@@ -134,6 +135,16 @@ export interface TestResultLite {
   domSnapshot: import("@/lib/db/schema").DomSnapshotData | null;
   // E1: headless API results (null for browser tests).
   apiResult: import("@/lib/db/schema").ApiTestResultData | null;
+  // ── Interactive playback + State tab (specs 27/28) ─────────────────────
+  /** Recording path — RunPane embeds the step-synced player when set. */
+  videoPath: string | null;
+  /** Per-step start/end on the video clock (EB runs). */
+  stepTimings: import("@/lib/db/schema").StepTiming[] | null;
+  /** Timestamped console entries (alongside the flat consoleErrors). */
+  consoleEntries: import("@/lib/db/schema").ConsoleEntry[] | null;
+  /** End-of-run cookies + localStorage snapshot — the State tab diffs this
+   *  against the baseline run's snapshot. */
+  storageStateSnapshot: import("@/lib/db/schema").StorageStateSnapshot | null;
 }
 
 export interface VerifyFilters {

--- a/src/app/(app)/verify/[buildId]/board-focus-client.tsx
+++ b/src/app/(app)/verify/[buildId]/board-focus-client.tsx
@@ -206,6 +206,10 @@ interface BoardFocusClientProps {
    *  review panel can render every token tile, not just those that
    *  appear in violations. */
   repoDesignSystem: import("@/lib/db/schema").DesignSystemConfig | null;
+  /** Early Adopter gate for the spec-28 annotated player (see
+   *  `@/lib/playback/feature-flag`). When false the Run pane renders no
+   *  recording card at all — its pre-spec-28 state. */
+  interactivePlayback?: boolean;
 }
 
 type Mode = "board" | "focus";
@@ -1267,6 +1271,7 @@ function BoardFocusInner(props: BoardFocusClientProps) {
             violations: props.designSystemViolations,
             config: props.repoDesignSystem,
           }}
+          interactivePlayback={props.interactivePlayback ?? false}
         />
       )}
 

--- a/src/app/(app)/verify/[buildId]/board-view.tsx
+++ b/src/app/(app)/verify/[buildId]/board-view.tsx
@@ -1860,6 +1860,8 @@ function wasLayerCaptured(
       );
     case "api":
       return result?.apiResult != null;
+    case "storage":
+      return result?.storageStateSnapshot != null;
   }
 }
 

--- a/src/app/(app)/verify/[buildId]/focus-view.tsx
+++ b/src/app/(app)/verify/[buildId]/focus-view.tsx
@@ -184,6 +184,10 @@ interface FocusViewProps {
     }>;
     violations?: BuildA11yViolationRow[];
   };
+  /** Early Adopter gate for the spec-28 annotated player. Off → the Run pane
+   *  renders no recording card (its pre-spec-28 state). See
+   *  `@/lib/playback/feature-flag`. */
+  interactivePlayback?: boolean;
 }
 
 type CompareTab = EvidenceLayer | "text" | "run";
@@ -1272,6 +1276,7 @@ export function FocusView(props: FocusViewProps) {
             buildDesignSystem={props.buildDesignSystem}
             buildId={props.buildId}
             repositoryId={props.repositoryId}
+            interactivePlayback={props.interactivePlayback ?? false}
             regionsCtx={{
               showRegions,
               setShowRegions,
@@ -2008,6 +2013,8 @@ interface ComparePaneProps {
   buildId: string;
   /** Repo forwarded so the Network pane can seed a new API test from a row. */
   repositoryId: string | null;
+  /** Early Adopter gate for the spec-28 annotated player (Run pane). */
+  interactivePlayback: boolean;
 }
 
 function ComparePane({
@@ -2024,6 +2031,7 @@ function ComparePane({
   buildDesignSystem,
   buildId,
   repositoryId,
+  interactivePlayback,
 }: ComparePaneProps) {
   if (!step) {
     return (
@@ -2105,6 +2113,7 @@ function ComparePane({
         activeStepId={activeStepId}
         onSelectStep={onSelectStep}
         buildId={buildId}
+        interactivePlayback={interactivePlayback}
       />
     );
   if (tab === "visual")
@@ -2565,6 +2574,7 @@ function RunPane({
   activeStepId,
   onSelectStep,
   buildId,
+  interactivePlayback,
 }: {
   result: TestResultLite | null;
   failed: boolean;
@@ -2572,6 +2582,7 @@ function RunPane({
   activeStepId: string | null;
   onSelectStep: (stepId: string) => void;
   buildId: string;
+  interactivePlayback: boolean;
 }) {
   if (!result) {
     return (
@@ -2691,8 +2702,9 @@ function RunPane({
       {/* Step-synced recording (spec 28). Segment ticks come from persisted
           stepTimings; clicking a segment seeks AND selects that step in the
           case rail. "Follow playback" (opt-in) keeps the rail selection on
-          the step currently playing. */}
-      {result.videoPath && (
+          the step currently playing. Early Adopter only — before spec 28 the
+          Run pane had no player at all, so gated teams get no card. */}
+      {interactivePlayback && result.videoPath && (
         <RunPlaybackCard
           result={result}
           stepCells={stepCells}

--- a/src/app/(app)/verify/[buildId]/focus-view.tsx
+++ b/src/app/(app)/verify/[buildId]/focus-view.tsx
@@ -92,6 +92,12 @@ import {
 import { useIsMobile } from "@/lib/hooks/use-is-mobile";
 import type { VisualDiffLite, TestResultLite } from "./board-focus-client";
 import { RcaBadge } from "@/components/diff/rca-badge";
+import {
+  VideoPlayer,
+  type PlayerSegment,
+  type VideoPlayerHandle,
+} from "@/components/video-player";
+import { resolveStepSegments } from "@/lib/playback/step-timings";
 
 interface AreaLite {
   id: string;
@@ -571,6 +577,20 @@ export function FocusView(props: FocusViewProps) {
           e.preventDefault();
           goNext();
           break;
+        // Cycle the evidence tabs without reaching for the mouse — mirrors
+        // prev/next-case on ArrowLeft/Right one level down.
+        case "[":
+        case "]": {
+          e.preventDefault();
+          const dir = e.key === "]" ? 1 : -1;
+          setTab((cur) => {
+            const idx = COMPARE_TABS.findIndex((t) => t.id === cur);
+            const next =
+              (idx + dir + COMPARE_TABS.length) % COMPARE_TABS.length;
+            return COMPARE_TABS[next].id;
+          });
+          break;
+        }
         case "Escape":
           if (intentOpen) setIntentOpen(false);
           break;
@@ -1212,6 +1232,10 @@ export function FocusView(props: FocusViewProps) {
           </button>
         </div>
 
+        {/* Per-step action metadata — kind, label, duration + video time
+            range (from persisted stepTimings), verdict, step thumbnail. */}
+        <StepDetailHeader activeCase={activeCase} />
+
         {/* Compare pane */}
         <div
           style={{
@@ -1356,6 +1380,131 @@ export function FocusView(props: FocusViewProps) {
         initial={props.checkModes}
         onSaved={props.onRefresh}
       />
+    </div>
+  );
+}
+
+/** m:ss.d video-clock display (e.g. `0:10.1`). */
+function formatVideoMs(ms: number): string {
+  const total = Math.max(0, ms) / 1000;
+  const m = Math.floor(total / 60);
+  const s = total - m * 60;
+  return `${m}:${s < 10 ? "0" : ""}${s.toFixed(1)}`;
+}
+
+/** The persisted StepTiming for a case's step — matched by the structural
+ *  "Step N" label first (authoritative), then by index. Null for legacy runs
+ *  without stepTimings. */
+function timingForCase(
+  c: CaseRow,
+): import("@/lib/db/schema").StepTiming | null {
+  const timings = c.result?.stepTimings;
+  if (!timings || timings.length === 0) return null;
+  if (c.step.stepLabel) {
+    const byLabel = timings.find((t) => t.label === c.step.stepLabel);
+    if (byLabel) return byLabel;
+  }
+  if (c.step.stepIndex != null) {
+    return timings.find((t) => t.stepIndex === c.step.stepIndex) ?? null;
+  }
+  return null;
+}
+
+/** Compact per-step action metadata strip between the tab strip and the
+ *  compare pane: step number + label, action kind, duration and video time
+ *  range (when the run persisted stepTimings), verdict chip, and the step's
+ *  current screenshot as a thumbnail. Degrades field-by-field for legacy
+ *  runs — renders nothing without an active case. */
+function StepDetailHeader({ activeCase }: { activeCase: CaseRow | null }) {
+  if (!activeCase) return null;
+  const { step, visual, result } = activeCase;
+  const timing = timingForCase(activeCase);
+  const durationMs = timing ? timing.endMs - timing.startMs : null;
+  const thumb = visual?.currentImagePath ?? null;
+  const verdictTone =
+    step.verdict === "red"
+      ? "regression"
+      : step.verdict === "yellow"
+        ? "missed"
+        : "done";
+  return (
+    <div
+      style={{
+        padding: "6px 16px",
+        borderBottom: "1px solid var(--border)",
+        background: "var(--c-white)",
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        minHeight: 40,
+      }}
+    >
+      {thumb && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={thumb}
+          alt=""
+          style={{
+            width: 40,
+            height: 26,
+            objectFit: "cover",
+            objectPosition: "top",
+            borderRadius: 4,
+            border: "1px solid var(--border)",
+            flexShrink: 0,
+          }}
+        />
+      )}
+      <span className="mono" style={{ fontSize: 11, color: "var(--fg-3)" }}>
+        {step.stepIndex != null ? `#${step.stepIndex + 1}` : "—"}
+      </span>
+      <span
+        style={{
+          fontSize: 12,
+          fontWeight: 600,
+          color: "var(--fg-1)",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          maxWidth: 320,
+        }}
+        title={step.stepLabel ?? undefined}
+      >
+        {step.stepLabel ?? "Unlabeled step"}
+      </span>
+      {timing?.stepType && (
+        <span className="v-chip" style={{ fontSize: 9 }}>
+          {timing.stepType}
+        </span>
+      )}
+      <span className={`v-chip ${verdictTone}`} style={{ fontSize: 9 }}>
+        <span className="dot" />
+        {step.verdict}
+      </span>
+      <span style={{ flex: 1 }} />
+      {durationMs != null && (
+        <span
+          className="mono"
+          style={{ fontSize: 10, color: "var(--fg-2)" }}
+          title="Step duration"
+        >
+          {(durationMs / 1000).toFixed(1)}s
+        </span>
+      )}
+      {timing && (
+        <span
+          className="mono"
+          style={{ fontSize: 10, color: "var(--fg-3)" }}
+          title="Video time range — the recording plays this step here"
+        >
+          {formatVideoMs(timing.startMs)} → {formatVideoMs(timing.endMs)}
+        </span>
+      )}
+      {!timing && result?.durationMs != null && (
+        <span className="mono" style={{ fontSize: 10, color: "var(--fg-3)" }}>
+          run {(result.durationMs / 1000).toFixed(1)}s
+        </span>
+      )}
     </div>
   );
 }
@@ -1941,6 +2090,7 @@ function ComparePane({
         stepCells={runStepCells}
         activeStepId={activeStepId}
         onSelectStep={onSelectStep}
+        buildId={buildId}
       />
     );
   if (tab === "visual")
@@ -2165,12 +2315,14 @@ function RunPane({
   stepCells,
   activeStepId,
   onSelectStep,
+  buildId,
 }: {
   result: TestResultLite | null;
   failed: boolean;
   stepCells: RunStepCell[];
   activeStepId: string | null;
   onSelectStep: (stepId: string) => void;
+  buildId: string;
 }) {
   if (!result) {
     return (
@@ -2286,6 +2438,19 @@ function RunPane({
           </div>
         )}
       </div>
+
+      {/* Step-synced recording (spec 28). Segment ticks come from persisted
+          stepTimings; clicking a segment seeks AND selects that step in the
+          case rail. "Follow playback" (opt-in) keeps the rail selection on
+          the step currently playing. */}
+      {result.videoPath && (
+        <RunPlaybackCard
+          result={result}
+          stepCells={stepCells}
+          activeStepId={activeStepId}
+          onSelectStep={onSelectStep}
+        />
+      )}
 
       {/* All steps of the test with per-step passage. Cells are buttons so
           reviewers can jump to any step's other layers (visual/network/...)
@@ -2448,6 +2613,262 @@ function RunPane({
           }
         />
       )}
+
+      {/* Execution details + copyable IDs + agent snippets (Info parity). */}
+      <RunInfoCard result={result} buildId={buildId} />
+    </div>
+  );
+}
+
+/** Recording card inside the Run pane: the annotated player wired to the
+ *  case rail. Isolated from RunPane so its hooks sit behind RunPane's
+ *  null-result early return. */
+function RunPlaybackCard({
+  result,
+  stepCells,
+  activeStepId,
+  onSelectStep,
+}: {
+  result: TestResultLite;
+  stepCells: RunStepCell[];
+  activeStepId: string | null;
+  onSelectStep: (stepId: string) => void;
+}) {
+  const [follow, setFollow] = useState(false);
+  const handleRef = useRef<VideoPlayerHandle | null>(null);
+  const activeStepIdRef = useRef(activeStepId);
+  useEffect(() => {
+    activeStepIdRef.current = activeStepId;
+  }, [activeStepId]);
+
+  const segments = useMemo<PlayerSegment[]>(
+    () =>
+      resolveStepSegments({
+        stepTimings: result.stepTimings,
+        durationMs: result.durationMs,
+      }).map((t) => ({
+        index: t.stepIndex,
+        label: t.label,
+        stepType: t.stepType,
+        status: t.status,
+        startMs: t.startMs,
+        endMs: t.endMs,
+      })),
+    [result.stepTimings, result.durationMs],
+  );
+
+  const selectByStepIndex = useCallback(
+    (stepIndex: number) => {
+      const cell = stepCells.find((c) => c.stepIndex === stepIndex);
+      if (cell && cell.stepId !== activeStepIdRef.current) {
+        onSelectStep(cell.stepId);
+      }
+    },
+    [stepCells, onSelectStep],
+  );
+
+  // Opt-in follow: while playing, keep the case rail on the step whose
+  // segment contains the playhead.
+  useEffect(() => {
+    if (!follow || segments.length === 0) return;
+    const el = handleRef.current?.getElement();
+    if (!el) return;
+    const onTime = () => {
+      const ms = el.currentTime * 1000;
+      for (let i = segments.length - 1; i >= 0; i--) {
+        const seg = segments[i];
+        if (ms >= seg.startMs) {
+          selectByStepIndex(seg.index);
+          return;
+        }
+      }
+    };
+    el.addEventListener("timeupdate", onTime);
+    return () => el.removeEventListener("timeupdate", onTime);
+  }, [follow, segments, selectByStepIndex]);
+
+  return (
+    <div
+      className="v-card"
+      style={{
+        padding: 10,
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        flexShrink: 0,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <span className="label" style={{ fontSize: 10 }}>
+          Recording
+        </span>
+        <span style={{ flex: 1 }} />
+        <label
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 5,
+            fontSize: 10,
+            color: "var(--fg-2)",
+            cursor: "pointer",
+          }}
+          title="While playing, select the step under the playhead in the case rail"
+        >
+          <input
+            type="checkbox"
+            checked={follow}
+            onChange={(e) => setFollow(e.target.checked)}
+            style={{ accentColor: "var(--c-teal)" }}
+          />
+          Follow playback
+        </label>
+      </div>
+      <VideoPlayer
+        src={result.videoPath!}
+        durationMsFallback={result.durationMs}
+        segments={segments.length > 0 ? segments : undefined}
+        onSegmentSeek={(seg) => selectByStepIndex(seg.index)}
+        defaultPlaybackRate={2}
+        preload="metadata"
+        className="aspect-video w-full"
+        ariaLabel="Test run recording"
+        onReady={(h) => {
+          handleRef.current = h;
+        }}
+      />
+    </div>
+  );
+}
+
+/** Copyable execution details for the Run pane — result/run/test/build IDs
+ *  plus ready-to-paste agent snippets (MCP). */
+function RunInfoCard({
+  result,
+  buildId,
+}: {
+  result: TestResultLite;
+  buildId: string;
+}) {
+  const rows: Array<{ label: string; value: string }> = [
+    { label: "Build", value: buildId },
+    ...(result.testRunId
+      ? [{ label: "Test run", value: result.testRunId }]
+      : []),
+    ...(result.testId ? [{ label: "Test", value: result.testId }] : []),
+    { label: "Result", value: result.id },
+  ];
+  const snippets: Array<{ label: string; value: string }> = [
+    {
+      label: "MCP — build review",
+      value: `lastest_build action:"review" buildId:"${buildId}"`,
+    },
+    ...(result.testId
+      ? [
+          {
+            label: "MCP — rerun this test",
+            value: `lastest_run_tests testIds:["${result.testId}"]`,
+          },
+        ]
+      : []),
+  ];
+  const copy = (value: string) => {
+    navigator.clipboard
+      .writeText(value)
+      .then(() => toast.success("Copied"))
+      .catch(() => toast.error("Copy failed"));
+  };
+  return (
+    <div
+      className="v-card"
+      style={{
+        padding: 10,
+        display: "flex",
+        flexDirection: "column",
+        gap: 6,
+        flexShrink: 0,
+      }}
+    >
+      <span className="label" style={{ fontSize: 10 }}>
+        Execution details
+      </span>
+      {rows.map((r) => (
+        <div
+          key={r.label}
+          style={{ display: "flex", alignItems: "center", gap: 8 }}
+        >
+          <span
+            className="label"
+            style={{ fontSize: 9, width: 56, flexShrink: 0 }}
+          >
+            {r.label}
+          </span>
+          <code
+            className="mono"
+            style={{
+              fontSize: 10,
+              color: "var(--fg-2)",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              flex: 1,
+            }}
+          >
+            {r.value}
+          </code>
+          <button
+            type="button"
+            className="v-btn"
+            style={{ padding: "2px 6px", fontSize: 9, minHeight: 0 }}
+            onClick={() => copy(r.value)}
+            aria-label={`Copy ${r.label} ID`}
+          >
+            Copy
+          </button>
+        </div>
+      ))}
+      <div
+        style={{
+          borderTop: "1px solid var(--border)",
+          paddingTop: 6,
+          display: "flex",
+          flexDirection: "column",
+          gap: 6,
+        }}
+      >
+        {snippets.map((s) => (
+          <div
+            key={s.label}
+            style={{ display: "flex", alignItems: "center", gap: 8 }}
+          >
+            <code
+              className="mono"
+              title={s.label}
+              style={{
+                fontSize: 10,
+                color: "var(--fg-2)",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                flex: 1,
+                background: "var(--c-soft-2)",
+                borderRadius: 4,
+                padding: "3px 6px",
+              }}
+            >
+              {s.value}
+            </code>
+            <button
+              type="button"
+              className="v-btn"
+              style={{ padding: "2px 6px", fontSize: 9, minHeight: 0 }}
+              onClick={() => copy(s.value)}
+              aria-label={`Copy snippet: ${s.label}`}
+            >
+              Copy
+            </button>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/app/(app)/verify/[buildId]/focus-view.tsx
+++ b/src/app/(app)/verify/[buildId]/focus-view.tsx
@@ -98,6 +98,7 @@ import {
   type VideoPlayerHandle,
 } from "@/components/video-player";
 import { resolveStepSegments } from "@/lib/playback/step-timings";
+import { PerfVitalsChart } from "./perf-vitals-chart";
 
 interface AreaLite {
   id: string;
@@ -4406,6 +4407,11 @@ function NetworkPane({
   );
   const [typeFilter, setTypeFilter] = useState<Set<string>>(new Set());
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
+  // Column sort — "order" keeps capture order (the default devtools view).
+  const [sortKey, setSortKey] = useState<
+    "order" | "method" | "url" | "status" | "type" | "duration" | "size"
+  >("order");
+  const [sortDir, setSortDir] = useState<1 | -1>(1);
 
   // Per-group counts for the filter chips — always show the underlying total
   // so the user can see what's available to filter on.
@@ -4452,6 +4458,74 @@ function NetworkPane({
         return true;
       });
   }, [requests, search, methodFilter, statusFilter, typeFilter]);
+
+  const sorted = useMemo(() => {
+    if (sortKey === "order")
+      return sortDir === 1 ? filtered : [...filtered].reverse();
+    const val = (r: import("@/lib/db/schema").NetworkRequest) => {
+      switch (sortKey) {
+        case "method":
+          return r.method;
+        case "url":
+          return r.url;
+        case "status":
+          return r.status;
+        case "type":
+          return r.resourceType || "other";
+        case "duration":
+          return r.duration ?? -1;
+        case "size":
+          return r.responseSize ?? -1;
+      }
+    };
+    return [...filtered].sort((a, b) => {
+      const av = val(a.r);
+      const bv = val(b.r);
+      const cmp =
+        typeof av === "string"
+          ? av.localeCompare(String(bv))
+          : (av as number) - (bv as number);
+      return cmp * sortDir;
+    });
+  }, [filtered, sortKey, sortDir]);
+
+  const onSort = (key: typeof sortKey) => {
+    if (key === sortKey) setSortDir((d) => (d === 1 ? -1 : 1));
+    else {
+      setSortKey(key);
+      setSortDir(1);
+    }
+  };
+
+  // Request-density mini-timeline over the run: bucket the requests by their
+  // video-clock offset (atMs; legacy fallback = epoch startTime rebased to
+  // the first request). Hidden when the run has no usable timestamps.
+  const density = useMemo(() => {
+    let offsets = requests
+      .map((r) => (typeof r.atMs === "number" ? r.atMs : null))
+      .filter((v): v is number => v != null);
+    if (offsets.length < 2) {
+      const starts = requests
+        .map((r) => (typeof r.startTime === "number" ? r.startTime : null))
+        .filter((v): v is number => v != null);
+      if (starts.length < 2) return null;
+      const min = Math.min(...starts);
+      offsets = starts.map((s) => s - min);
+    }
+    const max = Math.max(...offsets);
+    if (max <= 0) return null;
+    const BUCKETS = 48;
+    const counts = new Array<number>(BUCKETS).fill(0);
+    for (const o of offsets) {
+      counts[Math.min(BUCKETS - 1, Math.floor((o / max) * BUCKETS))] += 1;
+    }
+    return { counts, maxCount: Math.max(...counts), spanMs: max };
+  }, [requests]);
+
+  const totalBytes = useMemo(
+    () => filtered.reduce((sum, { r }) => sum + (r.responseSize ?? 0), 0),
+    [filtered],
+  );
 
   const toggle = <T,>(set: Set<T>, val: T): Set<T> => {
     const next = new Set(set);
@@ -4766,11 +4840,50 @@ function NetworkPane({
               )}
             </div>
           </div>
+          {/* Request-density mini-timeline: where in the run the traffic
+              happened. Buckets over the video clock (atMs; legacy rows use
+              epoch startTime rebased to the first request). */}
+          {density && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "flex-end",
+                gap: 1,
+                height: 24,
+                padding: "4px 12px 2px",
+                borderBottom: "1px solid var(--border)",
+              }}
+              aria-label="Request density over the run"
+            >
+              {density.counts.map((n, i) => {
+                const bucketStartMs =
+                  (i / density.counts.length) * density.spanMs;
+                return (
+                  <div
+                    key={i}
+                    title={`${n} request${n === 1 ? "" : "s"} @ ${formatVideoMs(bucketStartMs)}`}
+                    style={{
+                      flex: 1,
+                      height:
+                        n > 0
+                          ? `${Math.max(15, (n / density.maxCount) * 100)}%`
+                          : 1,
+                      background:
+                        n > 0
+                          ? "color-mix(in oklab, var(--c-teal) 55%, white)"
+                          : "var(--border)",
+                      borderRadius: 1,
+                    }}
+                  />
+                );
+              })}
+            </div>
+          )}
           {/* Header + rows share one horizontal scroll container so the
               7-column grid stays aligned (and usable) on narrow viewports
               instead of crushing every track to a few px. */}
           <div style={{ overflowX: "auto" }}>
-            {/* Column header */}
+            {/* Column header — click to sort, click again to flip. */}
             <div
               style={{
                 display: "grid",
@@ -4783,24 +4896,36 @@ function NetworkPane({
               }}
             >
               <span />
-              <span className="label" style={{ fontSize: 9 }}>
-                Method
-              </span>
-              <span className="label" style={{ fontSize: 9 }}>
-                URL
-              </span>
-              <span className="label" style={{ fontSize: 9 }}>
-                Status
-              </span>
-              <span className="label" style={{ fontSize: 9 }}>
-                Type
-              </span>
-              <span className="label" style={{ fontSize: 9 }}>
-                Dur
-              </span>
-              <span className="label" style={{ fontSize: 9 }}>
-                Size
-              </span>
+              {(
+                [
+                  ["method", "Method"],
+                  ["url", "URL"],
+                  ["status", "Status"],
+                  ["type", "Type"],
+                  ["duration", "Dur"],
+                  ["size", "Size"],
+                ] as const
+              ).map(([key, name]) => (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => onSort(key)}
+                  className="label"
+                  title={`Sort by ${name.toLowerCase()}`}
+                  style={{
+                    fontSize: 9,
+                    background: "none",
+                    border: "none",
+                    padding: 0,
+                    cursor: "pointer",
+                    textAlign: "left",
+                    color: sortKey === key ? "var(--fg-1)" : undefined,
+                  }}
+                >
+                  {name}
+                  {sortKey === key ? (sortDir === 1 ? " ▲" : " ▼") : ""}
+                </button>
+              ))}
             </div>
             <div style={{ maxHeight: 480, overflowY: "auto", minWidth: 560 }}>
               {filtered.length === 0 && (
@@ -4811,7 +4936,7 @@ function NetworkPane({
                   No requests match the current filters
                 </div>
               )}
-              {filtered.slice(0, 500).map(({ r, i }) => (
+              {sorted.slice(0, 500).map(({ r, i }) => (
                 <NetworkRequestRow
                   key={i}
                   req={r}
@@ -4824,15 +4949,36 @@ function NetworkPane({
                   }
                 />
               ))}
-              {filtered.length > 500 && (
+              {sorted.length > 500 && (
                 <div
                   className="label"
                   style={{ padding: 8, textAlign: "center", fontSize: 10 }}
                 >
-                  +{filtered.length - 500} more not shown
+                  +{sorted.length - 500} more not shown
                 </div>
               )}
             </div>
+          </div>
+          {/* Totals footer — counts + transferred bytes for the current
+              filter set (responseSize is capture-time content-length). */}
+          <div
+            style={{
+              padding: "6px 12px",
+              borderTop: "1px solid var(--border)",
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
+            <span className="label" style={{ fontSize: 9 }}>
+              {filtered.length} request{filtered.length === 1 ? "" : "s"}
+              {filtered.length !== requests.length
+                ? ` (of ${requests.length})`
+                : ""}
+              {totalBytes > 0
+                ? ` · ${formatBytes(totalBytes)} transferred`
+                : ""}
+            </span>
           </div>
         </div>
       )}
@@ -5117,10 +5263,41 @@ function BodyBlock({ title, body }: { title: string; body: string }) {
     return body;
   })();
   const truncated = pretty.length > 8000;
+  const download = () => {
+    const isJson =
+      pretty.trimStart().startsWith("{") || pretty.trimStart().startsWith("[");
+    const blob = new Blob([body], {
+      type: isJson ? "application/json" : "text/plain",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${title.toLowerCase().replace(/\s+/g, "-")}.${isJson ? "json" : "txt"}`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
   return (
     <div>
-      <div className="label" style={{ fontSize: 9, marginBottom: 4 }}>
+      <div
+        className="label"
+        style={{
+          fontSize: 9,
+          marginBottom: 4,
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+        }}
+      >
         {title} · {body.length} chars{truncated ? " (truncated to 8k)" : ""}
+        <button
+          type="button"
+          onClick={download}
+          className="v-btn"
+          style={{ padding: "0 5px", fontSize: 9, minHeight: 0 }}
+          title="Download the full captured body"
+        >
+          Download
+        </button>
       </div>
       <pre
         className="mono"
@@ -5732,6 +5909,10 @@ function PerfPane({
           message={`No perf drift — ${samples.length} sample${samples.length === 1 ? "" : "s"} captured, all within budget`}
         />
       )}
+      {/* Per-step time series (spec 27): solid = current run; dashed = the
+          baseline-run value from the perf diff summary. Falls back to the
+          mean tiles below when there are too few samples to chart. */}
+      <PerfVitalsChart samples={samples} deltas={p?.deltas ?? null} />
       {p && p.deltas.length > 0 && (
         <div
           style={{

--- a/src/app/(app)/verify/[buildId]/focus-view.tsx
+++ b/src/app/(app)/verify/[buildId]/focus-view.tsx
@@ -199,6 +199,7 @@ const COMPARE_TABS: { id: CompareTab; name: string }[] = [
   { id: "design", name: "Design" },
   { id: "perf", name: "Perf" },
   { id: "url", name: "URL" },
+  { id: "storage", name: "State" },
   { id: "variable", name: "Variables" },
   { id: "api", name: "API" },
 ];
@@ -286,6 +287,9 @@ function classifyLayer(
         : "absent";
     case "api":
       return result?.apiResult != null ? "clean" : "absent";
+    case "storage":
+      // Snapshot capture is best-effort but always attempted on EB runs.
+      return result?.storageStateSnapshot != null ? "clean" : "absent";
   }
 }
 
@@ -1556,6 +1560,15 @@ function layerDelta(step: StepComparison, layer: CompareTab): string | null {
       if (!v) return null;
       return `Δ ${v.changes.length}`;
     }
+    case "storage": {
+      const s = layers?.storageState;
+      if (!s) return null;
+      const parts: string[] = [];
+      if (s.addedCount) parts.push(`+${s.addedCount}`);
+      if (s.removedCount) parts.push(`−${s.removedCount}`);
+      if (s.changedCount) parts.push(`~${s.changedCount}`);
+      return parts.join(" ") || null;
+    }
   }
   return null;
 }
@@ -2165,7 +2178,237 @@ function ComparePane({
     );
   if (tab === "api")
     return <ApiPane result={result} clean={layerState === "clean"} />;
+  if (tab === "storage")
+    return (
+      <StatePane step={step} result={result} clean={layerState === "clean"} />
+    );
   return null;
+}
+
+/** State tab (spec 27): the web analogue of a "files touched" pane. Renders
+ *  the storage diff computed post-run into step.layers.storageState
+ *  (current run vs baseline run — consistent with every other layer), plus
+ *  the current end-of-run snapshot for browsing. Values are hashed at
+ *  capture, so entries show keys + change kinds, never contents. */
+function StatePane({
+  step,
+  result,
+  clean,
+}: {
+  step: StepComparison;
+  result: TestResultLite | null;
+  clean: boolean;
+}) {
+  const diff = step.layers?.storageState ?? null;
+  const snapshot = result?.storageStateSnapshot ?? null;
+  const areas: Array<{
+    name: string;
+    entries: import("@/lib/db/schema").StorageStateDiffEntry[];
+  }> = diff
+    ? [
+        { name: "Cookies", entries: diff.cookies },
+        { name: "localStorage", entries: diff.localStorage },
+      ]
+    : [];
+  const changeTone: Record<string, string> = {
+    added: "done",
+    removed: "regression",
+    changed: "missed",
+  };
+  const changeLabel: Record<string, string> = {
+    added: "ADD",
+    removed: "REMOVE",
+    changed: "CHANGE",
+  };
+  return (
+    <div
+      style={{
+        flex: 1,
+        padding: 14,
+        background: "var(--c-soft-2)",
+        overflowY: "auto",
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
+      }}
+    >
+      {clean && !diff && (
+        <CleanBanner message="No storage changes in range — end-of-run cookies and localStorage match the baseline run" />
+      )}
+      {!diff && snapshot && (
+        <div className="label" style={{ fontSize: 10, padding: "0 2px" }}>
+          {`Diff vs baseline unavailable${
+            clean ? "" : " — the baseline run has no storage snapshot"
+          }. Current snapshot below.`}
+        </div>
+      )}
+      {areas.map(
+        (area) =>
+          area.entries.length > 0 && (
+            <div
+              key={area.name}
+              className="v-card"
+              style={{ padding: 0, overflow: "hidden" }}
+            >
+              <div
+                style={{
+                  padding: "8px 12px",
+                  borderBottom: "1px solid var(--border)",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                }}
+              >
+                <span className="label" style={{ fontSize: 10 }}>
+                  {area.name}
+                </span>
+                <span
+                  className="v-chip"
+                  style={{ fontSize: 9, padding: "1px 6px" }}
+                >
+                  +{area.entries.length}
+                </span>
+              </div>
+              {area.entries.map((e, i) => (
+                <div
+                  key={`${e.key}-${i}`}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    padding: "6px 12px",
+                    borderBottom:
+                      i < area.entries.length - 1
+                        ? "1px solid var(--border)"
+                        : undefined,
+                  }}
+                >
+                  <span
+                    className={`v-chip ${changeTone[e.change]}`}
+                    style={{ fontSize: 9, padding: "1px 6px", width: 62 }}
+                  >
+                    {changeLabel[e.change]}
+                  </span>
+                  <code
+                    className="mono"
+                    style={{
+                      fontSize: 10.5,
+                      color: "var(--fg-1)",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                      flex: 1,
+                    }}
+                    title={e.key}
+                  >
+                    {e.key}
+                  </code>
+                  {e.detail && (
+                    <span className="label" style={{ fontSize: 9 }}>
+                      {e.detail}
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          ),
+      )}
+      {snapshot && (
+        <div className="v-card" style={{ padding: 12 }}>
+          <div className="label" style={{ fontSize: 10, marginBottom: 6 }}>
+            End-of-run snapshot · {snapshot.cookies?.length ?? 0} cookie
+            {(snapshot.cookies?.length ?? 0) === 1 ? "" : "s"} ·{" "}
+            {snapshot.localStorage?.length ?? 0} localStorage key
+            {(snapshot.localStorage?.length ?? 0) === 1 ? "" : "s"}
+          </div>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+              gap: 6,
+            }}
+          >
+            {(snapshot.cookies ?? []).map((c, i) => (
+              <div
+                key={`c-${i}`}
+                style={{
+                  background: "var(--c-soft)",
+                  borderRadius: 6,
+                  padding: "6px 8px",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                }}
+                title={`${c.domain}${c.path}`}
+              >
+                <span className="label" style={{ fontSize: 8 }}>
+                  cookie
+                </span>
+                <code
+                  className="mono"
+                  style={{
+                    fontSize: 10,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {c.name}
+                </code>
+                {c.redacted && (
+                  <span className="label" style={{ fontSize: 8 }}>
+                    redacted
+                  </span>
+                )}
+              </div>
+            ))}
+            {(snapshot.localStorage ?? []).map((l, i) => (
+              <div
+                key={`l-${i}`}
+                style={{
+                  background: "var(--c-soft)",
+                  borderRadius: 6,
+                  padding: "6px 8px",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                }}
+                title={l.origin}
+              >
+                <span className="label" style={{ fontSize: 8 }}>
+                  local
+                </span>
+                <code
+                  className="mono"
+                  style={{
+                    fontSize: 10,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {l.name}
+                </code>
+                {l.redacted && (
+                  <span className="label" style={{ fontSize: 8 }}>
+                    redacted
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {!snapshot && !diff && (
+        <div
+          className="v-card"
+          style={{ padding: 24, textAlign: "center", color: "var(--fg-3)" }}
+        >
+          <span className="label">No storage state captured</span>
+        </div>
+      )}
+    </div>
+  );
 }
 
 interface AbsentHint {
@@ -2294,6 +2537,11 @@ function absentHint(
           "No API result for this case. The API layer runs only on API-type tests (a headless HTTP request + assertions). Convert or create an API test to populate this tab.",
         settingsHref: testId ? `/tests/${testId}` : undefined,
         settingsLabel: testId ? "Open test" : undefined,
+      };
+    case "storage":
+      return {
+        message:
+          "No storage state snapshot on this run. Snapshots (cookies + localStorage) are captured at end-of-test on embedded-browser runs — legacy or failed runs may lack one.",
       };
   }
 }

--- a/src/app/(app)/verify/[buildId]/page.tsx
+++ b/src/app/(app)/verify/[buildId]/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/lib/db/queries";
 import { getCurrentSession, requireRepoAccess } from "@/lib/auth";
 import { isVerifyPhaseEnabled } from "@/lib/verify/feature-flag";
+import { isInteractivePlaybackEnabled } from "@/lib/playback/feature-flag";
 import { fetchRepoBranches } from "@/server/actions/repos";
 import { BoardFocusClient } from "./board-focus-client";
 
@@ -102,6 +103,7 @@ export default async function VerifyBuildPage({
       designSystemTrend={designSystemTrend}
       designSystemViolations={designSystemViolations}
       repoDesignSystem={pwSettings?.designSystem ?? null}
+      interactivePlayback={isInteractivePlaybackEnabled(session?.team)}
     />
   );
 }

--- a/src/app/(app)/verify/[buildId]/perf-vitals-chart.tsx
+++ b/src/app/(app)/verify/[buildId]/perf-vitals-chart.tsx
@@ -1,0 +1,521 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { WebVitalsSample } from "@/lib/db/schema";
+
+// Per-step Web Vitals time series for the verify Perf pane. One axis (ms) for
+// the timing metrics; CLS is unitless so it gets its own mini-chart instead of
+// a second y-scale. Series hues follow the validated categorical order from
+// the dataviz reference palette (adjacent-pair CVD-safe on light surfaces);
+// identity is never color-alone — chips + direct end-labels name the series.
+const MS_SERIES = [
+  { key: "lcp", label: "LCP", color: "#2a78d6" },
+  { key: "fcp", label: "FCP", color: "#008300" },
+  { key: "inp", label: "INP", color: "#e87ba4" },
+  { key: "tbt", label: "TBT", color: "#eda100" },
+  { key: "ttfb", label: "TTFB", color: "#1baf7a" },
+] as const;
+const CLS_COLOR = "#eb6834";
+
+type MsKey = (typeof MS_SERIES)[number]["key"];
+
+interface PerfDelta {
+  metric: string;
+  baseline: number;
+  current: number;
+  delta: number;
+  budgetBreached?: boolean;
+  drifted?: boolean;
+}
+
+interface ChartPoint {
+  stepIndex: number;
+  stepLabel: string | null;
+  values: Partial<Record<MsKey | "cls", number>>;
+}
+
+function fmtMs(v: number): string {
+  return v >= 1000 ? `${(v / 1000).toFixed(1)}s` : `${Math.round(v)}ms`;
+}
+
+export function PerfVitalsChart({
+  samples,
+  deltas,
+}: {
+  samples: WebVitalsSample[];
+  deltas: PerfDelta[] | null;
+}) {
+  const points = useMemo<ChartPoint[]>(() => {
+    const rows = samples.map((s, i) => ({
+      stepIndex: s.stepIndex ?? i,
+      stepLabel: s.stepLabel ?? null,
+      values: {
+        lcp: s.lcp,
+        fcp: s.fcp,
+        inp: s.inp,
+        tbt: s.tbt,
+        ttfb: s.ttfb,
+        cls: s.cls,
+      } as ChartPoint["values"],
+    }));
+    rows.sort((a, b) => a.stepIndex - b.stepIndex);
+    return rows;
+  }, [samples]);
+
+  const present = useMemo(
+    () =>
+      MS_SERIES.filter((s) =>
+        points.some((p) => typeof p.values[s.key] === "number"),
+      ),
+    [points],
+  );
+  const hasCls = points.some((p) => typeof p.values.cls === "number");
+
+  const [enabled, setEnabled] = useState<Set<MsKey>>(
+    () => new Set(present.map((s) => s.key)),
+  );
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const [width, setWidth] = useState(560);
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(() => setWidth(el.clientWidth));
+    ro.observe(el);
+    setWidth(el.clientWidth);
+    return () => ro.disconnect();
+  }, []);
+
+  const active = present.filter((s) => enabled.has(s.key));
+  const baselineFor = (metric: string) =>
+    deltas?.find((d) => d.metric === metric)?.baseline ?? null;
+
+  const yMax = useMemo(() => {
+    let max = 0;
+    for (const p of points)
+      for (const s of active) {
+        const v = p.values[s.key];
+        if (typeof v === "number" && v > max) max = v;
+      }
+    for (const s of active) {
+      const b = baselineFor(s.key);
+      if (b != null && b > max) max = b;
+    }
+    return max > 0 ? max * 1.08 : 1;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [points, active, deltas]);
+
+  const peaks = useMemo(
+    () =>
+      active
+        .map((s) => {
+          let best: { v: number; p: ChartPoint } | null = null;
+          for (const p of points) {
+            const v = p.values[s.key];
+            if (typeof v === "number" && (!best || v > best.v)) best = { v, p };
+          }
+          return best ? { series: s, ...best } : null;
+        })
+        .filter(Boolean) as Array<{
+        series: (typeof MS_SERIES)[number];
+        v: number;
+        p: ChartPoint;
+      }>,
+    [active, points],
+  );
+
+  if (points.length < 2 || present.length === 0) return null;
+
+  const H = 190;
+  const PAD = { top: 10, right: 64, bottom: 22, left: 44 };
+  const plotW = Math.max(80, width - PAD.left - PAD.right);
+  const plotH = H - PAD.top - PAD.bottom;
+  const x = (i: number) =>
+    PAD.left + (points.length === 1 ? 0 : (i / (points.length - 1)) * plotW);
+  const y = (v: number) => PAD.top + plotH - (v / yMax) * plotH;
+
+  const onMove = (e: React.MouseEvent<SVGSVGElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const px = e.clientX - rect.left - PAD.left;
+    const idx = Math.round((px / plotW) * (points.length - 1));
+    setHoverIdx(Math.max(0, Math.min(points.length - 1, idx)));
+  };
+
+  const hover = hoverIdx != null ? points[hoverIdx] : null;
+  const ticks = [0, yMax / 2, yMax];
+
+  return (
+    <div className="v-card" style={{ padding: 12 }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          flexWrap: "wrap",
+          marginBottom: 6,
+        }}
+      >
+        <span className="label" style={{ fontSize: 10 }}>
+          Web Vitals per step
+        </span>
+        <span style={{ flex: 1 }} />
+        {present.map((s) => {
+          const on = enabled.has(s.key);
+          return (
+            <button
+              key={s.key}
+              type="button"
+              onClick={() =>
+                setEnabled((prev) => {
+                  const next = new Set(prev);
+                  if (next.has(s.key)) next.delete(s.key);
+                  else next.add(s.key);
+                  return next;
+                })
+              }
+              className="v-chip"
+              aria-pressed={on}
+              style={{
+                cursor: "pointer",
+                fontSize: 9,
+                padding: "1px 6px",
+                opacity: on ? 1 : 0.45,
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 4,
+              }}
+            >
+              <span
+                aria-hidden
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: "50%",
+                  background: s.color,
+                }}
+              />
+              {s.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Peak badges — worst value per enabled series with its step. */}
+      {peaks.length > 0 && (
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 4,
+            marginBottom: 6,
+          }}
+        >
+          {peaks.map(({ series, v, p }) => (
+            <span
+              key={series.key}
+              className="v-chip"
+              style={{ fontSize: 9, padding: "1px 6px" }}
+              title={p.stepLabel ?? undefined}
+            >
+              Peak {series.label} {fmtMs(v)} @ step {p.stepIndex + 1}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div ref={wrapRef} style={{ position: "relative" }}>
+        <svg
+          width="100%"
+          height={H}
+          role="img"
+          aria-label="Web Vitals per step line chart"
+          onMouseMove={onMove}
+          onMouseLeave={() => setHoverIdx(null)}
+          style={{ display: "block" }}
+        >
+          {/* Grid + y ticks */}
+          {ticks.map((t, i) => (
+            <g key={i}>
+              <line
+                x1={PAD.left}
+                x2={PAD.left + plotW}
+                y1={y(t)}
+                y2={y(t)}
+                stroke="var(--border)"
+                strokeWidth={1}
+              />
+              <text
+                x={PAD.left - 6}
+                y={y(t) + 3}
+                textAnchor="end"
+                fontSize={9}
+                fill="var(--fg-3)"
+              >
+                {fmtMs(t)}
+              </text>
+            </g>
+          ))}
+          {/* x labels: step numbers (sparse when crowded) */}
+          {points.map((p, i) => {
+            const every = Math.ceil(points.length / 12);
+            if (i % every !== 0) return null;
+            return (
+              <text
+                key={i}
+                x={x(i)}
+                y={H - 6}
+                textAnchor="middle"
+                fontSize={9}
+                fill="var(--fg-3)"
+              >
+                {p.stepIndex + 1}
+              </text>
+            );
+          })}
+          {/* Baseline overlays: dashed line at the baseline-run value. */}
+          {active.map((s) => {
+            const b = baselineFor(s.key);
+            if (b == null) return null;
+            return (
+              <line
+                key={`b-${s.key}`}
+                x1={PAD.left}
+                x2={PAD.left + plotW}
+                y1={y(b)}
+                y2={y(b)}
+                stroke={s.color}
+                strokeWidth={1}
+                strokeDasharray="4 3"
+                opacity={0.5}
+              />
+            );
+          })}
+          {/* Series lines + points + direct end-labels */}
+          {active.map((s) => {
+            const pts = points
+              .map((p, i) =>
+                typeof p.values[s.key] === "number"
+                  ? { i, v: p.values[s.key] as number }
+                  : null,
+              )
+              .filter(Boolean) as Array<{ i: number; v: number }>;
+            if (pts.length === 0) return null;
+            const d = pts
+              .map((pt, k) => `${k === 0 ? "M" : "L"}${x(pt.i)},${y(pt.v)}`)
+              .join(" ");
+            const last = pts[pts.length - 1];
+            return (
+              <g key={s.key}>
+                <path d={d} fill="none" stroke={s.color} strokeWidth={2} />
+                {pts.map((pt) => (
+                  <circle
+                    key={pt.i}
+                    cx={x(pt.i)}
+                    cy={y(pt.v)}
+                    r={hoverIdx === pt.i ? 4 : 2.5}
+                    fill={s.color}
+                    stroke="var(--c-white)"
+                    strokeWidth={1}
+                  />
+                ))}
+                <text
+                  x={x(last.i) + 6}
+                  y={y(last.v) + 3}
+                  fontSize={9}
+                  fill="var(--fg-2)"
+                >
+                  {s.label} {fmtMs(last.v)}
+                </text>
+              </g>
+            );
+          })}
+          {/* Crosshair */}
+          {hover && (
+            <line
+              x1={x(hoverIdx!)}
+              x2={x(hoverIdx!)}
+              y1={PAD.top}
+              y2={PAD.top + plotH}
+              stroke="var(--fg-3)"
+              strokeWidth={1}
+              strokeDasharray="2 2"
+            />
+          )}
+        </svg>
+        {/* Tooltip */}
+        {hover && (
+          <div
+            style={{
+              position: "absolute",
+              left: Math.min(
+                Math.max(x(hoverIdx!) - 70, 0),
+                Math.max(0, width - 150),
+              ),
+              top: 0,
+              pointerEvents: "none",
+              background: "var(--c-white)",
+              border: "1px solid var(--border)",
+              borderRadius: 6,
+              padding: "6px 8px",
+              boxShadow: "0 2px 8px rgba(0,0,0,0.08)",
+              fontSize: 10,
+              minWidth: 120,
+              zIndex: 2,
+            }}
+          >
+            <div
+              style={{ fontWeight: 600, color: "var(--fg-1)", marginBottom: 2 }}
+            >
+              Step {hover.stepIndex + 1}
+              {hover.stepLabel ? ` · ${hover.stepLabel}` : ""}
+            </div>
+            {active.map((s) => {
+              const v = hover.values[s.key];
+              return (
+                <div
+                  key={s.key}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 5,
+                    color: "var(--fg-2)",
+                  }}
+                >
+                  <span
+                    aria-hidden
+                    style={{
+                      width: 7,
+                      height: 7,
+                      borderRadius: "50%",
+                      background: s.color,
+                    }}
+                  />
+                  <span style={{ width: 34 }}>{s.label}</span>
+                  <span className="mono">
+                    {typeof v === "number" ? fmtMs(v) : "—"}
+                  </span>
+                </div>
+              );
+            })}
+            {typeof hover.values.cls === "number" && (
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 5,
+                  color: "var(--fg-2)",
+                }}
+              >
+                <span
+                  aria-hidden
+                  style={{
+                    width: 7,
+                    height: 7,
+                    borderRadius: "50%",
+                    background: CLS_COLOR,
+                  }}
+                />
+                <span style={{ width: 34 }}>CLS</span>
+                <span className="mono">{hover.values.cls.toFixed(3)}</span>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* CLS is unitless — its own mini-chart instead of a second y-axis. */}
+      {hasCls && (
+        <ClsMiniChart
+          points={points}
+          width={width}
+          baseline={baselineFor("cls")}
+        />
+      )}
+    </div>
+  );
+}
+
+function ClsMiniChart({
+  points,
+  width,
+  baseline,
+}: {
+  points: ChartPoint[];
+  width: number;
+  baseline: number | null;
+}) {
+  const H = 70;
+  const PAD = { top: 8, right: 64, bottom: 4, left: 44 };
+  const plotW = Math.max(80, width - PAD.left - PAD.right);
+  const plotH = H - PAD.top - PAD.bottom;
+  const vals = points
+    .map((p, i) =>
+      typeof p.values.cls === "number" ? { i, v: p.values.cls } : null,
+    )
+    .filter(Boolean) as Array<{ i: number; v: number }>;
+  if (vals.length === 0) return null;
+  const max =
+    Math.max(...vals.map((v) => v.v), baseline ?? 0, 0.01) * 1.15 || 0.01;
+  const x = (i: number) =>
+    PAD.left + (points.length === 1 ? 0 : (i / (points.length - 1)) * plotW);
+  const y = (v: number) => PAD.top + plotH - (v / max) * plotH;
+  const d = vals
+    .map((pt, k) => `${k === 0 ? "M" : "L"}${x(pt.i)},${y(pt.v)}`)
+    .join(" ");
+  const last = vals[vals.length - 1];
+  return (
+    <svg
+      width="100%"
+      height={H}
+      role="img"
+      aria-label="Cumulative Layout Shift per step"
+      style={{ display: "block", marginTop: 4 }}
+    >
+      <line
+        x1={PAD.left}
+        x2={PAD.left + plotW}
+        y1={y(0)}
+        y2={y(0)}
+        stroke="var(--border)"
+        strokeWidth={1}
+      />
+      {baseline != null && (
+        <line
+          x1={PAD.left}
+          x2={PAD.left + plotW}
+          y1={y(baseline)}
+          y2={y(baseline)}
+          stroke={CLS_COLOR}
+          strokeWidth={1}
+          strokeDasharray="4 3"
+          opacity={0.5}
+        />
+      )}
+      <path d={d} fill="none" stroke={CLS_COLOR} strokeWidth={2} />
+      {vals.map((pt) => (
+        <circle
+          key={pt.i}
+          cx={x(pt.i)}
+          cy={y(pt.v)}
+          r={2.5}
+          fill={CLS_COLOR}
+          stroke="var(--c-white)"
+          strokeWidth={1}
+        />
+      ))}
+      <text x={x(last.i) + 6} y={y(last.v) + 3} fontSize={9} fill="var(--fg-2)">
+        CLS {last.v.toFixed(3)}
+      </text>
+      <text
+        x={PAD.left - 6}
+        y={y(max / 1.15) + 3}
+        textAnchor="end"
+        fontSize={9}
+        fill="var(--fg-3)"
+      >
+        {(max / 1.15).toFixed(2)}
+      </text>
+    </svg>
+  );
+}

--- a/src/app/(public)/r/[slug]/page.tsx
+++ b/src/app/(public)/r/[slug]/page.tsx
@@ -40,6 +40,7 @@ import {
 import { buildXrayElements, buildXrayFromDomDiff } from "@/lib/share/xray";
 import type { XrayElement } from "@/lib/share/xray";
 import { ShareVideoPlayer } from "./share-video-player";
+import { resolveStepSegments } from "@/lib/playback/step-timings";
 import { ShareWcagPanel } from "@/components/share/share-wcag-panel";
 import { AwardBadgeRow } from "@/components/awards/award-badge-row";
 import { MobileDiffGallery } from "@/components/diff/mobile-diff-gallery-client";
@@ -476,7 +477,23 @@ export default async function PublicSharePage({ params }: PageProps) {
                 the page reads as a video watch page (Google's "video is the
                 main content" signal) and the player has an accessible label. */}
             <figure className="m-0 space-y-2">
-              <ShareVideoPlayer clips={clips} tracks={captionTracks} />
+              <ShareVideoPlayer
+                clips={clips}
+                tracks={captionTracks}
+                segments={resolveStepSegments({
+                  stepTimings: primaryResult?.stepTimings,
+                  screenshots: primaryResult?.screenshots,
+                  durationMs:
+                    clips[0]?.durationMs ?? primaryResult?.durationMs ?? null,
+                }).map((t) => ({
+                  index: t.stepIndex,
+                  label: t.label,
+                  stepType: t.stepType,
+                  status: t.status,
+                  startMs: t.startMs,
+                  endMs: t.endMs,
+                }))}
+              />
               <figcaption className="text-sm text-muted-foreground">
                 Recording of the visual regression run on {displayDomain}
                 {test?.name ? ` · ${test.name}` : ""}.

--- a/src/app/(public)/r/[slug]/page.tsx
+++ b/src/app/(public)/r/[slug]/page.tsx
@@ -6,6 +6,7 @@ import {
   getPublicShareContext,
   getPublicShareStats,
   getShareDataBySlug,
+  getShareOwnerTeamFlags,
   type PublicShareContext,
   type ShareVisualDiff,
   type ShareTestResult,
@@ -41,6 +42,7 @@ import { buildXrayElements, buildXrayFromDomDiff } from "@/lib/share/xray";
 import type { XrayElement } from "@/lib/share/xray";
 import { ShareVideoPlayer } from "./share-video-player";
 import { resolveStepSegments } from "@/lib/playback/step-timings";
+import { isInteractivePlaybackEnabled } from "@/lib/playback/feature-flag";
 import { ShareWcagPanel } from "@/components/share/share-wcag-panel";
 import { AwardBadgeRow } from "@/components/awards/award-badge-row";
 import { MobileDiffGallery } from "@/components/diff/mobile-diff-gallery-client";
@@ -415,6 +417,13 @@ export default async function PublicSharePage({ params }: PageProps) {
     : null;
   const showAwardBadges = !!award && award.currentTier !== "none";
 
+  // Spec-28 annotated player (step ticks on the scrubber + chapter-rail
+  // follow) is Early Adopter only. Viewers here are anonymous, so the gate
+  // reads the flag of the team that published the share.
+  const interactivePlayback = isInteractivePlaybackEnabled(
+    await getShareOwnerTeamFlags(repoIdForNotes),
+  );
+
   // Platform-wide activity numbers for the social-proof strip near the claim
   // CTA. Rendering is threshold-gated inside SocialProofStrip so early-days
   // counts never read as embarrassing.
@@ -480,19 +489,25 @@ export default async function PublicSharePage({ params }: PageProps) {
               <ShareVideoPlayer
                 clips={clips}
                 tracks={captionTracks}
-                segments={resolveStepSegments({
-                  stepTimings: primaryResult?.stepTimings,
-                  screenshots: primaryResult?.screenshots,
-                  durationMs:
-                    clips[0]?.durationMs ?? primaryResult?.durationMs ?? null,
-                }).map((t) => ({
-                  index: t.stepIndex,
-                  label: t.label,
-                  stepType: t.stepType,
-                  status: t.status,
-                  startMs: t.startMs,
-                  endMs: t.endMs,
-                }))}
+                segments={
+                  interactivePlayback
+                    ? resolveStepSegments({
+                        stepTimings: primaryResult?.stepTimings,
+                        screenshots: primaryResult?.screenshots,
+                        durationMs:
+                          clips[0]?.durationMs ??
+                          primaryResult?.durationMs ??
+                          null,
+                      }).map((t) => ({
+                        index: t.stepIndex,
+                        label: t.label,
+                        stepType: t.stepType,
+                        status: t.status,
+                        startMs: t.startMs,
+                        endMs: t.endMs,
+                      }))
+                    : undefined
+                }
               />
               <figcaption className="text-sm text-muted-foreground">
                 Recording of the visual regression run on {displayDomain}

--- a/src/app/api/builds/[buildId]/verify-status/route.ts
+++ b/src/app/api/builds/[buildId]/verify-status/route.ts
@@ -128,6 +128,7 @@ export async function GET(
   const slimResults = runningTestRows.map((r) => ({
     id: r.id,
     testId: r.testId,
+    testRunId: r.testRunId,
     status: r.status,
     errorMessage: r.errorMessage,
     durationMs: r.durationMs,
@@ -149,6 +150,10 @@ export async function GET(
     assignedVariables: r.assignedVariables,
     domSnapshot: r.domSnapshot,
     apiResult: r.apiResult,
+    videoPath: r.videoPath,
+    stepTimings: r.stepTimings,
+    consoleEntries: r.consoleEntries,
+    storageStateSnapshot: r.storageStateSnapshot,
   }));
 
   // "running tests" = test_results in 'running' status without an end timestamp.

--- a/src/components/diff/multi-layer-panel.tsx
+++ b/src/components/diff/multi-layer-panel.tsx
@@ -30,6 +30,7 @@ const LAYER_LABELS: Record<EvidenceLayer, string> = {
   perf: "Performance",
   variable: "Variables",
   api: "API",
+  storage: "Storage State",
 };
 
 function VerdictPill({ verdict }: { verdict: StepVerdict }) {

--- a/src/components/playback-sync.tsx
+++ b/src/components/playback-sync.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  type ReactNode,
+} from "react";
+import {
+  VideoPlayer,
+  type VideoPlayerHandle,
+  type VideoPlayerProps,
+} from "@/components/video-player";
+
+// Bidirectional playback↔evidence sync bus. A mounted player publishes its
+// position (video-clock ms) and evidence panes (step lists, network tables,
+// perf crosshairs, chapter rails) subscribe; panes call seekTo() to drive the
+// player. This is the React-side replacement for the document-level
+// `[data-seek]` click pattern in replay-player.tsx — that data-attribute path
+// stays for server-rendered share HTML; this bus layers on top for client
+// components.
+
+export interface PlaybackSyncApi {
+  /** Player side: register the imperative handle. Returns unregister. */
+  registerPlayer: (handle: VideoPlayerHandle) => () => void;
+  /** Player side: publish the current position (ms). Throttled to consumers. */
+  publishTime: (ms: number) => void;
+  /** Pane side: seek the mounted player. play=true also starts playback. */
+  seekTo: (ms: number, opts?: { play?: boolean }) => void;
+  /** Pane side: subscribe to time updates (~4 Hz). Returns unsubscribe. */
+  onTime: (fn: (ms: number) => void) => () => void;
+  /** Last published position (ms) for late subscribers. */
+  getTimeMs: () => number;
+  /** True when a player is currently registered on this bus. */
+  hasPlayer: () => boolean;
+}
+
+const TIME_THROTTLE_MS = 250;
+
+const PlaybackSyncContext = createContext<PlaybackSyncApi | null>(null);
+
+export function PlaybackSyncProvider({ children }: { children: ReactNode }) {
+  const playerRef = useRef<VideoPlayerHandle | null>(null);
+  const listenersRef = useRef<Set<(ms: number) => void>>(new Set());
+  const lastTimeMsRef = useRef(0);
+  const lastNotifyAtRef = useRef(0);
+
+  const registerPlayer = useCallback((handle: VideoPlayerHandle) => {
+    playerRef.current = handle;
+    return () => {
+      if (playerRef.current === handle) playerRef.current = null;
+    };
+  }, []);
+
+  const publishTime = useCallback((ms: number) => {
+    lastTimeMsRef.current = ms;
+    const now = performance.now();
+    if (now - lastNotifyAtRef.current < TIME_THROTTLE_MS) return;
+    lastNotifyAtRef.current = now;
+    listenersRef.current.forEach((fn) => fn(ms));
+  }, []);
+
+  const seekTo = useCallback((ms: number, opts?: { play?: boolean }) => {
+    const player = playerRef.current;
+    if (!player) return;
+    const seconds = ms / 1000;
+    if (opts?.play) void player.seekAndPlay(seconds);
+    else player.seek(seconds);
+    // Reflect the jump to subscribers immediately — a paused seek fires no
+    // timeupdate until the next play.
+    lastTimeMsRef.current = ms;
+    listenersRef.current.forEach((fn) => fn(ms));
+  }, []);
+
+  const onTime = useCallback((fn: (ms: number) => void) => {
+    listenersRef.current.add(fn);
+    return () => {
+      listenersRef.current.delete(fn);
+    };
+  }, []);
+
+  const api = useMemo<PlaybackSyncApi>(
+    () => ({
+      registerPlayer,
+      publishTime,
+      seekTo,
+      onTime,
+      getTimeMs: () => lastTimeMsRef.current,
+      hasPlayer: () => playerRef.current !== null,
+    }),
+    [registerPlayer, publishTime, seekTo, onTime],
+  );
+
+  return (
+    <PlaybackSyncContext.Provider value={api}>
+      {children}
+    </PlaybackSyncContext.Provider>
+  );
+}
+
+/** Null outside a provider so surfaces without sync render unchanged. */
+export function usePlaybackSync(): PlaybackSyncApi | null {
+  return useContext(PlaybackSyncContext);
+}
+
+/**
+ * VideoPlayer wired into the enclosing PlaybackSyncProvider: registers its
+ * handle for seekTo() and publishes timeupdate positions. Renders a plain
+ * VideoPlayer when no provider is mounted.
+ */
+export function SyncedVideoPlayer(props: VideoPlayerProps) {
+  const sync = usePlaybackSync();
+  const cleanupRef = useRef<(() => void) | null>(null);
+  const { onReady, ...rest } = props;
+
+  useEffect(() => () => cleanupRef.current?.(), []);
+
+  const handleReady = useCallback(
+    (handle: VideoPlayerHandle) => {
+      onReady?.(handle);
+      if (!sync) return;
+      cleanupRef.current?.();
+      const unregister = sync.registerPlayer(handle);
+      const el = handle.getElement();
+      const onTimeUpdate = () => {
+        const v = handle.getElement();
+        if (v) sync.publishTime(v.currentTime * 1000);
+      };
+      el?.addEventListener("timeupdate", onTimeUpdate);
+      cleanupRef.current = () => {
+        el?.removeEventListener("timeupdate", onTimeUpdate);
+        unregister();
+      };
+    },
+    [onReady, sync],
+  );
+
+  return <VideoPlayer {...rest} onReady={handleReady} />;
+}

--- a/src/components/replay-player.tsx
+++ b/src/components/replay-player.tsx
@@ -3,9 +3,16 @@
 import { useEffect, useRef } from "react";
 import {
   VideoPlayer,
+  type PlayerSegment,
   type VideoPlayerHandle,
   type VideoTextTrack,
 } from "@/components/video-player";
+
+/** Document event dispatched (throttled) with the primary clip's playback
+ *  position. Detail: `{ ms: number }`. Lets server-rendered islands (e.g. the
+ *  share page's ChapterRail) follow playback without a shared React context —
+ *  the client-component analogue is `usePlaybackSync`. */
+export const PLAYBACK_TIME_EVENT = "lastest:playback-time";
 
 export interface ReplayClip {
   src: string;
@@ -40,6 +47,11 @@ export interface ReplayPlayerProps {
    * primary test result's run.
    */
   tracks?: VideoTextTrack[];
+  /**
+   * Per-step scrubber segments for the FIRST clip (see PlayerSegment) —
+   * derive via `resolveStepSegments` from the result's stepTimings.
+   */
+  segments?: PlayerSegment[];
 }
 
 /**
@@ -50,7 +62,12 @@ export interface ReplayPlayerProps {
  * single component means scrubber, hover-preview, and step-seek behavior
  * stay aligned across surfaces.
  */
-export function ReplayPlayer({ clips, className, tracks }: ReplayPlayerProps) {
+export function ReplayPlayer({
+  clips,
+  className,
+  tracks,
+  segments,
+}: ReplayPlayerProps) {
   const handlesRef = useRef<(VideoPlayerHandle | null)[]>([]);
 
   useEffect(() => {
@@ -66,6 +83,26 @@ export function ReplayPlayer({ clips, className, tracks }: ReplayPlayerProps) {
     return () => document.removeEventListener("click", onClick, true);
   }, []);
 
+  // Broadcast the primary clip's position so sibling islands (chapter rail,
+  // step strips) can highlight along without a shared React context.
+  useEffect(() => {
+    const el = handlesRef.current[0]?.getElement();
+    if (!el) return;
+    let lastDispatch = 0;
+    const onTimeUpdate = () => {
+      const now = performance.now();
+      if (now - lastDispatch < 250) return;
+      lastDispatch = now;
+      document.dispatchEvent(
+        new CustomEvent(PLAYBACK_TIME_EVENT, {
+          detail: { ms: el.currentTime * 1000 },
+        }),
+      );
+    };
+    el.addEventListener("timeupdate", onTimeUpdate);
+    return () => el.removeEventListener("timeupdate", onTimeUpdate);
+  }, [clips.length]);
+
   return (
     <>
       {clips.map((clip, i) => (
@@ -76,6 +113,7 @@ export function ReplayPlayer({ clips, className, tracks }: ReplayPlayerProps) {
           durationMsFallback={clip.durationMs ?? null}
           tracks={i === 0 ? tracks : undefined}
           captionsDefaultOn={i === 0 && !!tracks && tracks.length > 0}
+          segments={i === 0 ? segments : undefined}
           autoPlay
           loop
           playsInline

--- a/src/components/replay-player.tsx
+++ b/src/components/replay-player.tsx
@@ -84,8 +84,11 @@ export function ReplayPlayer({
   }, []);
 
   // Broadcast the primary clip's position so sibling islands (chapter rail,
-  // step strips) can highlight along without a shared React context.
+  // step strips) can highlight along without a shared React context. Tied to
+  // `segments` — that prop IS the spec-28 Early Adopter gate, so a gated page
+  // emits no time events and its chapter rail stays static, as before.
   useEffect(() => {
+    if (!segments || segments.length === 0) return;
     const el = handlesRef.current[0]?.getElement();
     if (!el) return;
     let lastDispatch = 0;
@@ -101,7 +104,7 @@ export function ReplayPlayer({
     };
     el.addEventListener("timeupdate", onTimeUpdate);
     return () => el.removeEventListener("timeupdate", onTimeUpdate);
-  }, [clips.length]);
+  }, [clips.length, segments]);
 
   return (
     <>

--- a/src/components/share/chapter-rail.tsx
+++ b/src/components/share/chapter-rail.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Maximize2, Play } from "lucide-react";
 import { ScreenshotViewer } from "@/components/tests/screenshot-viewer";
+import { PLAYBACK_TIME_EVENT } from "@/components/replay-player";
 
 export type Chapter = {
   src: string;
@@ -32,6 +33,12 @@ function formatTime(sec: number): string {
  */
 export function ChapterRail({ chapters }: { chapters: Chapter[] }) {
   const [openIndex, setOpenIndex] = useState<number | null>(null);
+  // Chapter containing the current playback position (ReplayPlayer broadcasts
+  // it as a document event — see PLAYBACK_TIME_EVENT). null until playback.
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const listRef = useRef<HTMLOListElement | null>(null);
+  const userScrolledAtRef = useRef(0);
+  const programmaticScrollAtRef = useRef(0);
 
   useEffect(() => {
     if (openIndex == null) return;
@@ -41,6 +48,36 @@ export function ChapterRail({ chapters }: { chapters: Chapter[] }) {
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
   }, [openIndex]);
+
+  useEffect(() => {
+    const onTime = (e: Event) => {
+      const ms = (e as CustomEvent<{ ms: number }>).detail?.ms;
+      if (!Number.isFinite(ms)) return;
+      const sec = ms / 1000;
+      let idx: number | null = null;
+      for (let i = 0; i < chapters.length; i++) {
+        const at = chapters[i]!.atSec;
+        if (at != null && at <= sec) idx = i;
+      }
+      setActiveIndex(idx);
+    };
+    document.addEventListener(PLAYBACK_TIME_EVENT, onTime);
+    return () => document.removeEventListener(PLAYBACK_TIME_EVENT, onTime);
+  }, [chapters]);
+
+  // Follow playback with a horizontal scroll — but yield to the user for a
+  // few seconds after they scroll the rail themselves.
+  useEffect(() => {
+    if (activeIndex == null) return;
+    if (performance.now() - userScrolledAtRef.current < 4000) return;
+    const el = listRef.current?.children[activeIndex] as
+      | HTMLElement
+      | undefined;
+    if (el) {
+      programmaticScrollAtRef.current = performance.now();
+      el.scrollIntoView({ block: "nearest", inline: "nearest" });
+    }
+  }, [activeIndex]);
 
   if (chapters.length === 0) return null;
   const anySeekable = chapters.some((c) => c.atSec != null);
@@ -53,12 +90,27 @@ export function ChapterRail({ chapters }: { chapters: Chapter[] }) {
           {anySeekable ? "· click a step to jump to it" : "· click to enlarge"}
         </span>
       </h2>
-      <ol className="flex gap-2 overflow-x-auto pb-1 -mx-1 px-1">
+      <ol
+        ref={listRef}
+        onScroll={() => {
+          // scrollIntoView also fires onScroll — only count human scrolls.
+          if (performance.now() - programmaticScrollAtRef.current > 300) {
+            userScrolledAtRef.current = performance.now();
+          }
+        }}
+        className="flex gap-2 overflow-x-auto pb-1 -mx-1 px-1"
+      >
         {chapters.map((c, i) => {
           const seekable = c.atSec != null;
+          const isActive = i === activeIndex;
           return (
             <li key={c.src + i} className="shrink-0">
-              <div className="group relative w-40 rounded-md border bg-card p-1">
+              <div
+                className={
+                  "group relative w-40 rounded-md border bg-card p-1 transition-shadow" +
+                  (isActive ? " border-primary/60 ring-2 ring-primary/40" : "")
+                }
+              >
                 {/* Seek target — carries data-seek so <ReplayPlayer> seeks the
                     recording on click. Falls back to opening the lightbox when
                     the chapter has no known offset. */}

--- a/src/components/verify/check-modes-dialog.tsx
+++ b/src/components/verify/check-modes-dialog.tsx
@@ -23,6 +23,7 @@ import {
   Gauge,
   Link as LinkIcon,
   Webhook,
+  Database,
 } from "lucide-react";
 import { savePlaywrightSettings } from "@/server/actions/settings";
 import {
@@ -117,6 +118,13 @@ const LAYERS: LayerMeta[] = [
     icon: Webhook,
     description:
       "Headless HTTP request + response assertions (API-type tests). A failed status/schema/body assertion gates the step.",
+  },
+  {
+    id: "storage",
+    name: "State",
+    icon: Database,
+    description:
+      "Diff end-of-run cookies + localStorage against the baseline run. Capture is always on; informational — never fails a test.",
   },
 ];
 

--- a/src/components/video-player.tsx
+++ b/src/components/video-player.tsx
@@ -13,18 +13,25 @@ import {
 } from "react";
 import * as SliderPrimitive from "@radix-ui/react-slider";
 import {
+  Camera,
   Captions,
   CaptionsOff,
   Check,
+  CircleCheck,
+  Globe,
+  Keyboard,
   Maximize2,
   Minimize2,
+  MousePointerClick,
   Pause,
   Play,
   SkipBack,
   SkipForward,
+  Timer,
   Volume1,
   Volume2,
   VolumeX,
+  type LucideIcon,
 } from "lucide-react";
 import {
   Popover,
@@ -33,7 +40,7 @@ import {
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
-const RATE_OPTIONS = [0.5, 1, 1.5, 2, 3, 4] as const;
+const RATE_OPTIONS = [0.5, 1, 1.5, 2, 3, 4, 6, 8] as const;
 const VOLUME_KEY = "lastest:videoplayer:volume";
 const MUTED_KEY = "lastest:videoplayer:muted";
 const CAPTIONS_KEY = "lastest:videoplayer:captions";
@@ -43,6 +50,37 @@ export interface VideoTextTrack {
   srclang: string;
   label: string;
 }
+
+/** One test step rendered as a segment on the scrubber (video-clock ms). */
+export interface PlayerSegment {
+  /** 0-based step index; shown 1-based in the UI. */
+  index: number;
+  label: string;
+  /** Action kind → tick icon (navigate/click/fill/shot/assert/wait/...). */
+  stepType?: string;
+  status?: "passed" | "failed";
+  startMs: number;
+  endMs: number;
+}
+
+// Icon per step kind on the segment strip. Anything unmapped falls back to
+// the step number (which is also what narrow segments show).
+const SEGMENT_ICONS: Record<string, LucideIcon> = {
+  navigate: Globe,
+  goto: Globe,
+  click: MousePointerClick,
+  dblclick: MousePointerClick,
+  hover: MousePointerClick,
+  fill: Keyboard,
+  type: Keyboard,
+  press: Keyboard,
+  select: Keyboard,
+  shot: Camera,
+  screenshot: Camera,
+  assert: CircleCheck,
+  expect: CircleCheck,
+  wait: Timer,
+};
 
 export interface VideoPlayerHandle {
   play: () => Promise<void>;
@@ -86,6 +124,15 @@ export interface VideoPlayerProps {
   tracks?: VideoTextTrack[];
   /** Whether captions start visible. Overridden by the user's saved choice. */
   captionsDefaultOn?: boolean;
+  /**
+   * Per-step segments drawn as an annotated strip above the scrubber: one
+   * tick per step with an action icon (or the step number when narrow),
+   * pass/fail coloring, click-to-seek, and active-segment highlight during
+   * playback. Omit for the plain scrubber.
+   */
+  segments?: PlayerSegment[];
+  /** Called when the user seeks via a segment tick (ms on the video clock). */
+  onSegmentSeek?: (segment: PlayerSegment) => void;
 }
 
 function formatTime(s: number): string {
@@ -147,6 +194,8 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       durationMsFallback,
       tracks,
       captionsDefaultOn = false,
+      segments,
+      onSegmentSeek,
     },
     ref,
   ) {
@@ -647,6 +696,31 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       [skip, toggleFullscreen, toggleMute, togglePlay, wakeControls, tracks],
     );
 
+    const sortedSegments = useMemo(
+      () =>
+        segments && segments.length > 0
+          ? [...segments].sort((a, b) => a.startMs - b.startMs)
+          : null,
+      [segments],
+    );
+
+    const seekToSegment = useCallback(
+      (seg: PlayerSegment) => {
+        const v = videoRef.current;
+        if (!v) return;
+        const t = seg.startMs / 1000 + 0.01;
+        v.currentTime = clamp(
+          t,
+          0,
+          Number.isFinite(v.duration) ? v.duration : t,
+        );
+        setCurrentTime(v.currentTime);
+        wakeControls();
+        onSegmentSeek?.(seg);
+      },
+      [onSegmentSeek, wakeControls],
+    );
+
     const VolumeIcon =
       muted || volume === 0 ? VolumeX : volume < 0.5 ? Volume1 : Volume2;
     const showControls = !isPlaying || isScrubbing || controlsVisible;
@@ -745,6 +819,63 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
             "data-[visible=true]:translate-y-0 data-[visible=true]:opacity-100",
           )}
         >
+          {sortedSegments && safeDuration > 0 && (
+            <div
+              role="group"
+              aria-label="Test steps"
+              className="relative h-5 w-full"
+            >
+              {sortedSegments.map((seg, i) => {
+                const durMs = safeDuration * 1000;
+                const leftPct = clamp((seg.startMs / durMs) * 100, 0, 100);
+                const rightPct = clamp((seg.endMs / durMs) * 100, leftPct, 100);
+                const widthPct = Math.max(rightPct - leftPct, 0.4);
+                const pxWidth = (widthPct / 100) * scrubberWidth;
+                const tMs = currentTime * 1000;
+                const isLast = i === sortedSegments.length - 1;
+                const active =
+                  tMs >= seg.startMs &&
+                  (isLast ? tMs <= seg.endMs + 1000 : tMs < seg.endMs);
+                const failed = seg.status === "failed";
+                const Icon = seg.stepType
+                  ? SEGMENT_ICONS[seg.stepType.toLowerCase()]
+                  : undefined;
+                const range = `${formatTime(seg.startMs / 1000)} – ${formatTime(seg.endMs / 1000)}`;
+                return (
+                  <button
+                    key={`${seg.index}-${seg.startMs}`}
+                    type="button"
+                    title={`${seg.index + 1}. ${seg.label} (${range})`}
+                    aria-label={`Seek to step ${seg.index + 1}: ${seg.label}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      seekToSegment(seg);
+                    }}
+                    className={cn(
+                      "absolute inset-y-0 flex items-center justify-center overflow-hidden rounded-sm border-l transition-colors",
+                      failed
+                        ? "border-red-400/80 text-red-200/80 hover:bg-red-500/25 hover:text-red-100"
+                        : "border-white/35 text-white/60 hover:bg-white/15 hover:text-white",
+                      active &&
+                        (failed
+                          ? "bg-red-500/25 text-red-100"
+                          : "bg-white/20 text-white"),
+                    )}
+                    style={{ left: `${leftPct}%`, width: `${widthPct}%` }}
+                  >
+                    {Icon && pxWidth >= 20 ? (
+                      <Icon className="h-3 w-3" />
+                    ) : pxWidth >= 13 ? (
+                      <span className="font-mono text-[9px] tabular-nums">
+                        {seg.index + 1}
+                      </span>
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
           <div
             ref={scrubberRef}
             className="relative flex h-4 items-center"

--- a/src/lib/comparison/scorer.ts
+++ b/src/lib/comparison/scorer.ts
@@ -39,6 +39,10 @@ import {
 import { computeA11yDiff, summarizeA11yDiff } from "./a11y-diff";
 import { computeVariableDiff, summarizeVariableDiff } from "./variable-diff";
 import { computePerfDiff, summarizePerfDiff } from "./perf-diff";
+import {
+  computeStorageStateDiff,
+  summarizeStorageStateDiff,
+} from "./storage-state-diff";
 
 export interface MultiLayerVerdict {
   verdict: StepVerdict;
@@ -47,15 +51,18 @@ export interface MultiLayerVerdict {
 }
 
 interface ScoreInputs {
-  baseline: Pick<
-    TestResult,
-    | "consoleErrors"
-    | "networkRequests"
-    | "a11yViolations"
-    | "urlTrajectory"
-    | "webVitals"
-    | "extractedVariables"
-  > | null;
+  baseline:
+    | (Pick<
+        TestResult,
+        | "consoleErrors"
+        | "networkRequests"
+        | "a11yViolations"
+        | "urlTrajectory"
+        | "webVitals"
+        | "extractedVariables"
+      > &
+        Partial<Pick<TestResult, "storageStateSnapshot">>)
+    | null;
   current: Pick<
     TestResult,
     | "consoleErrors"
@@ -64,7 +71,8 @@ interface ScoreInputs {
     | "urlTrajectory"
     | "webVitals"
     | "extractedVariables"
-  >;
+  > &
+    Partial<Pick<TestResult, "storageStateSnapshot">>;
   /** Optional visual-diff record so we can fold visual signal into the verdict.
    *  When omitted we skip the visual layer entirely. */
   visualDiff?: Pick<
@@ -273,6 +281,23 @@ export function scoreMultiLayer({
       layer: "perf",
       signal: newBreach ? "high" : drifted ? "medium" : "low",
       summary: summarizePerfDiff(perfDiff),
+    });
+  }
+
+  // ── Storage state (informational — never gates) ──────────────────────
+  // End-of-run cookies + localStorage vs the baseline run. Sessions rotate
+  // and caches churn, so this stays 'low' signal: it feeds the State tab
+  // and the tab delta, but can't flip a verdict on its own.
+  const storageDiff = computeStorageStateDiff(
+    baseline?.storageStateSnapshot ?? null,
+    current.storageStateSnapshot ?? null,
+  );
+  if (storageDiff) {
+    layers.storageState = storageDiff;
+    evidence.push({
+      layer: "storage",
+      signal: "low",
+      summary: summarizeStorageStateDiff(storageDiff),
     });
   }
 

--- a/src/lib/comparison/storage-state-diff.ts
+++ b/src/lib/comparison/storage-state-diff.ts
@@ -1,0 +1,116 @@
+/**
+ * Storage-state diff engine (spec 27 — the State layer). Compares the
+ * current run's end-of-run cookies + localStorage snapshot against the
+ * baseline run's, keyed structurally:
+ *
+ *   cookies       → (domain, path, name), compared by valueHash
+ *   localStorage  → (origin, name), compared by value (when parseable JSON
+ *                   was stored) or valueHash
+ *
+ * Values are hashed at capture time (see StorageStateSnapshot), so the diff
+ * can say "changed" but never leak what changed to. Purely informational —
+ * evidence is emitted at 'low' signal and never gates a verdict.
+ */
+
+import type {
+  StorageStateSnapshot,
+  StorageStateDiffEntry,
+  StorageStateDiffSummary,
+} from "@/lib/db/schema";
+
+function cookieKey(c: StorageStateSnapshot["cookies"][number]): string {
+  return `${c.domain} ${c.path} ${c.name}`;
+}
+
+function localKey(l: StorageStateSnapshot["localStorage"][number]): string {
+  return `${l.origin} ${l.name}`;
+}
+
+function localFingerprint(
+  l: StorageStateSnapshot["localStorage"][number],
+): string {
+  if (l.valueHash) return `h:${l.valueHash}`;
+  try {
+    return `v:${JSON.stringify(l.value)}`;
+  } catch {
+    return "v:?";
+  }
+}
+
+export function computeStorageStateDiff(
+  baseline: StorageStateSnapshot | null | undefined,
+  current: StorageStateSnapshot | null | undefined,
+): StorageStateDiffSummary | null {
+  // Both sides must exist — diffing against a missing baseline snapshot
+  // would report every entry as "added" and drown the signal.
+  if (!baseline || !current) return null;
+
+  const cookies: StorageStateDiffEntry[] = [];
+  const localStorageEntries: StorageStateDiffEntry[] = [];
+
+  const baseCookies = new Map(
+    (baseline.cookies ?? []).map((c) => [cookieKey(c), c]),
+  );
+  const curCookies = new Map(
+    (current.cookies ?? []).map((c) => [cookieKey(c), c]),
+  );
+  for (const [key, cur] of curCookies) {
+    const base = baseCookies.get(key);
+    if (!base) {
+      cookies.push({ key, change: "added" });
+    } else if (
+      base.valueHash &&
+      cur.valueHash &&
+      base.valueHash !== cur.valueHash
+    ) {
+      cookies.push({ key, change: "changed", detail: "value changed" });
+    }
+  }
+  for (const key of baseCookies.keys()) {
+    if (!curCookies.has(key)) cookies.push({ key, change: "removed" });
+  }
+
+  const baseLocal = new Map(
+    (baseline.localStorage ?? []).map((l) => [localKey(l), l]),
+  );
+  const curLocal = new Map(
+    (current.localStorage ?? []).map((l) => [localKey(l), l]),
+  );
+  for (const [key, cur] of curLocal) {
+    const base = baseLocal.get(key);
+    if (!base) {
+      localStorageEntries.push({ key, change: "added" });
+    } else if (localFingerprint(base) !== localFingerprint(cur)) {
+      localStorageEntries.push({
+        key,
+        change: "changed",
+        detail: "value changed",
+      });
+    }
+  }
+  for (const key of baseLocal.keys()) {
+    if (!curLocal.has(key))
+      localStorageEntries.push({ key, change: "removed" });
+  }
+
+  const all = [...cookies, ...localStorageEntries];
+  if (all.length === 0) return null;
+
+  return {
+    cookies,
+    localStorage: localStorageEntries,
+    addedCount: all.filter((e) => e.change === "added").length,
+    removedCount: all.filter((e) => e.change === "removed").length,
+    changedCount: all.filter((e) => e.change === "changed").length,
+  };
+}
+
+export function summarizeStorageStateDiff(
+  diff: StorageStateDiffSummary,
+): string {
+  const parts: string[] = [];
+  if (diff.addedCount) parts.push(`+${diff.addedCount}`);
+  if (diff.removedCount) parts.push(`−${diff.removedCount}`);
+  if (diff.changedCount) parts.push(`~${diff.changedCount}`);
+  return `storage state: ${parts.join(" ")} (cookies ${diff.cookies.length}, localStorage ${diff.localStorage.length})`;
+}

--- a/src/lib/db/queries/public-shares.ts
+++ b/src/lib/db/queries/public-shares.ts
@@ -15,6 +15,7 @@ import type {
   PublicShareKind,
   Baseline,
   CapturedScreenshot,
+  StepTiming,
   DomDiffResult,
   StepComparisonEvidence,
   StepVerdict,
@@ -407,6 +408,7 @@ export type ShareTestResult = {
   durationMs: number | null;
   screenshots: CapturedScreenshot[] | null;
   webVitals: WebVitalsSample[] | null;
+  stepTimings: StepTiming[] | null;
 };
 
 // Slim step-comparison projection for share rendering. Drops issue/reviewer
@@ -481,6 +483,7 @@ export async function getShareDataBySlug(
           durationMs: testResults.durationMs,
           screenshots: testResults.screenshots,
           webVitals: testResults.webVitals,
+          stepTimings: testResults.stepTimings,
         })
         .from(testResults)
         .where(

--- a/src/lib/db/queries/public-shares.ts
+++ b/src/lib/db/queries/public-shares.ts
@@ -8,6 +8,8 @@ import {
   visualDiffs,
   testResults,
   stepComparisons,
+  repositories,
+  teams,
 } from "../schema";
 import type {
   NewPublicShare,
@@ -296,6 +298,25 @@ export interface PublicShareContext {
   build: typeof builds.$inferSelect;
   test: typeof tests.$inferSelect | null;
   testRun: typeof testRuns.$inferSelect | null;
+}
+
+/**
+ * Feature flags of the team that owns a share's repository. A public share
+ * page has no session, so per-team gating (e.g. the spec-28 annotated player)
+ * reads the OWNER's flags instead of the anonymous viewer's. One join —
+ * the share page is server-rendered on every request.
+ */
+export async function getShareOwnerTeamFlags(
+  repositoryId: string | null | undefined,
+): Promise<{ earlyAdopterMode: boolean } | null> {
+  if (!repositoryId) return null;
+  const [row] = await db
+    .select({ earlyAdopterMode: teams.earlyAdopterMode })
+    .from(repositories)
+    .innerJoin(teams, eq(repositories.teamId, teams.id))
+    .where(eq(repositories.id, repositoryId))
+    .limit(1);
+  return row ? { earlyAdopterMode: row.earlyAdopterMode ?? false } : null;
 }
 
 export async function getActiveBaselinesForTest(

--- a/src/lib/db/queries/settings.ts
+++ b/src/lib/db/queries/settings.ts
@@ -155,6 +155,7 @@ export async function getPlaywrightSettings(repositoryId?: string | null) {
     perfMode: null as string | null,
     urlMode: null as string | null,
     apiMode: null as string | null,
+    storageMode: null as string | null,
     createdAt: null,
     updatedAt: null,
   };

--- a/src/lib/db/queries/tests.ts
+++ b/src/lib/db/queries/tests.ts
@@ -656,6 +656,7 @@ export async function getTestResultsByTest(testId: string) {
       totalSteps: testResults.totalSteps,
       extractedVariables: testResults.extractedVariables,
       assignedVariables: testResults.assignedVariables,
+      stepTimings: testResults.stepTimings,
       gitBranch: testRuns.gitBranch,
       gitCommit: testRuns.gitCommit,
     })

--- a/src/lib/execution/executor.ts
+++ b/src/lib/execution/executor.ts
@@ -1294,13 +1294,16 @@ async function executeViaRunner(
         );
       }
 
-      // Save video file if present in the result
+      // Save video file if present in the result. Not best-effort: a lost
+      // recording silently kills every playback surface, so retry once and
+      // surface a final failure in the persisted result logs.
       let videoPath: string | undefined;
+      let videoSaveError: string | undefined;
       if (payload.videoPath) {
         // Video already saved to disk by the runner route handler
         videoPath = payload.videoPath as string;
       } else if (payload.videoData && payload.videoFilename) {
-        try {
+        const writeVideo = async () => {
           const videoDir = path.join(
             STORAGE_DIRS.videos,
             options.repositoryId || "default",
@@ -1314,9 +1317,24 @@ async function executeViaRunner(
             videoDest,
             Buffer.from(payload.videoData as string, "base64"),
           );
-          videoPath = toRelativePath(videoDest);
-        } catch {
-          // Video save is best-effort
+          return toRelativePath(videoDest);
+        };
+        try {
+          videoPath = await writeVideo();
+        } catch (err) {
+          console.warn(
+            `[Executor] Video save failed for ${payload.videoFilename}, retrying once:`,
+            err,
+          );
+          try {
+            videoPath = await writeVideo();
+          } catch (retryErr) {
+            videoSaveError =
+              retryErr instanceof Error ? retryErr.message : String(retryErr);
+            console.error(
+              `[Executor] Video save failed after retry for ${payload.videoFilename}: ${videoSaveError}`,
+            );
+          }
         }
       }
 
@@ -1416,14 +1434,24 @@ async function executeViaRunner(
         // alongside extractedVariables so the Vars-tab "Last run" column has
         // data for both modes (especially with random/increment row picks).
         assignedVariables: info.assignedVariables,
-        logs:
-          Array.isArray(payload.logs) && payload.logs.length > 0
-            ? (payload.logs as Array<{
-                timestamp: number;
-                level: string;
-                message: string;
-              }>)
-            : undefined,
+        logs: (() => {
+          const base =
+            Array.isArray(payload.logs) && payload.logs.length > 0
+              ? (payload.logs as Array<{
+                  timestamp: number;
+                  level: string;
+                  message: string;
+                }>)
+              : [];
+          if (videoSaveError) {
+            base.push({
+              timestamp: Date.now(),
+              level: "error",
+              message: `Video save failed after retry — recording lost: ${videoSaveError}`,
+            });
+          }
+          return base.length > 0 ? base : undefined;
+        })(),
         // EB ships a11yViolations / a11yPassesCount on the response payload
         // when `enableA11y` was set on the command. Forward them onto the
         // TestRunResult so `createTestResult` persists them; otherwise the
@@ -1464,6 +1492,15 @@ async function executeViaRunner(
           payload.storageStateSnapshot &&
           typeof payload.storageStateSnapshot === "object"
             ? (payload.storageStateSnapshot as import("@/lib/db/schema").StorageStateSnapshot)
+            : undefined,
+        stepTimings:
+          Array.isArray(payload.stepTimings) && payload.stepTimings.length > 0
+            ? (payload.stepTimings as import("@/lib/db/schema").StepTiming[])
+            : undefined,
+        consoleEntries:
+          Array.isArray(payload.consoleEntries) &&
+          payload.consoleEntries.length > 0
+            ? (payload.consoleEntries as import("@/lib/db/schema").ConsoleEntry[])
             : undefined,
       };
 

--- a/src/lib/playback/feature-flag.ts
+++ b/src/lib/playback/feature-flag.ts
@@ -1,0 +1,33 @@
+/**
+ * Interactive playback feature flag (spec 28).
+ *
+ * The "new player" — the step-annotated scrubber (per-step segment ticks with
+ * action icons, click-to-seek, active-segment highlight), the Verify Run-pane
+ * recording card, and the playback↔evidence sync that drives the chapter rail
+ * — ships behind Early Adopter mode.
+ *
+ * Everything degrades by omission: surfaces simply don't pass `segments` to
+ * `<VideoPlayer>` / `<ReplayPlayer>`, so teams without the flag get exactly the
+ * plain player they had before spec 28. Verify's Run pane had no player at all
+ * before the spec, so it renders none when the flag is off.
+ *
+ * Two ways to enable:
+ *   - Per-team flag: teams.earlyAdopterMode = true
+ *   - Env override:  INTERACTIVE_PLAYBACK_ENABLED=1 (turns it on for everyone)
+ *
+ * Mirrors `isVerifyPhaseEnabled()` in `@/lib/verify/feature-flag`.
+ */
+
+import type { Team } from "@/lib/db/schema";
+
+export function isInteractivePlaybackEnabled(
+  team?: Pick<Team, "earlyAdopterMode"> | null | undefined,
+): boolean {
+  if (
+    process.env.INTERACTIVE_PLAYBACK_ENABLED === "1" ||
+    process.env.INTERACTIVE_PLAYBACK_ENABLED === "true"
+  ) {
+    return true;
+  }
+  return team?.earlyAdopterMode ?? false;
+}

--- a/src/lib/playback/step-timings.ts
+++ b/src/lib/playback/step-timings.ts
@@ -1,0 +1,63 @@
+import type { CapturedScreenshot, StepTiming } from "@/lib/db/schema";
+
+/**
+ * Resolve per-step video-clock segments for a test result, degrading through
+ * the same ladder the share page's chapter rail uses:
+ *
+ *   1. persisted `test_results.step_timings` (EB runs, spec 28) — exact;
+ *   2. `screenshots[].atMs` anchors — each step spans from its screenshot's
+ *      offset to the next one's (the last extends to the recording end);
+ *   3. even split of the recording duration across the steps.
+ *
+ * Returns [] when there's nothing to place steps with (no timings, no
+ * screenshots, no duration). All values are ms on the video clock.
+ */
+export function resolveStepSegments(input: {
+  stepTimings?: StepTiming[] | null;
+  screenshots?: CapturedScreenshot[] | null;
+  durationMs?: number | null;
+}): StepTiming[] {
+  const { stepTimings, screenshots, durationMs } = input;
+
+  if (stepTimings && stepTimings.length > 0) {
+    return [...stepTimings].sort((a, b) => a.startMs - b.startMs);
+  }
+
+  const shots = screenshots ?? [];
+  const total = durationMs && durationMs > 0 ? durationMs : null;
+
+  const anchored = shots
+    .map((s, i) => ({ shot: s, index: i }))
+    .filter((e) => typeof e.shot.atMs === "number");
+  if (anchored.length > 0) {
+    return anchored.map((e, i) => {
+      const startMs = Math.max(0, e.shot.atMs as number);
+      const next = anchored[i + 1];
+      const endMs = next
+        ? Math.max(startMs, next.shot.atMs as number)
+        : Math.max(startMs, total ?? startMs + 3000);
+      return {
+        stepIndex: e.index,
+        label: e.shot.label ?? `Step ${e.index + 1}`,
+        stepType: "shot",
+        status: "passed" as const,
+        startMs,
+        endMs,
+      };
+    });
+  }
+
+  if (shots.length > 0 && total) {
+    const per = total / shots.length;
+    return shots.map((s, i) => ({
+      stepIndex: i,
+      label: s.label ?? `Step ${i + 1}`,
+      stepType: "shot",
+      status: "passed" as const,
+      startMs: Math.round(i * per),
+      endMs: Math.round((i + 1) * per),
+    }));
+  }
+
+  return [];
+}

--- a/src/lib/playwright/types.ts
+++ b/src/lib/playwright/types.ts
@@ -9,6 +9,8 @@ import type {
   UrlTrajectoryStep,
   WebVitalsSample,
   StorageStateSnapshot,
+  StepTiming,
+  ConsoleEntry,
 } from "@/lib/db/schema";
 
 export interface CapturedScreenshot {
@@ -54,6 +56,9 @@ export interface TestRunResult {
   urlTrajectory?: UrlTrajectoryStep[];
   webVitals?: WebVitalsSample[];
   storageStateSnapshot?: StorageStateSnapshot;
+  // ── Interactive playback (spec 28) ─────────────────────────────────────
+  stepTimings?: StepTiming[];
+  consoleEntries?: ConsoleEntry[];
   // ── API tests (E1) — set for testType==='api' results (headless HTTP) ──
   apiResult?: import("@/lib/db/schema").ApiTestResultData;
 }

--- a/src/lib/share/captions.ts
+++ b/src/lib/share/captions.ts
@@ -8,10 +8,10 @@
  * wrinkle is passing the screenshots as `images` (vision input), which
  * generateWithAI now forwards to the provider.
  *
- * TIMING IS APPROXIMATE. We don't persist a real per-step video timestamp, so
- * each cue is placed by evenly splitting the recording's duration_ms across the
- * steps — the same model the step-strip seek already uses on the share page.
- * Good enough to keep narration tracking the right step; not frame-accurate.
+ * TIMING: cues anchor to each screenshot's recorded offset (`atMs`) when the
+ * run captured it — the same clock the chapter rail seeks with, so narration
+ * stays in lockstep with click-to-seek. Legacy rows without anchors fall back
+ * to evenly splitting the recording's duration_ms across the steps.
  */
 
 import { readFile } from "fs/promises";
@@ -26,6 +26,10 @@ export interface CaptionStepInput {
   /** Storage-relative screenshot path (e.g. `/screenshots/<repo>/<file>.png`). */
   path: string;
   label?: string | null;
+  /** The screenshot's offset into the recording (CapturedScreenshot.atMs).
+   *  When present, cues anchor to it instead of the even split — keeping
+   *  narration in lockstep with the chapter rail's seek targets. */
+  atMs?: number | null;
 }
 
 export interface GenerateVideoCaptionsInput {
@@ -95,15 +99,36 @@ function normalizeFocus(
   return { x: clamp01(x), y: clamp01(y), w: clamp01(w), h: clamp01(h) };
 }
 
-// Even-split timing: step i occupies [i/N, (i+1)/N] of the clip. N is the
-// number of steps we actually narrate, so cues always span the whole timeline.
+// Cue timing ladder: anchor to the screenshot's real recording offset
+// (`atMs`, the same clock the chapter rail seeks with) when the run captured
+// it — the cue runs from this step's anchor to the next anchored step's.
+// Legacy rows without anchors fall back to the old even split (step i
+// occupies [i/N, (i+1)/N] of the clip).
 function timingFor(
   stepIndex: number,
-  totalSteps: number,
+  steps: CaptionStepInput[],
   durationMs: number | null,
 ): { startMs: number; endMs: number } {
+  const totalSteps = steps.length;
   const total =
     durationMs && durationMs > 0 ? durationMs : totalSteps * DEFAULT_STEP_MS;
+
+  const at = steps[stepIndex]?.atMs;
+  if (typeof at === "number" && at >= 0) {
+    let endMs: number | null = null;
+    for (let i = stepIndex + 1; i < totalSteps; i++) {
+      const next = steps[i]?.atMs;
+      if (typeof next === "number" && next > at) {
+        endMs = next;
+        break;
+      }
+    }
+    return {
+      startMs: Math.round(at),
+      endMs: Math.round(endMs ?? Math.max(at + 1000, total)),
+    };
+  }
+
   const per = total / Math.max(1, totalSteps);
   return {
     startMs: Math.round(stepIndex * per),
@@ -193,12 +218,11 @@ Write one caption per step. Return the strict JSON described in the system promp
     if (!byStep.has(c.stepIndex)) byStep.set(c.stepIndex, c);
   }
 
-  const totalSteps = steps.length;
   const out: VideoCaption[] = [];
   for (const l of loaded) {
     const c = byStep.get(l.index);
     if (!c) continue;
-    const { startMs, endMs } = timingFor(l.index, totalSteps, input.durationMs);
+    const { startMs, endMs } = timingFor(l.index, steps, input.durationMs);
     const annotation =
       c.annotation === "arrow" ||
       c.annotation === "underline" ||

--- a/src/lib/share/generate-captions.ts
+++ b/src/lib/share/generate-captions.ts
@@ -73,6 +73,7 @@ export async function resolveCaptionTarget(
     steps: (candidate.screenshots ?? []).map((s) => ({
       path: s.path,
       label: s.label ?? null,
+      atMs: s.atMs ?? null,
     })),
     uxSummary: existing?.uxSummary || null,
   };

--- a/src/lib/share/video-fallback.ts
+++ b/src/lib/share/video-fallback.ts
@@ -12,6 +12,27 @@ const VIDEO_ROOT = path.join(process.cwd(), "storage", "videos");
  * /api/media/videos/... by next.config, already public behind proxy.ts.
  * Returns null on any error (missing dir, no match).
  */
+/**
+ * Exact-file variant of `resolveTestVideoUrl` for a specific result row: the
+ * EB names recordings `<testRunId>-<testId>.webm`, so when a row's
+ * `video_path` is null (historical best-effort save) we can still check
+ * whether that run's file made it to disk. One stat, no directory scan.
+ */
+export async function resolveResultVideoUrl(
+  repositoryId: string | null | undefined,
+  testRunId: string | null | undefined,
+  testId: string | null | undefined,
+): Promise<string | null> {
+  if (!repositoryId || !testRunId || !testId) return null;
+  const name = `${testRunId}-${testId}.webm`;
+  try {
+    await stat(path.join(VIDEO_ROOT, repositoryId, name));
+  } catch {
+    return null;
+  }
+  return `/videos/${repositoryId}/${name}`;
+}
+
 export async function resolveTestVideoUrl(
   repositoryId: string | null | undefined,
   testId: string | null | undefined,

--- a/src/lib/verify/backfill-step-comparisons.ts
+++ b/src/lib/verify/backfill-step-comparisons.ts
@@ -79,6 +79,7 @@ export async function ensureStepComparisonsForBuild(
             urlTrajectory: prevResult.urlTrajectory ?? null,
             webVitals: prevResult.webVitals ?? null,
             extractedVariables: prevResult.extractedVariables ?? null,
+            storageStateSnapshot: prevResult.storageStateSnapshot ?? null,
           }
         : null;
       const currentPayload = {
@@ -88,6 +89,7 @@ export async function ensureStepComparisonsForBuild(
         urlTrajectory: tr.urlTrajectory ?? null,
         webVitals: tr.webVitals ?? null,
         extractedVariables: tr.extractedVariables ?? null,
+        storageStateSnapshot: tr.storageStateSnapshot ?? null,
       };
 
       for (const [stepLabel, groupDiffs] of byStep) {

--- a/src/lib/verify/check-modes.test.ts
+++ b/src/lib/verify/check-modes.test.ts
@@ -28,6 +28,7 @@ describe("check-modes — derivation", () => {
       perf: "log",
       url: "log",
       api: "enforce",
+      storage: "log",
     } satisfies CheckModeMap);
   });
 

--- a/src/lib/verify/check-modes.ts
+++ b/src/lib/verify/check-modes.ts
@@ -26,7 +26,8 @@ export type CheckLayer =
   | "design"
   | "perf"
   | "url"
-  | "api";
+  | "api"
+  | "storage";
 
 export type CheckModeMap = Record<CheckLayer, CheckMode>;
 
@@ -36,6 +37,7 @@ const ALWAYS_CAPTURED: ReadonlySet<CheckLayer> = new Set([
   "visual",
   "url",
   "perf",
+  "storage",
 ]);
 
 const DEFAULTS: CheckModeMap = {
@@ -51,6 +53,10 @@ const DEFAULTS: CheckModeMap = {
   // API request/response assertions (E1). Standalone api-type tests run a
   // headless HTTP request; a failed status/schema/body assertion gates red.
   api: "enforce",
+  // End-of-run storage state diff (cookies + localStorage, State tab).
+  // Sessions rotate and caches churn — log-only by default, and the diff
+  // engine emits 'low' signal so it never gates a verdict either way.
+  storage: "log",
 };
 
 /** Repo / global default to use when nothing is persisted. */
@@ -82,6 +88,7 @@ type LegacySource = Partial<
     | "perfMode"
     | "urlMode"
     | "apiMode"
+    | "storageMode"
   >
 > & {
   textDiffEnabled?: boolean | null;
@@ -164,10 +171,11 @@ export function deriveCheckModes(
     normalizeMode(source.designMode) ??
     (source.enableDesignSystem === true ? "enforce" : DEFAULTS.design);
 
-  // --- perf / url / api ---
+  // --- perf / url / api / storage ---
   out.perf = normalizeMode(source.perfMode) ?? DEFAULTS.perf;
   out.url = normalizeMode(source.urlMode) ?? DEFAULTS.url;
   out.api = normalizeMode(source.apiMode) ?? DEFAULTS.api;
+  out.storage = normalizeMode(source.storageMode) ?? DEFAULTS.storage;
 
   return out;
 }
@@ -190,6 +198,7 @@ export function checkModesToSettingsPatch(modes: Partial<CheckModeMap>): {
   perfMode?: CheckMode;
   urlMode?: CheckMode;
   apiMode?: CheckMode;
+  storageMode?: CheckMode;
   // legacy mirrors
   enableA11y?: boolean;
   enableDesignSystem?: boolean;
@@ -247,6 +256,9 @@ export function checkModesToSettingsPatch(modes: Partial<CheckModeMap>): {
   }
   if (modes.api) {
     patch.apiMode = modes.api;
+  }
+  if (modes.storage) {
+    patch.storageMode = modes.storage;
   }
 
   return patch;
@@ -355,6 +367,7 @@ export function pickTestModeOverrides(
         designMode?: string | null;
         perfMode?: string | null;
         urlMode?: string | null;
+        storageMode?: string | null;
         networkErrorMode?: "fail" | "warn" | "ignore" | null;
         consoleErrorMode?: "fail" | "warn" | "ignore" | null;
       }
@@ -382,6 +395,7 @@ export function pickTestModeOverrides(
     "perf",
     "url",
     "api",
+    "storage",
   ];
   for (const layer of layers) {
     const newKey = `${layer}Mode` as const;
@@ -427,6 +441,7 @@ export function testModeOverridesToOverridesPatch(
   designMode?: CheckMode;
   perfMode?: CheckMode;
   urlMode?: CheckMode;
+  storageMode?: CheckMode;
   networkErrorMode?: "fail" | "warn" | "ignore";
   consoleErrorMode?: "fail" | "warn" | "ignore";
 } {
@@ -439,6 +454,7 @@ export function testModeOverridesToOverridesPatch(
   if (modes.dom) patch.domMode = modes.dom;
   if (modes.perf) patch.perfMode = modes.perf;
   if (modes.url) patch.urlMode = modes.url;
+  if (modes.storage) patch.storageMode = modes.storage;
   if (modes.a11y) patch.a11yMode = modes.a11y;
   if (modes.design) patch.designMode = modes.design;
   if (modes.network) {

--- a/src/server/actions/builds.ts
+++ b/src/server/actions/builds.ts
@@ -1063,6 +1063,7 @@ async function runBuildAsync(
             urlTrajectory: prevResult.urlTrajectory ?? null,
             webVitals: prevResult.webVitals ?? null,
             extractedVariables: prevResult.extractedVariables ?? null,
+            storageStateSnapshot: prevResult.storageStateSnapshot ?? null,
           }
         : null;
       const currentPayload = {
@@ -1072,6 +1073,7 @@ async function runBuildAsync(
         urlTrajectory: result.urlTrajectory ?? null,
         webVitals: result.webVitals ?? null,
         extractedVariables: result.extractedVariables ?? null,
+        storageStateSnapshot: result.storageStateSnapshot ?? null,
       };
 
       for (const [stepLabel, groupDiffs] of byStep) {

--- a/src/server/actions/builds.ts
+++ b/src/server/actions/builds.ts
@@ -858,6 +858,8 @@ async function runBuildAsync(
     urlTrajectory?: import("@/lib/db/schema").UrlTrajectoryStep[];
     webVitals?: import("@/lib/db/schema").WebVitalsSample[];
     storageStateSnapshot?: import("@/lib/db/schema").StorageStateSnapshot;
+    stepTimings?: import("@/lib/db/schema").StepTiming[];
+    consoleEntries?: import("@/lib/db/schema").ConsoleEntry[];
     apiResult?: import("@/lib/db/schema").ApiTestResultData;
   }) => {
     processedCount++;
@@ -896,6 +898,8 @@ async function runBuildAsync(
       urlTrajectory: result.urlTrajectory,
       webVitals: result.webVitals,
       storageStateSnapshot: result.storageStateSnapshot,
+      stepTimings: result.stepTimings,
+      consoleEntries: result.consoleEntries,
     });
 
     // Stamp first build on the test version (idempotent)
@@ -1348,6 +1352,8 @@ async function runBuildAsync(
                 urlTrajectory: result.urlTrajectory,
                 webVitals: result.webVitals,
                 storageStateSnapshot: result.storageStateSnapshot,
+                stepTimings: result.stepTimings,
+                consoleEntries: result.consoleEntries,
                 retryOf: originalResult?.id ?? null,
                 isFlaky: false,
               });

--- a/src/server/actions/runs.ts
+++ b/src/server/actions/runs.ts
@@ -323,6 +323,8 @@ async function runTestsAsync(
         extractedVariables: result.extractedVariables,
         assignedVariables: result.assignedVariables,
         logs: result.logs,
+        stepTimings: result.stepTimings,
+        consoleEntries: result.consoleEntries,
       });
       await updateJobProgress(activeJobId, i + 1, tests.length);
     }

--- a/src/server/actions/tests.ts
+++ b/src/server/actions/tests.ts
@@ -18,6 +18,7 @@ import {
 import type { NewTest, NewFunctionalArea } from "@/lib/db/schema";
 import { getCurrentBranchForRepo } from "@/lib/git-utils";
 import { STORAGE_DIRS } from "@/lib/storage/paths";
+import { resolveResultVideoUrl } from "@/lib/share/video-fallback";
 
 /**
  * Fetch all selector_stats rows for a test so the UI can display per-step
@@ -537,9 +538,28 @@ export async function getTestDetailData(
       return false;
     })();
 
+  // Disk fallback for recordings whose best-effort video_path save failed:
+  // the file is usually on disk under the deterministic
+  // <testRunId>-<testId>.webm name. Only probe the newest rows — the
+  // Recordings card shows recent runs and each probe is a stat call.
+  const resultsWithVideo = await Promise.all(
+    results.map(async (r, i) =>
+      r.videoPath || i >= 10
+        ? r
+        : {
+            ...r,
+            videoPath: await resolveResultVideoUrl(
+              repoId,
+              r.testRunId,
+              r.testId,
+            ),
+          },
+    ),
+  );
+
   return {
     test,
-    results,
+    results: resultsWithVideo,
     repositoryId: repoId,
     screenshotGroups,
     plannedScreenshots,


### PR DESCRIPTION
## Summary

Implements two major features for the Verify review screen and test playback:

1. **Interactive Test Playback (Spec 28)**: Adds step-annotated video timeline with click-to-seek, playback↔evidence sync bus, and speed presets up to 8x. Unifies all evidence (network, perf, steps, storage) onto a single video clock (ms since recording start).

2. **Storage State Evidence Layer (Spec 27)**: New "State" tab in Verify showing cookies and localStorage diffs vs baseline, with per-entry change tracking (added/removed/changed) and end-of-run snapshot browsing.

## Key Changes

### Video Playback & Timeline
- **`src/components/video-player.tsx`**: Extended with `PlayerSegment` interface for per-step markers, segment strip rendering with action icons (navigate/click/fill/assert/wait/etc.), click-to-seek, and speed presets up to 8x
- **`src/components/playback-sync.tsx`** (new): Bidirectional sync bus for playback↔evidence coordination; panes subscribe to time updates and can drive the player via `seekTo()`
- **`src/components/replay-player.tsx`**: Broadcasts playback position as document event (`PLAYBACK_TIME_EVENT`) for server-rendered islands (chapter rail)
- **`src/lib/playback/step-timings.ts`** (new): Resolves per-step video-clock segments from persisted `StepTiming` rows, screenshot anchors, or even split fallback
- **`docs/specs/28-interactive-test-playback.md`** (new): Full spec for step-synced timeline, clock unification, and sync bus architecture

### Storage State Evidence
- **`src/lib/comparison/storage-state-diff.ts`** (new): Diff engine comparing cookies/localStorage by structural key (domain+path+name for cookies, origin+name for localStorage), hashed values to prevent leaking sensitive data
- **`src/app/(app)/verify/[buildId]/focus-view.tsx`**: 
  - Added "State" tab to `COMPARE_TABS`
  - `StatePane` component renders storage diffs and end-of-run snapshots with change badges (ADD/REMOVE/CHANGE)
  - `StepDetailHeader` component shows per-step metadata: action kind, duration, video time range, verdict chip, thumbnail
  - Keyboard shortcuts `[` / `]` to cycle evidence tabs
  - `classifyLayer` and `layerDelta` support storage state classification
- **`docs/specs/27-verify-review-evidence-ux.md`** (new): Full spec for Verify review upgrades including storage state, per-step metadata strip, and evidence sync

### Database & Schema
- **`src/lib/db/schema.ts`**: 
  - Added `atMs` (video-clock offset) to `NetworkRequest` and `UrlTrajectoryStep`
  - Added `storageMode` to `TestPlaywrightOverrides`
  - New `StepTiming` and `ConsoleEntry` types with video-clock timestamps
- **`packages/embedded-browser/src/test-executor.ts`**: 
  - `EmbeddedStepTiming` and `EmbeddedConsoleEntry` interfaces with video-clock support
  - Network requests now include `atMs` field
- **`src/lib/verify/check-modes.ts`**: Added "storage" to `CheckLayer` type and `ALWAYS_CAPTURED` set

### Verify & Comparison
- **`src/lib/comparison/scorer.ts`**: Integrated storage state diff computation into multi-layer verdict scoring
- **`src/lib/verify/backfill-step-comparisons.ts`**: Backfill logic includes storage state diffs
- **`src/app/(app)/verify/[buildId]/board-focus-client.tsx`**: Added `testRunId` to `TestResultLite`
- **`src/components/verify/check-modes-dialog.tsx`**: Added Database icon for storage mode toggle

### Perf Vitals Chart
- **`src

https://claude.ai/code/session_01HFmG39AXtwAxQAFKF69LQB