### PR TITLE
Add Explorer Agent — autonomous exploratory testing

### DIFF
--- a/docs/explorer-agent-plan.md
+++ b/docs/explorer-agent-plan.md
@@ -2,6 +2,19 @@
 
 Adding explorbot-style autonomous exploratory testing ([testomatio/explorbot](https://github.com/testomatio/explorbot)) as a new agent kind alongside the existing QA Agent.
 
+> **Status: implemented (all 4 milestones).** Entry points: `/explorer` page,
+> `src/server/actions/explorer-agent.ts`, `src/lib/explorer/`, MCP tools
+> `lastest_explorer*`. Two deviations from the plan below: the **act phase**
+> drives the browser via a host-side AI-in-the-loop action loop
+> (`src/lib/explorer/tester.ts` — observe DOM → model returns one JSON action →
+> Playwright-over-CDP executes) instead of the MCP bridge, which supports every
+> provider and yields an exact action log; and **keep-as-test** renders code
+> deterministically from that action log (`src/lib/explorer/keep.ts`) instead
+> of calling `agentCreateTest` (no AI or request-auth context needed in the
+> detached pipeline). Run `pnpm db:push` after pulling to create the new
+> tables (`agent_knowledge`, `agent_experience`, `agent_findings`,
+> `explorer_triggers`) and `ai_settings` columns.
+
 ## Context
 
 The QA Agent is a **suite builder**: it discovers routes, drafts a plan (with a human review gate), generates test code, executes it, and heals failures. Explorbot represents a different capability: an **exploratory tester** that autonomously drives a live browser in an iterative loop — research the current page, plan scenarios in rotating styles, execute them adaptively step-by-step, record defects/UX findings, learn from experience, and only *then* optionally keep passing flows as real tests. It finds bugs before any test code exists and accumulates memory across runs.

--- a/docs/explorer-agent-plan.md
+++ b/docs/explorer-agent-plan.md
@@ -1,0 +1,146 @@
+# Explorer Agent — Implementation Plan
+
+Adding explorbot-style autonomous exploratory testing ([testomatio/explorbot](https://github.com/testomatio/explorbot)) as a new agent kind alongside the existing QA Agent.
+
+## Context
+
+The QA Agent is a **suite builder**: it discovers routes, drafts a plan (with a human review gate), generates test code, executes it, and heals failures. Explorbot represents a different capability: an **exploratory tester** that autonomously drives a live browser in an iterative loop — research the current page, plan scenarios in rotating styles, execute them adaptively step-by-step, record defects/UX findings, learn from experience, and only *then* optionally keep passing flows as real tests. It finds bugs before any test code exists and accumulates memory across runs.
+
+**Feasibility verdict: yes — roughly 70% of the required infrastructure already exists.** The platform already has multi-step agent sessions, an embedded-browser (EB) pool with CDP + live streaming, AI-over-Playwright-MCP navigation, deterministic crawlers/page-mappers, an activity/SSE feed, and an AI-driven test generation path. What's genuinely new is the iterative loop orchestration, planning styles, the two memory systems (knowledge + experience), page-state hashing/stuck detection, and clustered findings.
+
+### Explorbot capability → what we have / what's new
+
+| Explorbot capability | Existing analog | Gap |
+|---|---|---|
+| Research (map page: forms, buttons, links) | `browsePageMap()` (`src/lib/playwright/ranger.ts`), `crawlTargetApp()` (`src/lib/qa-agent/crawl.ts`) | None — reuse as-is |
+| AI drives browser step-by-step | `generateWithAI()` + Playwright MCP over EB CDP (`src/lib/ai/index.ts`, `mcp-bridge.ts`) | None — reuse as-is |
+| Live watchable session | EB `streamUrl` + `BrowserViewer` (ranger/QA pattern) | None — reuse as-is |
+| Multi-step agent w/ pause/resume/cancel | `agent_sessions` + `executeQaPipeline` pattern (`src/server/actions/qa-agent.ts`) | Extend for iterative loop |
+| Planning styles (normal/curious/psycho) | — | **New**: style prompt fragments + rotation |
+| Knowledge (human hints per URL pattern) | — | **New**: `agent_knowledge` table + matcher + prompt injection |
+| Experience (learned notes per page state) | — | **New**: `agent_experience` table keyed by state hash |
+| Page state = URL + h1/h2 (loop detection) | — | **New**: `hashState()` + stuck heuristics |
+| Findings clustered by root cause, severity | `bug_reports` (user-scoped, wrong shape) | **New**: `agent_findings` table + AI analyst step |
+| Keep passing flows as tests | `agentCreateTest()` (`src/lib/playwright/generator-agent.ts`) | Wire action log → generator, create quarantined |
+| Autonomous scheduling / MCP control | `qa_agent_triggers`, `qa_tasks`, `packages/mcp-server` | Clone patterns (deferred milestone) |
+
+## Key design decisions
+
+1. **New `AgentSessionKind = "explorer"`**, cloning the QA-agent orchestration skeleton (detached fire-and-forget pipeline, AbortController registry, step-state array, poll route). Ranger (`src/server/actions/ranger-agent.ts`) is the provision→stream→observe→release template.
+2. **Iterative loop as repeated step entries.** `buildExplorerSteps(maxIterations)` emits `[setup, login]`, then per iteration a block of `research → plan → act → analyze` entries (new optional `iteration?: number` on `AgentStepState`), then `[keep, summary]`. The loop is linear in the array, so QA's `pipeline.indexOf(fromStep)` driver, pause/resume via `currentStepId`, and the timeline UI all work unchanged. Early exit (stuck / budget) marks remaining loop steps `skipped`.
+3. **Findings get a new `agent_findings` table**, not `bug_reports`. Bug reports are user-scoped (`reportedById` NOT NULL, no `repositoryId`, extension-shaped `context`); explorer findings need `sessionId`, `pageStateHash`, `rootCauseCluster`, `scenario`, evidence refs, and a `defect | ux` kind. A later "promote to bug report" action bridges the two.
+4. **Knowledge & experience are DB-backed** (explorbot uses filesystem markdown). Required for repo scoping, multi-tenancy, and credential encryption via the existing `crypto-fields` pattern. Markdown body is preserved as a text column; URL matching is a column (`exact | prefix | regex`).
+5. **Keep-as-test uses `agentCreateTest`** (semantic scenario in → MCP-verified selectors → `export async function test(page, baseUrl, screenshotPath, stepLogger)` out), not `event-to-code` (which needs raw recorded DOM events the explorer doesn't produce). Kept tests are created **quarantined** and linked to a functional area.
+6. **Cost control is structural**: hard iteration budget, per-scenario step budget, heuristic stuck-detection first (state-hash repetition) with an optional AI "pilot" second opinion off by default, planner skips already-covered scenarios via a coverage digest, JSON response format everywhere.
+
+## Schema changes (`src/lib/db/schema.ts`)
+
+Per CLAUDE.md: edit schema → update `DEFAULT_*` constants → `pnpm db:push` → update query modules.
+
+### Extend shared unions (highest-touch change — see Risks)
+
+- `AgentSessionKind` (~line 2580): add `"explorer"`.
+- `AgentStepId` (~line 2582): add `explorer_setup | explorer_login | explorer_research | explorer_plan | explorer_act | explorer_analyze | explorer_keep | explorer_summary`.
+- `PwAgentType` (~line 2627): add `"explorer"`; `ActivitySourceType` (~line 3811): add `"explorer_agent"`.
+- `AgentStepState`: add optional `iteration?: number`.
+- `AgentSessionMetadata` (~line 3129): add explorer block — `explorerTargetUrl`, `explorerMaxIterations`, `explorerIteration` (resume cursor), `explorerStyleRotation`, `explorerVisitedStates`/`explorerStateHistory` (hashes), `explorerPageMap`, `explorerCurrentPlan: ExplorerScenario[]`, `explorerActionLogs`, `explorerFindingIds`, `explorerReport`, `explorerKeptTestIds`, `explorerAuth` (reuse `QaAuthState`). Credentials reuse the existing encrypted `quickstartEmail`/`quickstartPassword` fields (already covered by `encrypt/decryptSessionMetadata` in `src/lib/crypto-fields.ts` — no new encrypted metadata field).
+
+New supporting types: `ExplorerStyle = "normal" | "curious" | "psycho"`, `ExplorerScenario` (id, title, style, steps, rationale, skipped/skipReason), `ExplorerActionStep`/`ExplorerActionLog` (per-step intent/action/selector/result, console errors, failed requests, final state hash), `ExplorerReport` (root-cause clusters with severity + finding ids), `ExplorerFindingKind = "defect" | "ux"`, `ExplorerSeverity`.
+
+### New tables
+
+**`agent_knowledge`** — human hints (explorbot `knowledge/`): `repositoryId` (FK cascade), `teamId`, `title`, `urlPattern`, `matchKind: exact|prefix|regex`, `body` (markdown), optional `credEmail`/`credPassword` (**encrypted**), optional `pageAutomation` jsonb (deterministic pre-steps, e.g. dismiss cookie banner), `enabled`, audit columns. Index on `repositoryId`.
+
+**`agent_experience`** — agent-learned notes (explorbot `experience/`): `repositoryId`, `teamId`, `stateHash` (unique per repo), `normalizedUrl`, `headingsDigest`, `notes` jsonb array (`{kind: resolution|failure|observation, text, scenarioStyle?, sessionId?, at}`), `timesVisited`, `lastSessionId`.
+
+**`agent_findings`**: `repositoryId`, `teamId`, `sessionId`, `kind`, `severity`, `title`, `description`, `rootCauseCluster` (set by analyst), `pageStateHash`, `url`, `scenario` jsonb, `evidence` jsonb (screenshot paths, console errors, failed requests, step-comparison ids), `status: open|triaged|dismissed|kept`, `bugReportId` (promotion link). Index on `sessionId`.
+
+### Crypto + settings
+
+- Extend `src/lib/crypto-fields.ts` with `encryptKnowledgeRow`/`decryptKnowledgeRow` for `agent_knowledge.credPassword` (same `ENC_PREFIX` primitives), applied in the knowledge query layer.
+- Extend `DEFAULT_AI_SETTINGS` + `getAISettings` fallback with `explorerMaxIterations: 8`, `explorerStyleRotation: "normal,curious,psycho"`, `explorerModelTier: ""` (empty = default model). Per CLAUDE.md, every new field must be in the default.
+
+## Query modules (`src/lib/db/queries/`, barrel-exported)
+
+- `explorer.ts` — findings CRUD: `createAgentFinding`, `listFindingsBySession`, `updateFindingCluster`, `updateFindingStatus`, `promoteFindingToBugReport`. Session queries in `integrations.ts` are kind-generic and reused unchanged.
+- `agent-knowledge.ts` — CRUD + `matchKnowledgeForUrl(repoId, url)` (enabled rows whose pattern matches, decrypted).
+- `agent-experience.ts` — `getExperience(repoId, stateHash)`, `upsertExperience` (increments `timesVisited`), `appendExperienceNote`, `listExperienceForUrls`.
+
+## New library: `src/lib/explorer/` (mirrors `src/lib/qa-agent/`)
+
+| File | Contents |
+|---|---|
+| `state.ts` (+test) | `normalizeUrl()` (strip query/hash noise, ids → `:id`), `hashState(url, headings)` — sha256 over normalized URL + lowercased h1/h2. The explorbot "state" concept: keys experience rows + drives loop detection. |
+| `url-match.ts` (+test) | `matchUrlPattern(pattern, matchKind, url)` — exact / `*` prefix wildcard / safe regex. |
+| `styles.ts` (+test) | `STYLE_FRAGMENTS: Record<ExplorerStyle, string>` (normal = happy-path CRUD flows; curious = coverage gaps/less-obvious paths; psycho = empty/invalid/extreme inputs then commit) + `nextStyle(rotation, iteration)`. |
+| `research.ts` | `researchPage(cdpUrl, url, viewport)` → wraps `browsePageMap` + screenshot → `{pageMap, stateHash, screenshotPath}`. |
+| `planner.ts` | `planScenarios(config, {pageMap, style, knowledge, experience, existingCoverage})` → `ExplorerScenario[]` via `generateWithAI` (JSON, no MCP). Instructed to skip covered scenarios. |
+| `tester.ts` | `runScenario(config, cdpEndpoint, scenario, {knowledge, signal})` → `ExplorerActionLog`. Applies knowledge `pageAutomation` deterministically, then AI drives the EB via `generateWithAI` + Playwright MCP over CDP (same mechanism as generator/healer agents). Captures per-step results, screenshots, console/network anomalies. |
+| `supervisor.ts` (+test) | `isStuck(stateHistory)` (repeated state hash), per-scenario step budget; optional AI pilot behind a flag. |
+| `analyst.ts` | `clusterFindings(config, findings)` → `ExplorerReport` — one AI call clustering by root cause, assigning severity + defect/ux. |
+| `coverage.ts` | `buildCoverageDigest(repoId)` from existing tests + prior findings + `functional_areas.agentPlan`. |
+
+## Orchestrator: `src/server/actions/explorer-agent.ts`
+
+Clone the QA-agent structure; reuse verbatim: AbortController registry, `emitActivity` (with `sourceType: "explorer_agent"`), step patch helpers, `assertSafeOutboundUrl` SSRF guard, `claimEmbeddedBrowserForAgent`/`releasePoolEB`, one-active-session-per-repo via `getActiveAgentSession(repoId, "explorer")`.
+
+Pipeline driver `executeExplorerPipeline(sessionId, teamId, repoId, fromStep)` — same control structure as `executeQaPipeline` (qa-agent.ts:2313). Per-step runners (`(sessionId, teamId, repoId, signal) => Promise<boolean>`):
+
+- `runExplorerSetup` — SSRF check, AI-provider + EB-pool validation (mirror `runQaSetup`).
+- `runExplorerLogin` — reuse QA login resolution / `QaAuthState` + storage-state injection; writes `explorerAuth`.
+- `runExplorerResearch(i)` — claim EB (persist proxied `streamUrl` + `queuedForBrowser` for the live viewer), `researchPage`, push state hash. **Exit check:** stuck or budget reached → skip remaining loop steps, jump to `explorer_keep`.
+- `runExplorerPlan(i)` — `nextStyle`, gather matched knowledge + experience + coverage digest, `planScenarios`.
+- `runExplorerAct(i)` — hold the same EB from research (release between iterations to limit pool contention); run each scenario via `runScenario`; create `agent_findings` for failures/anomalies.
+- `runExplorerAnalyze(i)` — experience write-back (`upsertExperience` + `appendExperienceNote`), advance `explorerIteration`.
+- `runExplorerKeep` — each passing action log → `agentCreateTest` → quarantined test linked to a functional area; findings for kept scenarios → `kept`.
+- `runExplorerSummary` — `clusterFindings`, persist `explorerReport`, back-fill finding clusters/severity, `session:complete`.
+
+Public actions (mirroring QA-agent exports, all `"use server"` + `requireRepoAccess` + `revalidatePath`): `startExplorerAgent({repositoryId, targetUrl?, maxIterations?, styleRotation?, email?, password?}) → {sessionId}`, `getExplorerSession`, `pauseExplorerAgent` / `resumeExplorerAgent` / `cancelExplorerAgent`, `listExplorerFindings`, `updateFindingStatus`, plus knowledge CRUD (`listExplorerKnowledge` / `upsertExplorerKnowledge` / `deleteExplorerKnowledge`).
+
+## API + UI
+
+- `src/app/api/explorer-agent/[sessionId]/route.ts` — clone QA poll route (404 unless `kind === "explorer"`, strip `quickstartPassword`).
+- `src/app/(app)/explorer/page.tsx` + sidebar entry (Compass icon) next to QA Agent.
+- `src/components/explorer/`: `explorer-client.tsx`, `use-explorer-agent.ts` (polling hook, clone of `use-qa-agent.ts`), `explorer-timeline.tsx` (steps grouped by `iteration`, collapsible loop blocks), `explorer-live-view.tsx` (existing `BrowserViewer` on `metadata.streamUrl`), `explorer-findings-panel.tsx` (cluster/severity grouping, evidence thumbnails, promote-to-bug-report, keep-as-test), `knowledge-editor.tsx` (CRUD: pattern, match kind, markdown, creds, page automation), `experience-viewer.tsx` (read-only).
+
+## MCP tools (`packages/mcp-server/src/server.ts`)
+
+Clone the `lastest_ranger`/`lastest_qa_agent` blocks (wrapped in `withActivityReporting`): `lastest_explorer` (start), `lastest_explorer_status` (poll: iteration, streamUrl, findings summary), `lastest_explorer_findings`, `lastest_explorer_learn` (write a knowledge note — the explorbot `/learn` equivalent).
+
+## Milestones
+
+- **M1 — Core loop + findings (read-only).** Union extensions + metadata + `agent_findings`; `src/lib/explorer/` (state, styles, research, planner, tester, supervisor, coverage + unit tests); orchestrator (setup→login→loop→summary, keep stubbed); poll route; minimal UI (timeline, live view, findings panel); sidebar entry. Planner runs with empty memory.
+- **M2 — Knowledge & experience.** `agent_knowledge` + `agent_experience` tables; crypto-fields extension; `url-match.ts`; planner/tester prompt injection; analyze write-back; knowledge editor + experience viewer UI.
+- **M3 — Keep-as-test + settings.** `runExplorerKeep` via `agentCreateTest` (quarantined, area-linked); findings→bug-report promotion; `DEFAULT_AI_SETTINGS` fields + settings UI (max iterations, style rotation, model tier).
+- **M4 — MCP + scheduling.** `lastest_explorer*` tools; `explorer_triggers` (clone `qa_agent_triggers`) for cron/PR runs; optional `explorer_tasks` direction queue (clone `qa_tasks`).
+
+Recommended first pass: **M1 + M2** — the loop plus the memory system is what makes this explorbot-like rather than a rerun of the QA agent's discover phase.
+
+## Verification
+
+- **Unit (vitest):** `state.test.ts` (normalization, hash stability), `url-match.test.ts` (exact/wildcard/regex incl. malformed regex), `styles.test.ts` (rotation wrap), `supervisor.test.ts` (stuck detection, budgets).
+- **E2E local (per CLAUDE.md):** `docker compose up -d` + `pnpm stack` + `pnpm dev`; start an explorer run against a demo app; watch the live BrowserViewer; confirm iterations advance, findings populate and cluster in the summary, experience `timesVisited` increments on re-run, a `/login`-pattern knowledge note appears in the planner prompt (verify via `aiPromptLogs` through `substep.promptLogId`), and (M3) "keep" yields a quarantined test that runs green.
+- **Controls:** pause mid-loop → `currentStepId` persists → resume continues same iteration; cancel aborts via controller registry.
+
+## Risks & mitigations
+
+- **Shared-union coordination:** `AgentStepId`/`AgentSessionMetadata`/`PwAgentType`/`ActivitySourceType` are global unions consumed by exhaustive switches and label maps across the app. After extending, grep all switches/maps over these types and add explorer arms — this is the highest-touch change and the main merge-conflict surface with concurrent agent work.
+- **EB pool contention:** one EB held per iteration (research + act share it, released between iterations); `queuedForBrowser` surfaces waits in the UI; one active explorer session per repo caps concurrency.
+- **Token cost:** iteration budget × scenario step budget × heuristic-first supervision × coverage-based skipping × JSON outputs; model-tier override lets cheap models drive the loop (explorbot's "cheap workers, smart managers" — smart model only for the analyst/planner if desired).
+- **SSRF:** every entry point (action, MCP tool, future trigger) calls `assertSafeOutboundUrl` before claiming an EB, same as ranger/QA.
+- **Credential leakage:** `credPassword` encrypted at the query layer and stripped from client responses; interpolated creds must never be echoed into `aiPromptLogs`.
+- **Non-termination:** state-hash stuck detection + hard iteration budget + per-scenario step budget guarantee the loop ends.
+
+## Critical files
+
+| File | Role |
+|---|---|
+| `src/lib/db/schema.ts` | Unions, metadata, 3 new tables, defaults |
+| `src/server/actions/qa-agent.ts` | Orchestrator pattern to clone |
+| `src/server/actions/ranger-agent.ts` | Provision→stream→observe→release skeleton |
+| `src/lib/playwright/ranger.ts` | `browsePageMap` for research |
+| `src/lib/qa-agent/crawl.ts` | Login helper + DOM extraction reference |
+| `src/lib/ai/index.ts` / `mcp-bridge.ts` | `generateWithAI` + MCP-over-CDP for act phase |
+| `src/lib/playwright/generator-agent.ts` | `agentCreateTest` for keep-as-test |
+| `src/lib/db/queries/integrations.ts` | Agent-session queries (reused unchanged) |
+| `src/lib/crypto-fields.ts` | Credential encryption to extend |

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -495,6 +495,73 @@ export class LastestClient {
     return this.del(`/api/v1/ranger/${sessionId}`);
   }
 
+  // --- Explorer (autonomous exploratory-testing agent) ---
+
+  async startExplorer(
+    repoId: string,
+    opts?: {
+      url?: string;
+      maxIterations?: number;
+      email?: string;
+      password?: string;
+    },
+  ): Promise<{ sessionId: string }> {
+    return this.post(`/api/v1/repos/${repoId}/explorer`, {
+      url: opts?.url,
+      maxIterations: opts?.maxIterations,
+      email: opts?.email,
+      password: opts?.password,
+    });
+  }
+
+  async getExplorerStatus(sessionId: string): Promise<{
+    id: string;
+    status: "active" | "completed" | "failed" | "cancelled" | "paused";
+    currentStepId: string | null;
+    steps: Array<{
+      id: string;
+      status: string;
+      label: string;
+      iteration?: number;
+      error?: string;
+    }>;
+    metadata: {
+      targetUrl?: string;
+      iteration: number;
+      maxIterations?: number;
+      streamUrl?: string;
+      queuedForBrowser?: boolean;
+      stuck?: boolean;
+      report?: Record<string, unknown> | null;
+      keptTestIds?: string[];
+    };
+    findingsSummary: { total: number; bySeverity: Record<string, number> };
+  }> {
+    return this.get(`/api/v1/explorer/${sessionId}`);
+  }
+
+  async getExplorerFindings(
+    sessionId: string,
+  ): Promise<{ findings: Array<Record<string, unknown>> }> {
+    return this.get(`/api/v1/explorer/${sessionId}/findings`);
+  }
+
+  async addExplorerKnowledge(
+    repoId: string,
+    input: {
+      title?: string;
+      urlPattern: string;
+      matchKind?: "exact" | "prefix" | "regex";
+      body: string;
+    },
+  ): Promise<{ id: string }> {
+    return this.post(`/api/v1/repos/${repoId}/explorer-knowledge`, input);
+  }
+
+  async cancelExplorer(sessionId: string): Promise<{ success: boolean }> {
+    return this.del(`/api/v1/explorer/${sessionId}`);
+  }
+
   // --- QuickStart agent ---
 
   async startQuickstart(

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -2296,6 +2296,150 @@ export function createServer(client: LastestClient): McpServer {
     }),
   );
 
+  // --- lastest_explorer ---
+  server.tool(
+    "lastest_explorer",
+    "Start the Explorer — an autonomous exploratory-testing agent (explorbot-style). It loops research → plan → act → analyze on a live Embedded Browser: maps each page, drafts scenarios in rotating styles (normal/curious/psycho), drives the browser through them adapting as it goes, records defect/UX findings clustered by root cause, learns per-page experience reused on later runs, and keeps passing flows as quarantined tests. WATCHABLE live in the Lastest activity feed. Async: returns a sessionId — poll lastest_explorer_status.",
+    {
+      repositoryId: z.string().describe("Repository ID to explore for"),
+      url: z
+        .string()
+        .optional()
+        .describe("Target app URL (defaults to the repo base URL)"),
+      maxIterations: z
+        .number()
+        .optional()
+        .describe("Loop-iteration budget (default from settings, max 12)"),
+    },
+    withActivityReporting(client, "lastest_explorer", async (params) => {
+      const { sessionId } = await client.startExplorer(
+        params.repositoryId as string,
+        {
+          url: params.url as string | undefined,
+          maxIterations: params.maxIterations as number | undefined,
+        },
+      );
+      const response: ToolResponse = {
+        status: "explorer_started",
+        summary: `Explorer session ${sessionId} started — it is exploring in an Embedded Browser, watchable live in the Lastest activity feed.`,
+        actionRequired: [
+          `Poll lastest_explorer_status with sessionId "${sessionId}" until status is "completed", then read the report and lastest_explorer_findings.`,
+        ],
+        details: { sessionId },
+      };
+      return {
+        content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+      };
+    }),
+  );
+
+  // --- lastest_explorer_status ---
+  server.tool(
+    "lastest_explorer_status",
+    "Poll an explorer session: status, current iteration, live stream URL, findings summary, and — once completed — the root-cause-clustered report plus any kept test ids.",
+    {
+      sessionId: z
+        .string()
+        .describe("Explorer session ID from lastest_explorer"),
+    },
+    withActivityReporting(client, "lastest_explorer_status", async (params) => {
+      const s = await client.getExplorerStatus(params.sessionId as string);
+      const done = s.status === "completed";
+      const response: ToolResponse = {
+        status: s.status,
+        summary: done
+          ? `Explorer complete: ${s.findingsSummary.total} findings across ${s.metadata.iteration} iterations${(s.metadata.keptTestIds?.length ?? 0) > 0 ? `, ${s.metadata.keptTestIds!.length} flows kept as tests` : ""}.`
+          : s.metadata.queuedForBrowser
+            ? "Waiting for an Embedded Browser to become available…"
+            : `Explorer ${s.status} — iteration ${s.metadata.iteration + 1}${s.metadata.maxIterations ? `/${s.metadata.maxIterations}` : ""}, ${s.findingsSummary.total} findings so far.`,
+        actionRequired: done
+          ? [
+              "Read details.metadata.report for the clustered assessment; call lastest_explorer_findings for full finding rows.",
+            ]
+          : s.status === "failed" || s.status === "cancelled"
+            ? ["The run ended early; findings so far are still readable."]
+            : ["Poll again in a few seconds."],
+        details: s as unknown as Record<string, unknown>,
+      };
+      return {
+        content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+      };
+    }),
+  );
+
+  // --- lastest_explorer_findings ---
+  server.tool(
+    "lastest_explorer_findings",
+    "List the full finding rows (defects + UX issues with severity, root-cause cluster, page state, and evidence) recorded by an explorer session.",
+    {
+      sessionId: z
+        .string()
+        .describe("Explorer session ID from lastest_explorer"),
+    },
+    withActivityReporting(
+      client,
+      "lastest_explorer_findings",
+      async (params) => {
+        const { findings } = await client.getExplorerFindings(
+          params.sessionId as string,
+        );
+        const response: ToolResponse = {
+          status: "ok",
+          summary: `${findings.length} finding(s).`,
+          details: { findings },
+        };
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+        };
+      },
+    ),
+  );
+
+  // --- lastest_explorer_learn ---
+  server.tool(
+    "lastest_explorer_learn",
+    "Teach the Explorer about the app: store a knowledge note (markdown hint) matched to pages by URL pattern — quirks, form rules, test data, navigation notes. Matching notes are injected into the explorer's planning and testing prompts on later runs (explorbot's /learn).",
+    {
+      repositoryId: z.string().describe("Repository ID the note belongs to"),
+      urlPattern: z
+        .string()
+        .describe(
+          'URL pattern: "/login" (exact/prefix), "/admin/*" (prefix), a regex, or "*" for all pages',
+        ),
+      matchKind: z
+        .enum(["exact", "prefix", "regex"])
+        .optional()
+        .describe("How to match the pattern (default prefix)"),
+      title: z.string().optional().describe("Short note title"),
+      body: z
+        .string()
+        .describe("The hint itself (markdown) — what the explorer should know"),
+    },
+    withActivityReporting(client, "lastest_explorer_learn", async (params) => {
+      const { id } = await client.addExplorerKnowledge(
+        params.repositoryId as string,
+        {
+          title: params.title as string | undefined,
+          urlPattern: params.urlPattern as string,
+          matchKind: params.matchKind as
+            | "exact"
+            | "prefix"
+            | "regex"
+            | undefined,
+          body: params.body as string,
+        },
+      );
+      const response: ToolResponse = {
+        status: "learned",
+        summary: `Knowledge note ${id} stored for pattern "${params.urlPattern}". The explorer will load it whenever a matching page opens.`,
+        details: { id },
+      };
+      return {
+        content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+      };
+    }),
+  );
+
   // --- lastest_create_test ---
   server.tool(
     "lastest_create_test",

--- a/src/app/(app)/explorer/page.tsx
+++ b/src/app/(app)/explorer/page.tsx
@@ -1,0 +1,133 @@
+import Link from "next/link";
+import { getCurrentSession } from "@/lib/auth";
+import {
+  getSelectedRepository,
+  getLatestAgentSession,
+  getAISettings,
+  listFindingsBySession,
+  listExperienceByRepo,
+  listKnowledgeByRepo,
+} from "@/lib/db/queries";
+import type { AgentSession } from "@/lib/db/schema";
+import { getEnvironmentConfig } from "@/server/actions/environment";
+import { ExplorerClient } from "@/components/explorer/explorer-client";
+import { QaAgentUpgradeGate } from "@/components/qa-agent/qa-agent-upgrade-gate";
+import {
+  hasQaAgentAccess,
+  qaAgentMinPlanName,
+} from "@/lib/billing/feature-access";
+import { planConfig } from "@/lib/billing/plans";
+import { Compass } from "lucide-react";
+
+export const dynamic = "force-dynamic";
+
+export default async function ExplorerPage() {
+  const session = await getCurrentSession();
+  const team = session?.team;
+  const teamId = team?.id;
+  const userId = session?.user?.id;
+
+  // Explorer shares the QA agent's plan tier.
+  if (team && !hasQaAgentAccess(team.plan)) {
+    return (
+      <QaAgentUpgradeGate
+        currentPlanName={planConfig(team.plan).name}
+        requiredPlanName={qaAgentMinPlanName()}
+      />
+    );
+  }
+
+  const selectedRepo = teamId
+    ? await getSelectedRepository(userId, teamId)
+    : null;
+
+  if (!selectedRepo) {
+    return (
+      <div className="flex-1 p-6 overflow-auto">
+        <div className="max-w-4xl mx-auto space-y-6">
+          <header>
+            <h1 className="text-2xl font-semibold flex items-center gap-2">
+              <Compass className="h-6 w-6" />
+              Explorer
+            </h1>
+          </header>
+          <div className="rounded-lg border border-dashed p-10 text-center text-sm text-muted-foreground">
+            Connect and select a repository first — the explorer records its
+            findings and learned experience into a repo.{" "}
+            <Link href="/tests" className="underline">
+              Add a repository
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const activeBranch =
+    selectedRepo.selectedBranch || selectedRepo.defaultBranch || "main";
+
+  const [explorerSession, knowledge, experience, envConfig, aiSettings] =
+    await Promise.all([
+      getLatestAgentSession(selectedRepo.id, "explorer").catch(() => null),
+      listKnowledgeByRepo(selectedRepo.id).catch(() => []),
+      listExperienceByRepo(selectedRepo.id, 50).catch(() => []),
+      getEnvironmentConfig(selectedRepo.id).catch(() => null),
+      getAISettings(selectedRepo.id).catch(() => null),
+    ]);
+
+  const findings = explorerSession
+    ? await listFindingsBySession(explorerSession.id).catch(() => [])
+    : [];
+
+  const defaultUrl =
+    selectedRepo.branchBaseUrls?.[activeBranch] ?? envConfig?.baseUrl ?? "";
+  const aiConfigured = Boolean(
+    aiSettings?.provider && aiSettings.provider !== "none",
+  );
+
+  // Credentials never reach the client.
+  const sanitize = (s: AgentSession): AgentSession => ({
+    ...s,
+    metadata: (({ quickstartPassword: _pw, ...rest }) => rest)(s.metadata),
+  });
+  const initialSession = explorerSession
+    ? { ...sanitize(explorerSession), findings }
+    : null;
+  const sanitizedKnowledge = knowledge.map(({ credPassword, ...rest }) => ({
+    id: rest.id,
+    title: rest.title,
+    urlPattern: rest.urlPattern,
+    matchKind: rest.matchKind,
+    body: rest.body,
+    credEmail: rest.credEmail,
+    hasCredentials: Boolean(credPassword),
+    enabled: rest.enabled,
+  }));
+
+  return (
+    <div className="flex-1 p-6 overflow-auto">
+      <div className="max-w-5xl mx-auto space-y-6">
+        <header className="space-y-1">
+          <h1 className="text-2xl font-semibold flex items-center gap-2">
+            <Compass className="h-6 w-6" />
+            Explorer
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            An autonomous exploratory tester — it researches each page, plans
+            scenarios in rotating styles, drives a live browser, records defects
+            and UX findings, learns from every run, and keeps passing flows as
+            tests.
+          </p>
+        </header>
+        <ExplorerClient
+          repositoryId={selectedRepo.id}
+          defaultUrl={defaultUrl}
+          aiConfigured={aiConfigured}
+          initialSession={initialSession}
+          initialKnowledge={sanitizedKnowledge}
+          initialExperience={experience}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/explorer-agent/[sessionId]/route.ts
+++ b/src/app/api/explorer-agent/[sessionId]/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAgentSession, listFindingsBySession } from "@/lib/db/queries";
+import { getCurrentSession } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> },
+) {
+  const auth = await getCurrentSession();
+  if (!auth?.team) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { sessionId } = await params;
+  const session = await getAgentSession(sessionId);
+
+  if (!session || session.kind !== "explorer") {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  if (session.teamId && session.teamId !== auth.team.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const findings = await listFindingsBySession(sessionId).catch(() => []);
+
+  // Credentials never leave the server — strip before returning.
+  const { quickstartPassword: _pw, ...metadata } = session.metadata;
+  return NextResponse.json(
+    { ...session, metadata, findings },
+    {
+      headers: {
+        "Cache-Control": "no-store, no-cache, must-revalidate",
+      },
+    },
+  );
+}

--- a/src/app/api/v1/[...slug]/route.ts
+++ b/src/app/api/v1/[...slug]/route.ts
@@ -1299,6 +1299,61 @@ export async function GET(
       });
     }
 
+    // Explorer session: GET /api/v1/explorer/:sessionId
+    // GET /api/v1/explorer/:sessionId/findings returns the full finding rows.
+    if (resource === "explorer" && id) {
+      const sessionRow = await queries.getAgentSession(id);
+      if (!sessionRow || sessionRow.kind !== "explorer") {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+      }
+      if (sessionRow.teamId && sessionRow.teamId !== session.team?.id) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+      }
+      if (subResource === "findings") {
+        const findings = await queries.listFindingsBySession(id);
+        return NextResponse.json({ findings });
+      }
+      const findings = await queries.listFindingsBySession(id).catch(() => []);
+      return NextResponse.json({
+        id: sessionRow.id,
+        kind: sessionRow.kind,
+        repositoryId: sessionRow.repositoryId,
+        status: sessionRow.status,
+        currentStepId: sessionRow.currentStepId,
+        steps: sessionRow.steps.map((s) => ({
+          id: s.id,
+          status: s.status,
+          label: s.label,
+          iteration: s.iteration,
+          startedAt: s.startedAt,
+          completedAt: s.completedAt,
+          error: s.error,
+          result: s.result,
+        })),
+        metadata: {
+          targetUrl: sessionRow.metadata.explorerTargetUrl,
+          iteration: sessionRow.metadata.explorerIteration ?? 0,
+          maxIterations: sessionRow.metadata.explorerMaxIterations,
+          // Live EB screencast — host-routable, secret-free; watch it explore.
+          streamUrl: sessionRow.metadata.streamUrl,
+          queuedForBrowser: sessionRow.metadata.queuedForBrowser,
+          stuck: sessionRow.metadata.explorerStuck ?? false,
+          report: sessionRow.metadata.explorerReport ?? null,
+          keptTestIds: sessionRow.metadata.explorerKeptTestIds ?? [],
+        },
+        findingsSummary: {
+          total: findings.length,
+          bySeverity: findings.reduce<Record<string, number>>((acc, f) => {
+            acc[f.severity] = (acc[f.severity] ?? 0) + 1;
+            return acc;
+          }, {}),
+        },
+        createdAt: sessionRow.createdAt,
+        updatedAt: sessionRow.updatedAt,
+        completedAt: sessionRow.completedAt,
+      });
+    }
+
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   } catch (error) {
     const mapped = mapAuthError(error);
@@ -2475,6 +2530,97 @@ export async function POST(
       }
     }
 
+    // Explorer — autonomous exploratory testing: POST /api/v1/repos/:id/explorer
+    // Body: { url?: string, maxIterations?: number, email?, password? }
+    // Returns { sessionId }; poll GET /api/v1/explorer/:sessionId.
+    if (resource === "repos" && id && subResource === "explorer") {
+      if (!(await verifyRepoOwnership(id, session))) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+      }
+      const body = (await request.json().catch(() => ({}))) as {
+        url?: string;
+        maxIterations?: number;
+        email?: string;
+        password?: string;
+      };
+      try {
+        let targetUrl = typeof body.url === "string" ? body.url : "";
+        if (!targetUrl) {
+          const repo = await queries.getRepository(id);
+          const branchBaseUrls = (repo?.branchBaseUrls ?? {}) as Record<
+            string,
+            string
+          >;
+          targetUrl =
+            (repo?.defaultBranch
+              ? branchBaseUrls[repo.defaultBranch]
+              : undefined) ??
+            branchBaseUrls.main ??
+            Object.values(branchBaseUrls)[0] ??
+            "";
+        }
+        if (!targetUrl) {
+          return NextResponse.json(
+            { error: "No url provided and the repo has no base URL set" },
+            { status: 400 },
+          );
+        }
+        const { startExplorerAgent } =
+          await import("@/server/actions/explorer-agent");
+        const result = await startExplorerAgent({
+          repositoryId: id,
+          targetUrl,
+          maxIterations: body.maxIterations,
+          email: body.email,
+          password: body.password,
+        });
+        return NextResponse.json(result, { status: 201 });
+      } catch (err) {
+        return NextResponse.json(
+          { error: err instanceof Error ? err.message : "Explorer failed" },
+          { status: 400 },
+        );
+      }
+    }
+
+    // Explorer knowledge (the MCP "learn" tool):
+    // POST /api/v1/repos/:id/explorer-knowledge
+    // Body: { title?, urlPattern, matchKind?, body }
+    if (resource === "repos" && id && subResource === "explorer-knowledge") {
+      if (!(await verifyRepoOwnership(id, session))) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+      }
+      const body = (await request.json().catch(() => ({}))) as {
+        title?: string;
+        urlPattern?: string;
+        matchKind?: "exact" | "prefix" | "regex";
+        body?: string;
+      };
+      if (!body.urlPattern || !body.body) {
+        return NextResponse.json(
+          { error: "urlPattern and body are required" },
+          { status: 400 },
+        );
+      }
+      try {
+        const { upsertExplorerKnowledge } =
+          await import("@/server/actions/explorer-agent");
+        const result = await upsertExplorerKnowledge({
+          repositoryId: id,
+          title: body.title || `Note for ${body.urlPattern}`,
+          urlPattern: body.urlPattern,
+          matchKind: body.matchKind ?? "prefix",
+          body: body.body,
+        });
+        return NextResponse.json(result, { status: 201 });
+      } catch (err) {
+        return NextResponse.json(
+          { error: err instanceof Error ? err.message : "Learn failed" },
+          { status: 400 },
+        );
+      }
+    }
+
     // Import tests + functional areas: POST /api/v1/repos/:id/import
     if (resource === "repos" && id && subResource === "import") {
       if (!(await verifyRepoOwnership(id, session))) {
@@ -3222,6 +3368,21 @@ export async function DELETE(
       }
       const { cancelRanger } = await import("@/server/actions/ranger-agent");
       const result = await cancelRanger(id);
+      return NextResponse.json(result);
+    }
+
+    // Cancel Explorer session: DELETE /api/v1/explorer/:sessionId
+    if (resource === "explorer" && id) {
+      const sessionRow = await queries.getAgentSession(id);
+      if (!sessionRow || sessionRow.kind !== "explorer") {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+      }
+      if (sessionRow.teamId && sessionRow.teamId !== session.team?.id) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+      }
+      const { cancelExplorerAgent } =
+        await import("@/server/actions/explorer-agent");
+      const result = await cancelExplorerAgent(id);
       return NextResponse.json(result);
     }
 

--- a/src/components/explorer/experience-viewer.tsx
+++ b/src/components/explorer/experience-viewer.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { AgentExperience } from "@/lib/db/schema";
+import { Brain } from "lucide-react";
+
+/** Read-only view of what the explorer has learned per page state. */
+export function ExperienceViewer({ rows }: { rows: AgentExperience[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Brain className="h-4 w-4" />
+          Experience
+          <span className="text-xs font-normal text-muted-foreground">
+            what the explorer learned by doing — reused on every run
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {rows.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Nothing learned yet. After a run, per-page notes (what worked, what
+            failed) accumulate here and make the next run smarter.
+          </p>
+        ) : (
+          rows.map((row) => (
+            <div key={row.id} className="rounded-md border p-3 space-y-1.5">
+              <div className="flex items-center gap-2 min-w-0">
+                <span className="text-sm font-medium truncate">
+                  {row.normalizedUrl}
+                </span>
+                <Badge variant="outline" className="text-[10px]">
+                  visited {row.timesVisited}×
+                </Badge>
+              </div>
+              {row.headingsDigest && (
+                <p className="text-[11px] text-muted-foreground/70 truncate">
+                  {row.headingsDigest}
+                </p>
+              )}
+              {row.notes.length > 0 && (
+                <ul className="space-y-0.5">
+                  {row.notes.slice(-6).map((note, i) => (
+                    <li key={i} className="text-xs flex items-start gap-1.5">
+                      <Badge
+                        variant="outline"
+                        className="text-[9px] shrink-0 mt-0.5"
+                      >
+                        {note.kind}
+                      </Badge>
+                      <span className="text-muted-foreground break-words">
+                        {note.text}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/explorer/explorer-client.tsx
+++ b/src/components/explorer/explorer-client.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Progress } from "@/components/ui/progress";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { BrowserViewer } from "@/components/embedded-browser/browser-viewer-client";
+import { ExplorerTimeline } from "./explorer-timeline";
+import { ExplorerFindingsPanel } from "./explorer-findings-panel";
+import { KnowledgeEditor, type KnowledgeListItem } from "./knowledge-editor";
+import { ExperienceViewer } from "./experience-viewer";
+import {
+  useExplorerAgent,
+  type ExplorerSessionWithFindings,
+} from "./use-explorer-agent";
+import type { AgentExperience } from "@/lib/db/schema";
+import {
+  Compass,
+  Loader2,
+  MonitorPlay,
+  Pause,
+  Play,
+  Square,
+  TestTubes,
+} from "lucide-react";
+
+export function ExplorerClient({
+  repositoryId,
+  defaultUrl,
+  aiConfigured,
+  initialSession,
+  initialKnowledge,
+  initialExperience,
+}: {
+  repositoryId: string;
+  defaultUrl: string;
+  aiConfigured: boolean;
+  initialSession: ExplorerSessionWithFindings | null;
+  initialKnowledge: KnowledgeListItem[];
+  initialExperience: AgentExperience[];
+}) {
+  const {
+    session,
+    loading,
+    error,
+    isRunning,
+    isPaused,
+    isTerminal,
+    progress,
+    start,
+    pause,
+    resume,
+    cancel,
+    dismiss,
+  } = useExplorerAgent(repositoryId, initialSession);
+
+  const [targetUrl, setTargetUrl] = useState(defaultUrl);
+  const [maxIterations, setMaxIterations] = useState(4);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const meta = session?.metadata;
+  const streamUrl = typeof meta?.streamUrl === "string" ? meta.streamUrl : "";
+  const queuedForBrowser = Boolean(meta?.queuedForBrowser);
+  const findings = session?.findings ?? [];
+  const report = meta?.explorerReport;
+  const keptCount = meta?.explorerKeptTestIds?.length ?? 0;
+
+  const showSetup = !session;
+
+  return (
+    <Tabs defaultValue="run" className="space-y-4">
+      <TabsList>
+        <TabsTrigger value="run">Explore</TabsTrigger>
+        <TabsTrigger value="knowledge">Knowledge</TabsTrigger>
+        <TabsTrigger value="experience">Experience</TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="run" className="space-y-4">
+        {showSetup && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Compass className="h-4 w-4" />
+                Start exploring
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {!aiConfigured && (
+                <p className="text-sm text-amber-600">
+                  No AI provider configured — set one under Settings → AI first.
+                </p>
+              )}
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                <div className="space-y-1 sm:col-span-2">
+                  <Label htmlFor="x-url">Target URL</Label>
+                  <Input
+                    id="x-url"
+                    value={targetUrl}
+                    placeholder="https://staging.your-app.com"
+                    onChange={(e) => setTargetUrl(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="x-iterations">Iterations</Label>
+                  <Input
+                    id="x-iterations"
+                    type="number"
+                    min={1}
+                    max={12}
+                    value={maxIterations}
+                    onChange={(e) =>
+                      setMaxIterations(
+                        Math.max(1, Math.min(12, Number(e.target.value) || 1)),
+                      )
+                    }
+                  />
+                </div>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div className="space-y-1">
+                  <Label htmlFor="x-email">Login email (optional)</Label>
+                  <Input
+                    id="x-email"
+                    value={email}
+                    autoComplete="off"
+                    onChange={(e) => setEmail(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="x-password">Password (optional)</Label>
+                  <Input
+                    id="x-password"
+                    type="password"
+                    value={password}
+                    autoComplete="new-password"
+                    onChange={(e) => setPassword(e.target.value)}
+                  />
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                The explorer loops research → plan → act → analyze, rotating
+                planning styles (normal → curious → psycho), records findings,
+                learns from every page, and keeps passing flows as quarantined
+                tests.
+              </p>
+              {error && <p className="text-sm text-red-600">{error}</p>}
+              <Button
+                onClick={() =>
+                  start({
+                    targetUrl,
+                    maxIterations,
+                    ...(email && password ? { email, password } : {}),
+                  })
+                }
+                disabled={loading || !targetUrl || !aiConfigured}
+              >
+                {loading ? (
+                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                ) : (
+                  <Play className="h-4 w-4 mr-2" />
+                )}
+                Start exploration
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
+        {session && (
+          <>
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center justify-between text-base">
+                  <span className="flex items-center gap-2">
+                    <Compass className="h-4 w-4" />
+                    {meta?.explorerTargetUrl}
+                    <Badge
+                      variant={
+                        session.status === "completed"
+                          ? "default"
+                          : session.status === "failed"
+                            ? "destructive"
+                            : "outline"
+                      }
+                    >
+                      {session.status}
+                    </Badge>
+                    {keptCount > 0 && (
+                      <Badge variant="outline" className="gap-1">
+                        <TestTubes className="h-3 w-3" />
+                        {keptCount} kept
+                      </Badge>
+                    )}
+                  </span>
+                  <span className="flex items-center gap-1">
+                    {isRunning && (
+                      <Button variant="ghost" size="sm" onClick={pause}>
+                        <Pause className="h-3.5 w-3.5 mr-1" />
+                        Pause
+                      </Button>
+                    )}
+                    {isPaused && (
+                      <Button variant="ghost" size="sm" onClick={resume}>
+                        <Play className="h-3.5 w-3.5 mr-1" />
+                        Resume
+                      </Button>
+                    )}
+                    {(isRunning || isPaused) && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-red-600"
+                        onClick={cancel}
+                      >
+                        <Square className="h-3.5 w-3.5 mr-1" />
+                        Stop
+                      </Button>
+                    )}
+                    {isTerminal && (
+                      <Button variant="outline" size="sm" onClick={dismiss}>
+                        New run
+                      </Button>
+                    )}
+                  </span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <Progress value={progress} />
+                {error && <p className="text-sm text-red-600">{error}</p>}
+                <ExplorerTimeline steps={session.steps} />
+              </CardContent>
+            </Card>
+
+            {(isRunning || isPaused) && (streamUrl || queuedForBrowser) && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-base">
+                    <MonitorPlay className="h-4 w-4" />
+                    Live browser
+                    <span className="text-xs font-normal text-muted-foreground">
+                      {queuedForBrowser
+                        ? "waiting for a browser from the pool…"
+                        : "watching the explorer work"}
+                    </span>
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {streamUrl ? (
+                    <BrowserViewer
+                      streamUrl={streamUrl}
+                      interactive={false}
+                      hideToolbar
+                      className="rounded-md overflow-hidden border"
+                    />
+                  ) : (
+                    <div className="flex items-center justify-center h-40 text-sm text-muted-foreground">
+                      <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                      Waiting for an embedded browser…
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            )}
+
+            <ExplorerFindingsPanel findings={findings} report={report} />
+          </>
+        )}
+      </TabsContent>
+
+      <TabsContent value="knowledge">
+        <KnowledgeEditor
+          repositoryId={repositoryId}
+          initialNotes={initialKnowledge}
+        />
+      </TabsContent>
+
+      <TabsContent value="experience">
+        <ExperienceViewer rows={initialExperience} />
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/src/components/explorer/explorer-findings-panel.tsx
+++ b/src/components/explorer/explorer-findings-panel.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type {
+  AgentFinding,
+  ExplorerReport,
+  ExplorerSeverity,
+} from "@/lib/db/schema";
+import { setFindingStatus } from "@/server/actions/explorer-agent";
+import { Bug, Sparkles } from "lucide-react";
+import { toast } from "sonner";
+
+const SEVERITY_STYLES: Record<ExplorerSeverity, string> = {
+  critical: "bg-red-600 text-white",
+  high: "bg-red-500/15 text-red-600 border-red-500/30",
+  medium: "bg-amber-500/15 text-amber-600 border-amber-500/30",
+  low: "bg-blue-500/15 text-blue-600 border-blue-500/30",
+  info: "bg-muted text-muted-foreground",
+};
+
+const SEVERITY_ORDER: ExplorerSeverity[] = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "info",
+];
+
+function FindingRow({
+  finding,
+  onStatusChange,
+}: {
+  finding: AgentFinding;
+  onStatusChange: (id: string, status: "dismissed" | "triaged") => void;
+}) {
+  return (
+    <div className="rounded-md border p-3 space-y-1.5">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <Badge className={SEVERITY_STYLES[finding.severity]}>
+            {finding.severity}
+          </Badge>
+          <Badge variant="outline" className="text-[10px]">
+            {finding.kind}
+          </Badge>
+          <span className="text-sm font-medium truncate">{finding.title}</span>
+        </div>
+        <div className="flex items-center gap-1 shrink-0">
+          {finding.status === "open" ? (
+            <>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 text-xs"
+                onClick={() => onStatusChange(finding.id, "triaged")}
+              >
+                Triage
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 text-xs text-muted-foreground"
+                onClick={() => onStatusChange(finding.id, "dismissed")}
+              >
+                Dismiss
+              </Button>
+            </>
+          ) : (
+            <Badge variant="outline" className="text-[10px]">
+              {finding.status}
+            </Badge>
+          )}
+        </div>
+      </div>
+      <p className="text-xs text-muted-foreground whitespace-pre-line break-words">
+        {finding.description}
+      </p>
+      {finding.url && (
+        <p className="text-[11px] text-muted-foreground/70 truncate">
+          {finding.url}
+        </p>
+      )}
+      {(finding.evidence?.consoleErrors?.length ?? 0) > 0 && (
+        <details className="text-xs">
+          <summary className="cursor-pointer text-muted-foreground">
+            Console errors ({finding.evidence!.consoleErrors!.length})
+          </summary>
+          <ul className="mt-1 space-y-0.5 font-mono text-[11px] text-red-600/80">
+            {finding.evidence!.consoleErrors!.slice(0, 8).map((e, i) => (
+              <li key={i} className="truncate">
+                {e}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  );
+}
+
+export function ExplorerFindingsPanel({
+  findings,
+  report,
+}: {
+  findings: AgentFinding[];
+  report?: ExplorerReport;
+}) {
+  const [hidden, setHidden] = useState<Set<string>>(new Set());
+  const visible = useMemo(
+    () => findings.filter((f) => !hidden.has(f.id)),
+    [findings, hidden],
+  );
+
+  const handleStatus = async (id: string, status: "dismissed" | "triaged") => {
+    try {
+      await setFindingStatus(id, status);
+      if (status === "dismissed") {
+        setHidden((prev) => new Set(prev).add(id));
+      }
+      toast.success(
+        status === "dismissed" ? "Finding dismissed" : "Marked triaged",
+      );
+    } catch {
+      toast.error("Could not update the finding");
+    }
+  };
+
+  if (findings.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Bug className="h-4 w-4" />
+            Findings
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          No findings yet — defects and UX issues the explorer observes will
+          appear here as it works.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const byId = new Map(visible.map((f) => [f.id, f]));
+  const clustered = new Set(
+    (report?.clusters ?? []).flatMap((c) => c.findingIds),
+  );
+  const unclustered = visible.filter((f) => !clustered.has(f.id));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Bug className="h-4 w-4" />
+          Findings
+          <span className="text-xs font-normal text-muted-foreground">
+            {visible.length} total
+            {report ? ` in ${report.clusters.length} root-cause clusters` : ""}
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {report?.assessment && (
+          <div className="rounded-md bg-muted/50 p-3 text-sm flex gap-2">
+            <Sparkles className="h-4 w-4 shrink-0 mt-0.5 text-muted-foreground" />
+            <p>{report.assessment}</p>
+          </div>
+        )}
+        {report
+          ? [...report.clusters]
+              .sort(
+                (a, b) =>
+                  SEVERITY_ORDER.indexOf(a.severity) -
+                  SEVERITY_ORDER.indexOf(b.severity),
+              )
+              .map((cluster, i) => {
+                const rows = cluster.findingIds
+                  .map((id) => byId.get(id))
+                  .filter((f): f is AgentFinding => Boolean(f));
+                if (rows.length === 0) return null;
+                return (
+                  <div key={i} className="space-y-2">
+                    <div className="flex items-center gap-2">
+                      <Badge className={SEVERITY_STYLES[cluster.severity]}>
+                        {cluster.severity}
+                      </Badge>
+                      <span className="text-sm font-semibold">
+                        {cluster.rootCause}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        {rows.length} finding{rows.length === 1 ? "" : "s"}
+                      </span>
+                    </div>
+                    {cluster.summary && (
+                      <p className="text-xs text-muted-foreground">
+                        {cluster.summary}
+                      </p>
+                    )}
+                    <div className="space-y-2">
+                      {rows.map((f) => (
+                        <FindingRow
+                          key={f.id}
+                          finding={f}
+                          onStatusChange={handleStatus}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                );
+              })
+          : null}
+        {(report ? unclustered : visible).length > 0 && (
+          <div className="space-y-2">
+            {report && (
+              <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Not yet clustered
+              </span>
+            )}
+            {(report ? unclustered : visible).map((f) => (
+              <FindingRow
+                key={f.id}
+                finding={f}
+                onStatusChange={handleStatus}
+              />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/explorer/explorer-timeline.tsx
+++ b/src/components/explorer/explorer-timeline.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import type { AgentStepState } from "@/lib/db/schema";
+import {
+  CheckCircle2,
+  Circle,
+  CircleDashed,
+  Loader2,
+  XCircle,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Explorer timeline: the linear setup/login prefix and keep/summary suffix
+ * render as plain steps; the repeated research/plan/act/analyze entries are
+ * grouped into one block per loop iteration.
+ */
+
+function StepIcon({ status }: { status: AgentStepState["status"] }) {
+  switch (status) {
+    case "completed":
+      return <CheckCircle2 className="h-4 w-4 text-green-600" />;
+    case "active":
+      return <Loader2 className="h-4 w-4 animate-spin text-blue-600" />;
+    case "failed":
+      return <XCircle className="h-4 w-4 text-red-600" />;
+    case "skipped":
+      return <CircleDashed className="h-4 w-4 text-muted-foreground" />;
+    default:
+      return <Circle className="h-4 w-4 text-muted-foreground/50" />;
+  }
+}
+
+function StepRow({ step }: { step: AgentStepState }) {
+  return (
+    <div className="space-y-1">
+      <div className="flex items-start gap-2">
+        <div className="mt-0.5">
+          <StepIcon status={step.status} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span
+              className={cn(
+                "text-sm font-medium",
+                step.status === "pending" && "text-muted-foreground",
+                step.status === "skipped" &&
+                  "text-muted-foreground line-through",
+              )}
+            >
+              {step.label}
+            </span>
+            {step.status === "failed" && (
+              <Badge variant="destructive" className="text-[10px]">
+                failed
+              </Badge>
+            )}
+          </div>
+          {step.status === "pending" ? null : step.error ? (
+            <p className="text-xs text-red-600 break-words">{step.error}</p>
+          ) : step.result?.reason ? (
+            <p className="text-xs text-muted-foreground">
+              {String(step.result.reason)}
+            </p>
+          ) : null}
+          {(step.substeps?.length ?? 0) > 0 && (
+            <ul className="mt-1 space-y-0.5">
+              {step.substeps!.map((sub, i) => (
+                <li
+                  key={i}
+                  className="flex items-center gap-1.5 text-xs text-muted-foreground"
+                >
+                  {sub.status === "running" ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : sub.status === "done" ? (
+                    <CheckCircle2 className="h-3 w-3 text-green-600" />
+                  ) : sub.status === "error" ? (
+                    <XCircle className="h-3 w-3 text-red-500" />
+                  ) : (
+                    <Circle className="h-3 w-3 opacity-40" />
+                  )}
+                  <span className="truncate">{sub.label}</span>
+                  {sub.detail && (
+                    <span className="truncate opacity-70">— {sub.detail}</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ExplorerTimeline({ steps }: { steps: AgentStepState[] }) {
+  const prefix = steps.filter((s) => s.iteration === undefined);
+  const loops = new Map<number, AgentStepState[]>();
+  for (const step of steps) {
+    if (step.iteration === undefined) continue;
+    const group = loops.get(step.iteration) ?? [];
+    group.push(step);
+    loops.set(step.iteration, group);
+  }
+
+  const linearHead = prefix.filter((s) =>
+    ["explorer_setup", "explorer_login"].includes(s.id),
+  );
+  const linearTail = prefix.filter((s) =>
+    ["explorer_keep", "explorer_summary"].includes(s.id),
+  );
+
+  return (
+    <div className="space-y-3">
+      {linearHead.map((step, i) => (
+        <StepRow key={`head-${i}`} step={step} />
+      ))}
+      {Array.from(loops.entries()).map(([iteration, group]) => {
+        const allPending = group.every((s) => s.status === "pending");
+        const allSkipped = group.every((s) => s.status === "skipped");
+        return (
+          <div
+            key={`loop-${iteration}`}
+            className={cn(
+              "rounded-md border p-3 space-y-2",
+              allPending && "opacity-50",
+              allSkipped && "opacity-40",
+            )}
+          >
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Iteration {iteration + 1}
+              </span>
+              {allSkipped && (
+                <Badge variant="outline" className="text-[10px]">
+                  skipped
+                </Badge>
+              )}
+            </div>
+            <div className="space-y-2">
+              {group.map((step, i) => (
+                <StepRow key={`it${iteration}-${i}`} step={step} />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+      {linearTail.map((step, i) => (
+        <StepRow key={`tail-${i}`} step={step} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/explorer/knowledge-editor.tsx
+++ b/src/components/explorer/knowledge-editor.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  upsertExplorerKnowledge,
+  deleteExplorerKnowledge,
+} from "@/server/actions/explorer-agent";
+import type { KnowledgeMatchKind } from "@/lib/db/schema";
+import { BookOpen, Plus, Trash2, KeyRound } from "lucide-react";
+import { toast } from "sonner";
+
+/** Knowledge rows as shipped to the client: password replaced by a flag. */
+export interface KnowledgeListItem {
+  id: string;
+  title: string;
+  urlPattern: string;
+  matchKind: KnowledgeMatchKind;
+  body: string;
+  credEmail: string | null;
+  hasCredentials: boolean;
+  enabled: boolean;
+}
+
+interface DraftNote {
+  id?: string;
+  title: string;
+  urlPattern: string;
+  matchKind: KnowledgeMatchKind;
+  body: string;
+  credEmail: string;
+  credPassword: string;
+}
+
+const EMPTY_DRAFT: DraftNote = {
+  title: "",
+  urlPattern: "/",
+  matchKind: "prefix",
+  body: "",
+  credEmail: "",
+  credPassword: "",
+};
+
+export function KnowledgeEditor({
+  repositoryId,
+  initialNotes,
+}: {
+  repositoryId: string;
+  initialNotes: KnowledgeListItem[];
+}) {
+  const [notes, setNotes] = useState(initialNotes);
+  const [draft, setDraft] = useState<DraftNote | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const save = async () => {
+    if (!draft) return;
+    setSaving(true);
+    try {
+      const { id } = await upsertExplorerKnowledge({
+        id: draft.id,
+        repositoryId,
+        title: draft.title,
+        urlPattern: draft.urlPattern,
+        matchKind: draft.matchKind,
+        body: draft.body,
+        credEmail: draft.credEmail || undefined,
+        // Only send a password when the user typed one — keeps existing.
+        ...(draft.credPassword ? { credPassword: draft.credPassword } : {}),
+      });
+      const updated: KnowledgeListItem = {
+        id,
+        title: draft.title,
+        urlPattern: draft.urlPattern,
+        matchKind: draft.matchKind,
+        body: draft.body,
+        credEmail: draft.credEmail || null,
+        hasCredentials: Boolean(
+          draft.credPassword || notes.find((n) => n.id === id)?.hasCredentials,
+        ),
+        enabled: true,
+      };
+      setNotes((prev) => {
+        const idx = prev.findIndex((n) => n.id === id);
+        if (idx === -1) return [updated, ...prev];
+        const next = [...prev];
+        next[idx] = updated;
+        return next;
+      });
+      setDraft(null);
+      toast.success("Knowledge note saved");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Could not save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async (id: string) => {
+    try {
+      await deleteExplorerKnowledge(id, repositoryId);
+      setNotes((prev) => prev.filter((n) => n.id !== id));
+      toast.success("Knowledge note deleted");
+    } catch {
+      toast.error("Could not delete the note");
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between text-base">
+          <span className="flex items-center gap-2">
+            <BookOpen className="h-4 w-4" />
+            Knowledge
+            <span className="text-xs font-normal text-muted-foreground">
+              hints the explorer loads when a matching page opens
+            </span>
+          </span>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setDraft({ ...EMPTY_DRAFT })}
+          >
+            <Plus className="h-3.5 w-3.5 mr-1" />
+            Add note
+          </Button>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {draft && (
+          <div className="rounded-md border p-3 space-y-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <Label htmlFor="k-title">Title</Label>
+                <Input
+                  id="k-title"
+                  value={draft.title}
+                  placeholder="Login credentials"
+                  onChange={(e) =>
+                    setDraft({ ...draft, title: e.target.value })
+                  }
+                />
+              </div>
+              <div className="flex gap-2">
+                <div className="space-y-1 flex-1">
+                  <Label htmlFor="k-pattern">URL pattern</Label>
+                  <Input
+                    id="k-pattern"
+                    value={draft.urlPattern}
+                    placeholder="/admin/*"
+                    onChange={(e) =>
+                      setDraft({ ...draft, urlPattern: e.target.value })
+                    }
+                  />
+                </div>
+                <div className="space-y-1 w-28">
+                  <Label>Match</Label>
+                  <Select
+                    value={draft.matchKind}
+                    onValueChange={(v) =>
+                      setDraft({ ...draft, matchKind: v as KnowledgeMatchKind })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="prefix">prefix</SelectItem>
+                      <SelectItem value="exact">exact</SelectItem>
+                      <SelectItem value="regex">regex</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="k-body">Hint (markdown)</Label>
+              <Textarea
+                id="k-body"
+                rows={4}
+                value={draft.body}
+                placeholder={
+                  "The date filter expects DD.MM.YYYY.\nUse the demo project, never touch 'Production'."
+                }
+                onChange={(e) => setDraft({ ...draft, body: e.target.value })}
+              />
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <Label htmlFor="k-email">Login email (optional)</Label>
+                <Input
+                  id="k-email"
+                  value={draft.credEmail}
+                  autoComplete="off"
+                  onChange={(e) =>
+                    setDraft({ ...draft, credEmail: e.target.value })
+                  }
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="k-password">
+                  Password (optional{draft.id ? ", blank keeps existing" : ""})
+                </Label>
+                <Input
+                  id="k-password"
+                  type="password"
+                  value={draft.credPassword}
+                  autoComplete="new-password"
+                  onChange={(e) =>
+                    setDraft({ ...draft, credPassword: e.target.value })
+                  }
+                />
+              </div>
+            </div>
+            <div className="flex gap-2 justify-end">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setDraft(null)}
+                disabled={saving}
+              >
+                Cancel
+              </Button>
+              <Button size="sm" onClick={save} disabled={saving}>
+                Save note
+              </Button>
+            </div>
+          </div>
+        )}
+        {notes.length === 0 && !draft ? (
+          <p className="text-sm text-muted-foreground">
+            No knowledge yet. Add credentials, form quirks, or navigation hints
+            — the explorer injects matching notes into its planning and testing
+            prompts.
+          </p>
+        ) : (
+          notes.map((note) => (
+            <div
+              key={note.id}
+              className="rounded-md border p-3 flex items-start justify-between gap-2"
+            >
+              <div className="min-w-0 space-y-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">{note.title}</span>
+                  <Badge variant="outline" className="text-[10px] font-mono">
+                    {note.urlPattern}
+                  </Badge>
+                  <Badge variant="outline" className="text-[10px]">
+                    {note.matchKind}
+                  </Badge>
+                  {note.hasCredentials && (
+                    <KeyRound className="h-3 w-3 text-muted-foreground" />
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground line-clamp-2 whitespace-pre-line">
+                  {note.body}
+                </p>
+              </div>
+              <div className="flex items-center gap-1 shrink-0">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 text-xs"
+                  onClick={() =>
+                    setDraft({
+                      id: note.id,
+                      title: note.title,
+                      urlPattern: note.urlPattern,
+                      matchKind: note.matchKind,
+                      body: note.body,
+                      credEmail: note.credEmail ?? "",
+                      credPassword: "",
+                    })
+                  }
+                >
+                  Edit
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 text-muted-foreground"
+                  onClick={() => remove(note.id)}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </div>
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/explorer/use-explorer-agent.ts
+++ b/src/components/explorer/use-explorer-agent.ts
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import type {
+  AgentFinding,
+  AgentSession,
+  ExplorerStyle,
+} from "@/lib/db/schema";
+import {
+  startExplorerAgent,
+  pauseExplorerAgent,
+  resumeExplorerAgent,
+  cancelExplorerAgent,
+} from "@/server/actions/explorer-agent";
+
+const POLL_INTERVAL = 2000;
+
+export type ExplorerSessionWithFindings = AgentSession & {
+  findings?: AgentFinding[];
+};
+
+export interface StartExplorerOptions {
+  targetUrl: string;
+  maxIterations?: number;
+  styleRotation?: ExplorerStyle[];
+  email?: string;
+  password?: string;
+}
+
+/**
+ * Client driver for an explorer session: starts/controls it via server
+ * actions and polls /api/explorer-agent/[sessionId] for live state (session +
+ * findings), mirroring useQaAgent. The session id is remembered per-repo so a
+ * page reload re-attaches.
+ */
+export function useExplorerAgent(
+  repositoryId: string | null | undefined,
+  initialSession: ExplorerSessionWithFindings | null,
+) {
+  const [session, setSession] = useState<ExplorerSessionWithFindings | null>(
+    initialSession,
+  );
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const storageKey = repositoryId ? `explorer-session-${repositoryId}` : null;
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const poll = useCallback(
+    async (sid: string) => {
+      try {
+        const res = await fetch(`/api/explorer-agent/${sid}`, {
+          cache: "no-store",
+        });
+        if (!res.ok) {
+          if (res.status === 404 && storageKey) {
+            localStorage.removeItem(storageKey);
+            setSession(null);
+          }
+          return;
+        }
+        const data: ExplorerSessionWithFindings = await res.json();
+        setSession(data);
+        if (data.status !== "active" && data.status !== "paused") {
+          stopPolling();
+        }
+      } catch {
+        // Transient network errors are ignored; next tick retries.
+      }
+    },
+    [storageKey, stopPolling],
+  );
+
+  const startPolling = useCallback(
+    (sid: string) => {
+      stopPolling();
+      pollRef.current = setInterval(() => poll(sid), POLL_INTERVAL);
+      void poll(sid);
+    },
+    [poll, stopPolling],
+  );
+
+  useEffect(() => {
+    const sid =
+      initialSession?.id ??
+      (storageKey ? localStorage.getItem(storageKey) : null);
+    if (!sid) return;
+    if (
+      initialSession &&
+      initialSession.status !== "active" &&
+      initialSession.status !== "paused"
+    ) {
+      return;
+    }
+    startPolling(sid);
+    return stopPolling;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [repositoryId]);
+
+  const start = useCallback(
+    async (options: StartExplorerOptions) => {
+      if (!repositoryId) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await startExplorerAgent({ repositoryId, ...options });
+        if (storageKey) localStorage.setItem(storageKey, result.sessionId);
+        startPolling(result.sessionId);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to start");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [repositoryId, storageKey, startPolling],
+  );
+
+  const runAction = useCallback(
+    async (fn: () => Promise<unknown>, sid?: string) => {
+      setLoading(true);
+      setError(null);
+      try {
+        await fn();
+        if (sid) startPolling(sid);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Action failed");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [startPolling],
+  );
+
+  const pause = useCallback(
+    () =>
+      session
+        ? runAction(() => pauseExplorerAgent(session.id), session.id)
+        : Promise.resolve(),
+    [session, runAction],
+  );
+
+  const resume = useCallback(
+    () =>
+      session
+        ? runAction(() => resumeExplorerAgent(session.id), session.id)
+        : Promise.resolve(),
+    [session, runAction],
+  );
+
+  const cancel = useCallback(
+    () =>
+      session
+        ? runAction(() => cancelExplorerAgent(session.id), session.id)
+        : Promise.resolve(),
+    [session, runAction],
+  );
+
+  /** Forget the current (terminal) session so the setup form shows again. */
+  const dismiss = useCallback(() => {
+    stopPolling();
+    if (storageKey) localStorage.removeItem(storageKey);
+    setSession(null);
+  }, [storageKey, stopPolling]);
+
+  const isRunning = session?.status === "active";
+  const isPaused = session?.status === "paused";
+  const isTerminal =
+    session?.status === "completed" ||
+    session?.status === "failed" ||
+    session?.status === "cancelled";
+
+  const completedSteps =
+    session?.steps.filter(
+      (s) => s.status === "completed" || s.status === "skipped",
+    ).length ?? 0;
+  const totalSteps = session?.steps.length ?? 1;
+  const progress =
+    totalSteps > 0 ? Math.round((completedSteps / totalSteps) * 100) : 0;
+
+  return {
+    session,
+    loading,
+    error,
+    isRunning,
+    isPaused,
+    isTerminal,
+    progress,
+    start,
+    pause,
+    resume,
+    cancel,
+    dismiss,
+  };
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -19,6 +19,7 @@ import {
   GitCommit,
   Wrench,
   Bot,
+  Compass,
   Lock,
 } from "lucide-react";
 import Image from "next/image";
@@ -79,6 +80,7 @@ const definitionNav = [
 const executionNav = [
   { name: "Runs", href: "/run", icon: Play },
   { name: "QA Agent", href: "/qa-agent", icon: Bot },
+  { name: "Explorer", href: "/explorer", icon: Compass },
   { name: "Compare", href: "/compare", icon: GitCompare },
   { name: "URL Diff", href: "/url-diff", icon: SplitSquareHorizontal },
   { name: "Impact", href: "/analytics/impact", icon: TrendingDown },

--- a/src/components/play-agent/play-agent-step.tsx
+++ b/src/components/play-agent/play-agent-step.tsx
@@ -63,6 +63,11 @@ const AGENT_BADGE_STYLES: Record<
     text: "text-teal-600 dark:text-teal-400",
     label: "Ranger",
   },
+  explorer: {
+    bg: "bg-orange-500/15",
+    text: "text-orange-600 dark:text-orange-400",
+    label: "Explorer",
+  },
 };
 
 export function AgentBadge({ agent }: { agent: PwAgentType }) {

--- a/src/components/play-agent/play-agent-timeline.tsx
+++ b/src/components/play-agent/play-agent-timeline.tsx
@@ -148,6 +148,10 @@ const ROSTER_BADGE_STYLES: Record<PwAgentType, { bg: string; text: string }> = {
     bg: "bg-teal-500/15",
     text: "text-teal-600 dark:text-teal-400",
   },
+  explorer: {
+    bg: "bg-orange-500/15",
+    text: "text-orange-600 dark:text-orange-400",
+  },
 };
 
 // ============================================

--- a/src/components/qa-agent/qa-agent-client.tsx
+++ b/src/components/qa-agent/qa-agent-client.tsx
@@ -473,6 +473,7 @@ const SOURCE_LABELS: Record<ActivitySourceType, string> = {
   generate_agent: "Generator agent",
   heal_agent: "Healer agent",
   qa_agent: "QA agent",
+  explorer_agent: "Explorer agent",
 };
 
 const EXTERNAL_ACTIVITY_WINDOW_MS = 5 * 60 * 1000;

--- a/src/components/settings/ai-settings-card.tsx
+++ b/src/components/settings/ai-settings-card.tsx
@@ -40,6 +40,7 @@ import {
   XCircle,
   Zap,
   Bot,
+  Compass,
   Eye,
   Server,
   Brain,
@@ -127,6 +128,17 @@ export function AISettingsCard({
     settings.pwAgentTimeout ?? 300000,
   );
 
+  // Explorer agent settings
+  const [explorerMaxIterations, setExplorerMaxIterations] = useState(
+    settings.explorerMaxIterations ?? DEFAULT_AI_SETTINGS.explorerMaxIterations,
+  );
+  const [explorerStyleRotation, setExplorerStyleRotation] = useState(
+    settings.explorerStyleRotation || DEFAULT_AI_SETTINGS.explorerStyleRotation,
+  );
+  const [explorerModel, setExplorerModel] = useState(
+    settings.explorerModel || "",
+  );
+
   // AI Diffing settings
   const [aiDiffingEnabled, setAiDiffingEnabled] = useState(
     settings.aiDiffingEnabled ?? false,
@@ -178,6 +190,13 @@ export function AISettingsCard({
     aiDiffingOllamaModel: settings.aiDiffingOllamaModel || "",
     pwAgentModel: settings.pwAgentModel || "",
     pwAgentTimeout: settings.pwAgentTimeout ?? 300000,
+    explorerMaxIterations:
+      settings.explorerMaxIterations ??
+      DEFAULT_AI_SETTINGS.explorerMaxIterations,
+    explorerStyleRotation:
+      settings.explorerStyleRotation ||
+      DEFAULT_AI_SETTINGS.explorerStyleRotation,
+    explorerModel: settings.explorerModel || "",
   });
 
   const doSave = useCallback(() => {
@@ -210,6 +229,9 @@ export function AISettingsCard({
           aiDiffingOllamaModel: aiDiffingOllamaModel || null,
           pwAgentModel: pwAgentModel || null,
           pwAgentTimeout,
+          explorerMaxIterations,
+          explorerStyleRotation: explorerStyleRotation || null,
+          explorerModel: explorerModel || null,
         });
         toast.success("AI settings saved");
       } catch (err) {
@@ -241,6 +263,9 @@ export function AISettingsCard({
     aiDiffingOllamaModel,
     pwAgentModel,
     pwAgentTimeout,
+    explorerMaxIterations,
+    explorerStyleRotation,
+    explorerModel,
   ]);
 
   // Auto-save with debounce - only when values differ from original props
@@ -267,7 +292,10 @@ export function AISettingsCard({
       aiDiffingOllamaBaseUrl !== orig.aiDiffingOllamaBaseUrl ||
       aiDiffingOllamaModel !== orig.aiDiffingOllamaModel ||
       pwAgentModel !== orig.pwAgentModel ||
-      pwAgentTimeout !== orig.pwAgentTimeout;
+      pwAgentTimeout !== orig.pwAgentTimeout ||
+      explorerMaxIterations !== orig.explorerMaxIterations ||
+      explorerStyleRotation !== orig.explorerStyleRotation ||
+      explorerModel !== orig.explorerModel;
 
     if (!hasChanges) return;
 
@@ -306,6 +334,9 @@ export function AISettingsCard({
     aiDiffingOllamaModel,
     pwAgentModel,
     pwAgentTimeout,
+    explorerMaxIterations,
+    explorerStyleRotation,
+    explorerModel,
     doSave,
   ]);
 
@@ -782,6 +813,63 @@ export function AISettingsCard({
               />
               <p className="text-xs text-muted-foreground">
                 Maximum time for agent operations. Default: 300s (5 min).
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Explorer Agent Section */}
+        <div className="border-t pt-6">
+          <div className="flex items-center gap-2 mb-4">
+            <Compass className="w-4 h-4 text-orange-600" />
+            <h3 className="font-medium">Explorer Agent</h3>
+          </div>
+          <p className="text-xs text-muted-foreground mb-4">
+            Defaults for autonomous exploratory-testing runs (the /explorer
+            page). The explorer makes many small AI calls, so a cheaper, faster
+            model is often the right choice here.
+          </p>
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor="explorerMaxIterations">Max iterations</Label>
+              <Input
+                id="explorerMaxIterations"
+                type="number"
+                min={1}
+                max={12}
+                value={explorerMaxIterations}
+                onChange={(e) =>
+                  setExplorerMaxIterations(
+                    Math.max(1, Math.min(12, Number(e.target.value) || 1)),
+                  )
+                }
+              />
+              <p className="text-xs text-muted-foreground">
+                Research→plan→act→analyze loops per run (budget).
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="explorerStyleRotation">Style rotation</Label>
+              <Input
+                id="explorerStyleRotation"
+                value={explorerStyleRotation}
+                onChange={(e) => setExplorerStyleRotation(e.target.value)}
+                placeholder="normal,curious,psycho"
+              />
+              <p className="text-xs text-muted-foreground">
+                Comma list of planning styles cycled per iteration.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="explorerModel">Model override</Label>
+              <Input
+                id="explorerModel"
+                value={explorerModel}
+                onChange={(e) => setExplorerModel(e.target.value)}
+                placeholder="empty = same as test generation"
+              />
+              <p className="text-xs text-muted-foreground">
+                Model for the explorer loop on the active provider.
               </p>
             </div>
           </div>

--- a/src/lib/crypto-fields.ts
+++ b/src/lib/crypto-fields.ts
@@ -16,7 +16,12 @@
  */
 
 import { encrypt, decryptField, ENC_PREFIX } from "./crypto";
-import type { SetupAuthConfig, AgentSessionMetadata } from "./db/schema";
+import type {
+  SetupAuthConfig,
+  AgentSessionMetadata,
+  AgentKnowledge,
+  NewAgentKnowledge,
+} from "./db/schema";
 
 function encField(value: string): string {
   return value.startsWith(ENC_PREFIX) ? value : encrypt(value);
@@ -73,4 +78,22 @@ export function decryptSessionMetadata<
 >(meta: T): T {
   if (!meta || meta.quickstartPassword == null) return meta;
   return { ...meta, quickstartPassword: decryptField(meta.quickstartPassword) };
+}
+
+// ── agent_knowledge.credPassword ────────────────────────────────────────────
+// Explorer-agent knowledge notes may carry page-scoped login credentials.
+// Only the password is encrypted; credEmail stays plaintext (identifier).
+
+export function encryptKnowledgeRow<
+  T extends Pick<NewAgentKnowledge, "credPassword"> | null | undefined,
+>(row: T): T {
+  if (!row || row.credPassword == null) return row;
+  return { ...row, credPassword: encField(row.credPassword) };
+}
+
+export function decryptKnowledgeRow<
+  T extends Pick<AgentKnowledge, "credPassword"> | null | undefined,
+>(row: T): T {
+  if (!row || row.credPassword == null) return row;
+  return { ...row, credPassword: decryptField(row.credPassword) };
 }

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -43,3 +43,6 @@ export * from "./queries/playground";
 export * from "./queries/billing";
 export * from "./queries/qa-tasks";
 export * from "./queries/qa-agent-triggers";
+export * from "./queries/explorer";
+export * from "./queries/agent-knowledge";
+export * from "./queries/agent-experience";

--- a/src/lib/db/queries/agent-experience.ts
+++ b/src/lib/db/queries/agent-experience.ts
@@ -1,0 +1,128 @@
+import { db } from "../index";
+import { agentExperience } from "../schema";
+import type { AgentExperience, ExperienceNote } from "../schema";
+import { eq, and, desc, inArray } from "drizzle-orm";
+
+/**
+ * Explorer-agent experience: what the agent learned by doing (explorbot's
+ * `experience/` directory, DB-backed). Rows are keyed by page state —
+ * hashState(normalizedUrl, headings) — and accumulate notes across runs.
+ */
+
+/** Cap notes per state so hot pages don't grow unbounded; newest kept. */
+const MAX_NOTES_PER_STATE = 40;
+
+export async function getExperienceByState(
+  repositoryId: string,
+  stateHash: string,
+): Promise<AgentExperience | undefined> {
+  const [row] = await db
+    .select()
+    .from(agentExperience)
+    .where(
+      and(
+        eq(agentExperience.repositoryId, repositoryId),
+        eq(agentExperience.stateHash, stateHash),
+      ),
+    );
+  return row;
+}
+
+export async function listExperienceByStates(
+  repositoryId: string,
+  stateHashes: string[],
+): Promise<AgentExperience[]> {
+  if (stateHashes.length === 0) return [];
+  return db
+    .select()
+    .from(agentExperience)
+    .where(
+      and(
+        eq(agentExperience.repositoryId, repositoryId),
+        inArray(agentExperience.stateHash, stateHashes),
+      ),
+    );
+}
+
+export async function listExperienceByRepo(
+  repositoryId: string,
+  limit = 200,
+): Promise<AgentExperience[]> {
+  return db
+    .select()
+    .from(agentExperience)
+    .where(eq(agentExperience.repositoryId, repositoryId))
+    .orderBy(desc(agentExperience.updatedAt))
+    .limit(limit);
+}
+
+/** Record a visit to a page state: bump timesVisited (creating the row on
+ *  first sight) and optionally append learned notes. */
+export async function recordExperience(input: {
+  repositoryId: string;
+  teamId: string;
+  stateHash: string;
+  normalizedUrl: string;
+  headingsDigest?: string;
+  sessionId?: string;
+  notes?: ExperienceNote[];
+}): Promise<AgentExperience> {
+  const now = new Date();
+  const existing = await getExperienceByState(
+    input.repositoryId,
+    input.stateHash,
+  );
+  if (existing) {
+    const merged = [...existing.notes, ...(input.notes ?? [])].slice(
+      -MAX_NOTES_PER_STATE,
+    );
+    const [row] = await db
+      .update(agentExperience)
+      .set({
+        notes: merged,
+        timesVisited: existing.timesVisited + 1,
+        normalizedUrl: input.normalizedUrl,
+        headingsDigest: input.headingsDigest ?? existing.headingsDigest,
+        lastSessionId: input.sessionId ?? existing.lastSessionId,
+        updatedAt: now,
+      })
+      .where(eq(agentExperience.id, existing.id))
+      .returning();
+    return row;
+  }
+  const [row] = await db
+    .insert(agentExperience)
+    .values({
+      id: crypto.randomUUID(),
+      repositoryId: input.repositoryId,
+      teamId: input.teamId,
+      stateHash: input.stateHash,
+      normalizedUrl: input.normalizedUrl,
+      headingsDigest: input.headingsDigest ?? null,
+      notes: (input.notes ?? []).slice(-MAX_NOTES_PER_STATE),
+      timesVisited: 1,
+      lastSessionId: input.sessionId ?? null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+  return row;
+}
+
+/** Append notes to an existing state without counting a new visit. */
+export async function appendExperienceNotes(
+  repositoryId: string,
+  stateHash: string,
+  notes: ExperienceNote[],
+): Promise<void> {
+  if (notes.length === 0) return;
+  const existing = await getExperienceByState(repositoryId, stateHash);
+  if (!existing) return;
+  await db
+    .update(agentExperience)
+    .set({
+      notes: [...existing.notes, ...notes].slice(-MAX_NOTES_PER_STATE),
+      updatedAt: new Date(),
+    })
+    .where(eq(agentExperience.id, existing.id));
+}

--- a/src/lib/db/queries/agent-knowledge.ts
+++ b/src/lib/db/queries/agent-knowledge.ts
@@ -1,0 +1,98 @@
+import { db } from "../index";
+import { encryptKnowledgeRow, decryptKnowledgeRow } from "@/lib/crypto-fields";
+import { agentKnowledge } from "../schema";
+import type { AgentKnowledge, NewAgentKnowledge } from "../schema";
+import { matchUrlPattern } from "@/lib/explorer/url-match";
+import { eq, and, desc } from "drizzle-orm";
+
+/**
+ * Explorer-agent knowledge notes: human-provided markdown hints matched to
+ * pages by URL pattern (explorbot's `knowledge/` directory, DB-backed).
+ * credPassword is AES-256-GCM encrypted at rest here — callers always see
+ * plaintext.
+ */
+
+export async function listKnowledgeByRepo(
+  repositoryId: string,
+): Promise<AgentKnowledge[]> {
+  const rows = await db
+    .select()
+    .from(agentKnowledge)
+    .where(eq(agentKnowledge.repositoryId, repositoryId))
+    .orderBy(desc(agentKnowledge.updatedAt));
+  return rows.map((r) => decryptKnowledgeRow(r));
+}
+
+export async function getKnowledge(
+  id: string,
+): Promise<AgentKnowledge | undefined> {
+  const [row] = await db
+    .select()
+    .from(agentKnowledge)
+    .where(eq(agentKnowledge.id, id));
+  return row ? decryptKnowledgeRow(row) : undefined;
+}
+
+export async function createKnowledge(
+  data: Omit<NewAgentKnowledge, "id" | "createdAt" | "updatedAt">,
+): Promise<AgentKnowledge> {
+  const now = new Date();
+  const [row] = await db
+    .insert(agentKnowledge)
+    .values({
+      ...encryptKnowledgeRow(data),
+      id: crypto.randomUUID(),
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+  return decryptKnowledgeRow(row);
+}
+
+export async function updateKnowledge(
+  id: string,
+  patch: Partial<
+    Pick<
+      NewAgentKnowledge,
+      | "title"
+      | "urlPattern"
+      | "matchKind"
+      | "body"
+      | "credEmail"
+      | "credPassword"
+      | "pageAutomation"
+      | "enabled"
+    >
+  >,
+): Promise<AgentKnowledge | undefined> {
+  const [row] = await db
+    .update(agentKnowledge)
+    .set({ ...encryptKnowledgeRow(patch), updatedAt: new Date() })
+    .where(eq(agentKnowledge.id, id))
+    .returning();
+  return row ? decryptKnowledgeRow(row) : undefined;
+}
+
+export async function deleteKnowledge(id: string): Promise<void> {
+  await db.delete(agentKnowledge).where(eq(agentKnowledge.id, id));
+}
+
+/** Enabled notes whose URL pattern matches the given page URL, decrypted.
+ *  Pattern matching happens in-process (repo note counts are small). */
+export async function matchKnowledgeForUrl(
+  repositoryId: string,
+  url: string,
+): Promise<AgentKnowledge[]> {
+  const rows = await db
+    .select()
+    .from(agentKnowledge)
+    .where(
+      and(
+        eq(agentKnowledge.repositoryId, repositoryId),
+        eq(agentKnowledge.enabled, true),
+      ),
+    );
+  return rows
+    .filter((r) => matchUrlPattern(r.urlPattern, r.matchKind, url))
+    .map((r) => decryptKnowledgeRow(r));
+}

--- a/src/lib/db/queries/explorer.ts
+++ b/src/lib/db/queries/explorer.ts
@@ -1,0 +1,171 @@
+import { db } from "../index";
+import { agentFindings, explorerTriggers } from "../schema";
+import type {
+  AgentFinding,
+  NewAgentFinding,
+  ExplorerFindingStatus,
+  ExplorerSeverity,
+  ExplorerFindingKind,
+  ExplorerTrigger,
+} from "../schema";
+import { eq, and, desc, lte, inArray } from "drizzle-orm";
+
+/**
+ * Explorer-agent findings (defects / UX issues observed while exploring) and
+ * the per-repo explorer cron trigger. Session rows live in agent_sessions
+ * (kind = "explorer") via the generic queries in ./integrations.ts.
+ */
+
+// ── agent_findings ───────────────────────────────────────────────────────────
+
+export async function createAgentFinding(
+  data: Omit<NewAgentFinding, "id" | "createdAt">,
+): Promise<AgentFinding> {
+  const [row] = await db
+    .insert(agentFindings)
+    .values({ ...data, id: crypto.randomUUID(), createdAt: new Date() })
+    .returning();
+  return row;
+}
+
+export async function getAgentFinding(
+  id: string,
+): Promise<AgentFinding | undefined> {
+  const [row] = await db
+    .select()
+    .from(agentFindings)
+    .where(eq(agentFindings.id, id));
+  return row;
+}
+
+export async function listFindingsBySession(
+  sessionId: string,
+): Promise<AgentFinding[]> {
+  return db
+    .select()
+    .from(agentFindings)
+    .where(eq(agentFindings.sessionId, sessionId))
+    .orderBy(desc(agentFindings.createdAt));
+}
+
+export async function listFindingsByRepo(
+  repositoryId: string,
+  opts?: { status?: ExplorerFindingStatus; limit?: number },
+): Promise<AgentFinding[]> {
+  const conds = [eq(agentFindings.repositoryId, repositoryId)];
+  if (opts?.status) conds.push(eq(agentFindings.status, opts.status));
+  return db
+    .select()
+    .from(agentFindings)
+    .where(and(...conds))
+    .orderBy(desc(agentFindings.createdAt))
+    .limit(opts?.limit ?? 200);
+}
+
+export async function updateFindingStatus(
+  id: string,
+  status: ExplorerFindingStatus,
+): Promise<void> {
+  await db
+    .update(agentFindings)
+    .set({ status })
+    .where(eq(agentFindings.id, id));
+}
+
+/** Analyst back-fill: stamp a shared root-cause label (and refined
+ *  severity/kind) onto every finding in a cluster. */
+export async function updateFindingCluster(
+  findingIds: string[],
+  patch: {
+    rootCauseCluster: string;
+    severity?: ExplorerSeverity;
+    kind?: ExplorerFindingKind;
+  },
+): Promise<void> {
+  if (findingIds.length === 0) return;
+  await db
+    .update(agentFindings)
+    .set(patch)
+    .where(inArray(agentFindings.id, findingIds));
+}
+
+export async function linkFindingToBugReport(
+  id: string,
+  bugReportId: string,
+): Promise<void> {
+  await db
+    .update(agentFindings)
+    .set({ bugReportId, status: "triaged" })
+    .where(eq(agentFindings.id, id));
+}
+
+// ── explorer_triggers (cron automation, mirrors qa-agent-triggers) ──────────
+
+export async function getExplorerTrigger(
+  repositoryId: string,
+): Promise<ExplorerTrigger | undefined> {
+  const [row] = await db
+    .select()
+    .from(explorerTriggers)
+    .where(eq(explorerTriggers.repositoryId, repositoryId));
+  return row;
+}
+
+export async function upsertExplorerTrigger(
+  repositoryId: string,
+  teamId: string,
+  patch: Partial<{
+    scheduleEnabled: boolean;
+    cronExpression: string | null;
+    maxIterations: number;
+    nextRunAt: Date | null;
+  }>,
+): Promise<ExplorerTrigger> {
+  const existing = await getExplorerTrigger(repositoryId);
+  const now = new Date();
+  if (existing) {
+    const [row] = await db
+      .update(explorerTriggers)
+      .set({ ...patch, updatedAt: now })
+      .where(eq(explorerTriggers.id, existing.id))
+      .returning();
+    return row;
+  }
+  const [row] = await db
+    .insert(explorerTriggers)
+    .values({
+      id: crypto.randomUUID(),
+      repositoryId,
+      teamId,
+      ...patch,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+  return row;
+}
+
+/** Enabled cron triggers whose nextRunAt has passed — the scheduler's pick. */
+export async function getDueExplorerTriggers(
+  now: Date = new Date(),
+): Promise<ExplorerTrigger[]> {
+  return db
+    .select()
+    .from(explorerTriggers)
+    .where(
+      and(
+        eq(explorerTriggers.scheduleEnabled, true),
+        lte(explorerTriggers.nextRunAt, now),
+      ),
+    );
+}
+
+export async function markExplorerTriggerFired(
+  id: string,
+  data: { nextRunAt: Date | null; lastRunAt?: Date; lastSessionId?: string },
+): Promise<void> {
+  await db
+    .update(explorerTriggers)
+    .set({ ...data, updatedAt: new Date() })
+    .where(eq(explorerTriggers.id, id));
+}

--- a/src/lib/db/queries/settings.ts
+++ b/src/lib/db/queries/settings.ts
@@ -468,6 +468,9 @@ export async function getAISettings(repositoryId?: string | null) {
     openaiModel: DEFAULT_AI_SETTINGS.openaiModel,
     pwAgentModel: DEFAULT_AI_SETTINGS.pwAgentModel,
     pwAgentTimeout: DEFAULT_AI_SETTINGS.pwAgentTimeout,
+    explorerMaxIterations: DEFAULT_AI_SETTINGS.explorerMaxIterations,
+    explorerStyleRotation: DEFAULT_AI_SETTINGS.explorerStyleRotation,
+    explorerModel: DEFAULT_AI_SETTINGS.explorerModel,
     createdAt: null,
     updatedAt: null,
   };

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1762,6 +1762,13 @@ export const aiSettings = pgTable("ai_settings", {
   aiDiffingOllamaModel: text("ai_diffing_ollama_model"),
   pwAgentModel: text("pw_agent_model"),
   pwAgentTimeout: integer("pw_agent_timeout").default(300000),
+  // Explorer agent settings
+  explorerMaxIterations: integer("explorer_max_iterations").default(8),
+  explorerStyleRotation: text("explorer_style_rotation").default(
+    "normal,curious,psycho",
+  ),
+  /** Model override for explorer loop calls (empty = same as test generation). */
+  explorerModel: text("explorer_model"),
   createdAt: timestamp("created_at"),
   updatedAt: timestamp("updated_at"),
 });
@@ -1785,6 +1792,9 @@ export const DEFAULT_AI_SETTINGS = {
   aiDiffingOllamaModel: "",
   pwAgentModel: "",
   pwAgentTimeout: 300000,
+  explorerMaxIterations: 8,
+  explorerStyleRotation: "normal,curious,psycho",
+  explorerModel: "",
 };
 
 // AI Prompt Logging for debugging and auditing
@@ -1806,7 +1816,10 @@ export type AIActionType =
   | "qa_plan"
   | "triage"
   | "generate_var_value"
-  | "suggest_app_fix";
+  | "suggest_app_fix"
+  | "explorer_plan"
+  | "explorer_act"
+  | "explorer_analyze";
 export type AILogStatus = "pending" | "success" | "error";
 
 export const aiPromptLogs = pgTable("ai_prompt_logs", {
@@ -2577,7 +2590,12 @@ export type AgentSessionStatus =
   | "failed"
   | "cancelled";
 
-export type AgentSessionKind = "play" | "quickstart" | "ranger" | "qa";
+export type AgentSessionKind =
+  | "play"
+  | "quickstart"
+  | "ranger"
+  | "qa"
+  | "explorer";
 
 export type AgentStepId =
   | "settings_check"
@@ -2614,7 +2632,19 @@ export type AgentStepId =
   | "qa_generate"
   | "qa_execute"
   | "qa_heal"
-  | "qa_summary";
+  | "qa_summary"
+  // Explorer Agent (explorbot-style autonomous exploratory testing, /explorer page).
+  // research/plan/act/analyze repeat once per loop iteration — the steps array
+  // carries one entry per (step, iteration) pair, disambiguated by
+  // AgentStepState.iteration.
+  | "explorer_setup"
+  | "explorer_login"
+  | "explorer_research"
+  | "explorer_plan"
+  | "explorer_act"
+  | "explorer_analyze"
+  | "explorer_keep"
+  | "explorer_summary";
 
 export type AgentStepStatus =
   | "pending"
@@ -2632,7 +2662,8 @@ export type PwAgentType =
   | "generator"
   | "healer"
   | "quickstart"
-  | "ranger";
+  | "ranger"
+  | "explorer";
 
 export interface AgentSubstep {
   label: string;
@@ -2715,6 +2746,9 @@ export interface AgentStepState {
   richResult?: AgentStepRichResult;
   userAction?: string;
   substeps?: AgentSubstep[];
+  /** Explorer loop index (0-based) for the repeated research/plan/act/analyze
+   *  step entries. Absent on linear (non-loop) steps and other agent kinds. */
+  iteration?: number;
 }
 
 export interface QuickstartAuthClassification {
@@ -3126,6 +3160,81 @@ export interface QaSummaryData {
   prCoverage?: QaPrCoverage;
 }
 
+// ── Explorer Agent (explorbot-style autonomous exploratory testing) ─────────
+
+/** Planning style rotated across loop iterations (explorbot's normal/curious/
+ *  psycho). Each style is a prompt fragment steering the scenario planner. */
+export type ExplorerStyle = "normal" | "curious" | "psycho";
+
+export type ExplorerFindingKind = "defect" | "ux";
+
+export type ExplorerSeverity = "critical" | "high" | "medium" | "low" | "info";
+
+export type ExplorerFindingStatus = "open" | "triaged" | "dismissed" | "kept";
+
+/** One scenario the explorer planner drafted for the current page/iteration. */
+export interface ExplorerScenario {
+  id: string;
+  title: string;
+  style: ExplorerStyle;
+  /** Ordered natural-language steps the tester executes adaptively. */
+  steps: string[];
+  /** Why this scenario matters / what it probes. */
+  rationale: string;
+  /** Expected outcome the tester verifies at the end. */
+  expectedOutcome?: string;
+  /** Planner marked it redundant with existing coverage — not executed. */
+  skipped?: boolean;
+  skipReason?: string;
+}
+
+/** One browser action the tester took while executing a scenario. */
+export interface ExplorerActionStep {
+  /** What the tester was trying to do ("submit the login form"). */
+  intent: string;
+  /** The concrete action taken ("click", "fill", "navigate"...). */
+  action: string;
+  selector?: string;
+  value?: string;
+  result: "ok" | "blocked" | "error";
+  note?: string;
+}
+
+export type ExplorerScenarioOutcome = "passed" | "failed" | "blocked" | "stuck";
+
+/** Execution record of one scenario: the adaptive step log + evidence. */
+export interface ExplorerActionLog {
+  scenarioId: string;
+  status: ExplorerScenarioOutcome;
+  steps: ExplorerActionStep[];
+  /** Console errors observed during execution (evidence). */
+  consoleErrors?: string[];
+  /** Failed same-origin requests observed during execution (evidence). */
+  failedRequests?: Array<{ url: string; status: number; method: string }>;
+  /** Page-state hash where the scenario ended. */
+  finalStateHash?: string;
+  finalUrl?: string;
+  summary?: string;
+}
+
+/** Analyst output: findings clustered by root cause. */
+export interface ExplorerReport {
+  clusters: Array<{
+    rootCause: string;
+    severity: ExplorerSeverity;
+    kind: ExplorerFindingKind;
+    findingIds: string[];
+    summary: string;
+  }>;
+  totalFindings: number;
+  iterationsRun: number;
+  /** Analyst's overall written assessment of the session. */
+  assessment?: string;
+}
+
+/** What started an explorer session (mirrors QaSessionTrigger). */
+export type ExplorerSessionTrigger = "manual" | "schedule" | "mcp";
+
 export interface AgentSessionMetadata {
   buildIds?: string[];
   fixAttempts?: Record<string, number>;
@@ -3228,6 +3337,42 @@ export interface AgentSessionMetadata {
   /** What started this session — powers the run-history provenance chip.
    *  Absent on sessions created before triggers existed = "manual". */
   qaTrigger?: QaSessionTrigger;
+  // Explorer Agent fields (kind = "explorer"). Target-app credentials reuse
+  // quickstartEmail/quickstartPassword above for AES-256-GCM encryption at rest.
+  /** Target app base URL being explored. */
+  explorerTargetUrl?: string;
+  /** Hard budget on research→plan→act→analyze loop iterations. */
+  explorerMaxIterations?: number;
+  /** Current loop index (0-based) — the resume cursor. */
+  explorerIteration?: number;
+  /** Style rotation order; iteration i uses rotation[i % length]. */
+  explorerStyleRotation?: ExplorerStyle[];
+  /** Ordered page-state hashes observed (loop/stuck detection + experience keys). */
+  explorerStateHistory?: string[];
+  /** Unvisited same-origin URLs queued for future iterations (BFS frontier). */
+  explorerFrontier?: string[];
+  /** Normalized URLs already researched (frontier dedup). */
+  explorerVisitedUrls?: string[];
+  /** Latest research output (RangerPageMap shape) feeding the planner. */
+  explorerPageMap?: Record<string, unknown>;
+  /** State hash + URL of the most recent research observation. */
+  explorerCurrentState?: { hash: string; url: string; headings: string[] };
+  /** Planner output for the current iteration. */
+  explorerCurrentPlan?: ExplorerScenario[];
+  /** scenarioId → execution log, accumulated across iterations. */
+  explorerActionLogs?: Record<string, ExplorerActionLog>;
+  /** agent_findings rows created by this session. */
+  explorerFindingIds?: string[];
+  /** Analyst clustering output (summary step). */
+  explorerReport?: ExplorerReport;
+  /** Tests created by the keep step (quarantined drafts). */
+  explorerKeptTestIds?: string[];
+  /** Resolved auth strategy (reuses the QA agent's login resolution). */
+  explorerAuth?: QaAuthState;
+  /** What started this session. Absent = "manual". */
+  explorerTrigger?: ExplorerSessionTrigger;
+  /** True when the stuck-loop heuristic ended the loop early. */
+  explorerStuck?: boolean;
   [key: string]: unknown;
 }
 
@@ -3337,6 +3482,185 @@ export const qaAgentTriggers = pgTable("qa_agent_triggers", {
 
 export type QaAgentTrigger = typeof qaAgentTriggers.$inferSelect;
 export type NewQaAgentTrigger = typeof qaAgentTriggers.$inferInsert;
+
+// ── Explorer Agent tables ────────────────────────────────────────────────────
+
+export type KnowledgeMatchKind = "exact" | "prefix" | "regex";
+
+/** One deterministic pre-step executed when a knowledge note matches a page
+ *  (dismiss a cookie banner, open a menu) before the AI takes over. */
+export interface KnowledgePageAutomationStep {
+  action: "click" | "fill" | "waitForSelector" | "wait";
+  selector?: string;
+  value?: string;
+}
+
+/** Human-provided hints the explorer loads when a page's URL matches
+ *  (explorbot's `knowledge/` directory, DB-backed for repo scoping +
+ *  credential encryption). Body is markdown injected into planner/tester
+ *  prompts verbatim. */
+export const agentKnowledge = pgTable(
+  "agent_knowledge",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    repositoryId: text("repository_id")
+      .references(() => repositories.id, { onDelete: "cascade" })
+      .notNull(),
+    teamId: text("team_id").notNull(),
+    title: text("title").notNull(),
+    /** "/login" (exact), "/admin/*" (prefix), "^/users/\\d+$" (regex), "*" = all. */
+    urlPattern: text("url_pattern").notNull(),
+    matchKind: text("match_kind")
+      .$type<KnowledgeMatchKind>()
+      .notNull()
+      .default("prefix"),
+    /** Markdown hint text (quirks, test data, form rules, navigation notes). */
+    body: text("body").notNull(),
+    /** Optional page-scoped credentials. Password encrypted at rest via the
+     *  agent-knowledge query layer (crypto-fields.ts); email stays plaintext
+     *  (low-sensitivity identifier). */
+    credEmail: text("cred_email"),
+    credPassword: text("cred_password"),
+    pageAutomation:
+      jsonb("page_automation").$type<KnowledgePageAutomationStep[]>(),
+    enabled: boolean("enabled").notNull().default(true),
+    createdById: text("created_by_id"),
+    createdAt: timestamp("created_at").$defaultFn(() => new Date()),
+    updatedAt: timestamp("updated_at").$defaultFn(() => new Date()),
+  },
+  (table) => [index("idx_agent_knowledge_repo").on(table.repositoryId)],
+);
+
+export type AgentKnowledge = typeof agentKnowledge.$inferSelect;
+export type NewAgentKnowledge = typeof agentKnowledge.$inferInsert;
+
+export type ExperienceNoteKind = "resolution" | "failure" | "observation";
+
+export interface ExperienceNote {
+  kind: ExperienceNoteKind;
+  text: string;
+  scenarioStyle?: ExplorerStyle;
+  sessionId?: string;
+  /** ISO timestamp. */
+  at: string;
+}
+
+/** What the explorer learned by doing (explorbot's `experience/` directory):
+ *  failed attempts, working resolutions, observations — keyed by page state
+ *  (normalized URL + h1/h2 headings hash) and reused on later runs. */
+export const agentExperience = pgTable(
+  "agent_experience",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    repositoryId: text("repository_id")
+      .references(() => repositories.id, { onDelete: "cascade" })
+      .notNull(),
+    teamId: text("team_id").notNull(),
+    /** hashState(normalizedUrl, headings) — see src/lib/explorer/state.ts. */
+    stateHash: text("state_hash").notNull(),
+    normalizedUrl: text("normalized_url").notNull(),
+    /** Human-readable h1/h2 digest for the experience viewer. */
+    headingsDigest: text("headings_digest"),
+    notes: jsonb("notes").$type<ExperienceNote[]>().notNull(),
+    timesVisited: integer("times_visited").notNull().default(1),
+    lastSessionId: text("last_session_id"),
+    createdAt: timestamp("created_at").$defaultFn(() => new Date()),
+    updatedAt: timestamp("updated_at").$defaultFn(() => new Date()),
+  },
+  (table) => [
+    uniqueIndex("uq_agent_experience_repo_state").on(
+      table.repositoryId,
+      table.stateHash,
+    ),
+  ],
+);
+
+export type AgentExperience = typeof agentExperience.$inferSelect;
+export type NewAgentExperience = typeof agentExperience.$inferInsert;
+
+export interface AgentFindingEvidence {
+  screenshotPaths?: string[];
+  consoleErrors?: string[];
+  failedRequests?: Array<{ url: string; status: number; method: string }>;
+  /** Action steps that led to the finding (from the scenario's action log). */
+  actionSteps?: ExplorerActionStep[];
+}
+
+/** A defect or UX issue the explorer observed. Clustered by root cause by the
+ *  analyst step; promotable to a bug_report, keepable as a test. Distinct from
+ *  bug_reports (user-scoped, extension-shaped context) by design. */
+export const agentFindings = pgTable(
+  "agent_findings",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    repositoryId: text("repository_id")
+      .references(() => repositories.id, { onDelete: "cascade" })
+      .notNull(),
+    teamId: text("team_id").notNull(),
+    /** agent_sessions.id of the explorer run that produced it. */
+    sessionId: text("session_id").notNull(),
+    kind: text("kind").$type<ExplorerFindingKind>().notNull().default("defect"),
+    severity: text("severity")
+      .$type<ExplorerSeverity>()
+      .notNull()
+      .default("medium"),
+    title: text("title").notNull(),
+    description: text("description").notNull(),
+    /** Set by the analyst step — findings sharing a root cause share a label. */
+    rootCauseCluster: text("root_cause_cluster"),
+    pageStateHash: text("page_state_hash"),
+    url: text("url"),
+    scenario: jsonb("scenario").$type<ExplorerScenario>(),
+    evidence: jsonb("evidence").$type<AgentFindingEvidence>(),
+    status: text("status")
+      .$type<ExplorerFindingStatus>()
+      .notNull()
+      .default("open"),
+    /** bug_reports.id when promoted. */
+    bugReportId: text("bug_report_id"),
+    createdAt: timestamp("created_at").$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("idx_agent_findings_session").on(table.sessionId),
+    index("idx_agent_findings_repo").on(table.repositoryId),
+  ],
+);
+
+export type AgentFinding = typeof agentFindings.$inferSelect;
+export type NewAgentFinding = typeof agentFindings.$inferInsert;
+
+/** Per-repo automation config for the explorer agent (mirror of
+ *  qa_agent_triggers, cron-only — explorer runs are app-facing, not
+ *  PR-facing). One row per repository. */
+export const explorerTriggers = pgTable("explorer_triggers", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  repositoryId: text("repository_id")
+    .references(() => repositories.id, { onDelete: "cascade" })
+    .notNull()
+    .unique(),
+  teamId: text("team_id").notNull(),
+  scheduleEnabled: boolean("schedule_enabled").notNull().default(false),
+  /** Cron schedule (5-field expression, UTC). */
+  cronExpression: text("cron_expression"),
+  /** Iteration budget for scheduled runs. */
+  maxIterations: integer("max_iterations").notNull().default(4),
+  nextRunAt: timestamp("next_run_at"),
+  lastRunAt: timestamp("last_run_at"),
+  lastSessionId: text("last_session_id"),
+  createdAt: timestamp("created_at").$defaultFn(() => new Date()),
+  updatedAt: timestamp("updated_at").$defaultFn(() => new Date()),
+});
+
+export type ExplorerTrigger = typeof explorerTriggers.$inferSelect;
+export type NewExplorerTrigger = typeof explorerTriggers.$inferInsert;
 
 // ── Bug Reports ──────────────────────────────────────────────────────────────
 
@@ -3813,7 +4137,8 @@ export type ActivitySourceType =
   | "mcp_server"
   | "generate_agent"
   | "heal_agent"
-  | "qa_agent";
+  | "qa_agent"
+  | "explorer_agent";
 
 export type ActivityArtifactType =
   | "test"

--- a/src/lib/explorer/analyst.ts
+++ b/src/lib/explorer/analyst.ts
@@ -1,0 +1,159 @@
+import { generateWithAI } from "@/lib/ai";
+import type { AIProviderConfig } from "@/lib/ai";
+import { parseAiJson } from "@/lib/ai/json-parse";
+import type {
+  AgentFinding,
+  ExplorerFindingKind,
+  ExplorerReport,
+  ExplorerSeverity,
+} from "@/lib/db/schema";
+
+/**
+ * Explorer analyst: one AI call at session end clustering raw findings by
+ * root cause (three failures on one control = one defect), refining severity,
+ * and writing the session assessment. Deterministic fallback: every finding
+ * becomes its own cluster.
+ */
+
+const ANALYST_SYSTEM_PROMPT = `You are a QA analyst reviewing raw findings from an exploratory testing session.
+Cluster findings that share a single root cause (e.g. three validation failures on one form = one defect). Separate real product defects from UX friction.
+Respond with JSON only:
+{"assessment": string, "clusters": [{"rootCause": string, "severity": "critical"|"high"|"medium"|"low"|"info", "kind": "defect"|"ux", "findingIds": string[], "summary": string}]}
+Every finding id must appear in exactly one cluster. The assessment is 2-4 sentences on overall app quality observed.`;
+
+const SEVERITIES: ExplorerSeverity[] = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "info",
+];
+const KINDS: ExplorerFindingKind[] = ["defect", "ux"];
+
+interface AnalystOutput {
+  assessment?: string;
+  clusters: Array<Record<string, unknown>>;
+}
+
+function isAnalystOutput(value: unknown): value is AnalystOutput {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    Array.isArray((value as { clusters?: unknown }).clusters)
+  );
+}
+
+function fallbackReport(
+  findings: AgentFinding[],
+  iterationsRun: number,
+): ExplorerReport {
+  return {
+    clusters: findings.map((f) => ({
+      rootCause: f.title.slice(0, 120),
+      severity: f.severity,
+      kind: f.kind,
+      findingIds: [f.id],
+      summary: f.description.slice(0, 300),
+    })),
+    totalFindings: findings.length,
+    iterationsRun,
+  };
+}
+
+export async function clusterFindings(
+  config: AIProviderConfig,
+  input: {
+    findings: AgentFinding[];
+    iterationsRun: number;
+    repositoryId: string;
+    signal?: AbortSignal;
+  },
+): Promise<ExplorerReport> {
+  if (input.findings.length === 0) {
+    return {
+      clusters: [],
+      totalFindings: 0,
+      iterationsRun: input.iterationsRun,
+      assessment:
+        "No defects or UX issues were observed during this exploration.",
+    };
+  }
+
+  const digest = input.findings
+    .map(
+      (f) =>
+        `id=${f.id} [${f.severity}/${f.kind}] "${f.title}" @ ${f.url ?? "?"}\n  ${f.description.replace(/\s+/g, " ").slice(0, 300)}`,
+    )
+    .join("\n");
+
+  let parsed: AnalystOutput | null = null;
+  try {
+    const raw = await generateWithAI(
+      config,
+      `FINDINGS (${input.findings.length}):\n${digest}\n\nCluster by root cause. JSON only.`,
+      ANALYST_SYSTEM_PROMPT,
+      {
+        actionType: "explorer_analyze",
+        repositoryId: input.repositoryId,
+        responseFormat: "json_object",
+        signal: input.signal,
+      },
+    );
+    parsed = parseAiJson(raw, isAnalystOutput, { source: "explorer-analyst" });
+  } catch {
+    parsed = null;
+  }
+  if (!parsed) return fallbackReport(input.findings, input.iterationsRun);
+
+  const validIds = new Set(input.findings.map((f) => f.id));
+  const assigned = new Set<string>();
+  const clusters: ExplorerReport["clusters"] = [];
+
+  for (const c of parsed.clusters) {
+    const ids = Array.isArray(c.findingIds)
+      ? c.findingIds.filter(
+          (id): id is string =>
+            typeof id === "string" && validIds.has(id) && !assigned.has(id),
+        )
+      : [];
+    if (ids.length === 0) continue;
+    ids.forEach((id) => assigned.add(id));
+    clusters.push({
+      rootCause:
+        typeof c.rootCause === "string"
+          ? c.rootCause.slice(0, 160)
+          : "Unclustered",
+      severity: SEVERITIES.includes(c.severity as ExplorerSeverity)
+        ? (c.severity as ExplorerSeverity)
+        : "medium",
+      kind: KINDS.includes(c.kind as ExplorerFindingKind)
+        ? (c.kind as ExplorerFindingKind)
+        : "defect",
+      findingIds: ids,
+      summary: typeof c.summary === "string" ? c.summary.slice(0, 400) : "",
+    });
+  }
+
+  // Findings the model forgot get singleton clusters — nothing is dropped.
+  for (const f of input.findings) {
+    if (!assigned.has(f.id)) {
+      clusters.push({
+        rootCause: f.title.slice(0, 120),
+        severity: f.severity,
+        kind: f.kind,
+        findingIds: [f.id],
+        summary: f.description.slice(0, 300),
+      });
+    }
+  }
+
+  return {
+    clusters,
+    totalFindings: input.findings.length,
+    iterationsRun: input.iterationsRun,
+    assessment:
+      typeof parsed.assessment === "string"
+        ? parsed.assessment.slice(0, 1000)
+        : undefined,
+  };
+}

--- a/src/lib/explorer/config.ts
+++ b/src/lib/explorer/config.ts
@@ -1,0 +1,32 @@
+import type { AIProviderConfig } from "@/lib/ai";
+import { getAIConfig } from "@/lib/playwright/agent-context";
+import type * as queries from "@/lib/db/queries";
+
+/**
+ * Explorer AI config: the repo's normal AI config with the optional
+ * `explorerModel` override applied to the active provider. The explorer loop
+ * makes many small calls (one per tester turn), so pointing it at a cheaper,
+ * faster model than test generation is often the right trade — explorbot's
+ * "cheap workers" principle.
+ */
+export function explorerConfigFromSettings(
+  settings: Awaited<ReturnType<typeof queries.getAISettings>>,
+): AIProviderConfig {
+  const config = getAIConfig(settings);
+  const model = settings.explorerModel?.trim();
+  if (!model) return config;
+  switch (config.provider) {
+    case "openrouter":
+      return { ...config, openrouterModel: model };
+    case "anthropic":
+      return { ...config, anthropicModel: model };
+    case "openai":
+      return { ...config, openaiModel: model };
+    case "ollama":
+      return { ...config, ollamaModel: model };
+    case "claude-agent-sdk":
+      return { ...config, agentSdkModel: model };
+    default:
+      return config;
+  }
+}

--- a/src/lib/explorer/coverage.ts
+++ b/src/lib/explorer/coverage.ts
@@ -1,0 +1,64 @@
+import * as queries from "@/lib/db/queries";
+
+/**
+ * Coverage digest: what's already tested/known, injected into the explorer
+ * planner so it skips covered ground (explorbot's "skips scenarios you
+ * already have"). Deterministic and cheap — names/titles only, hard-capped.
+ */
+
+const MAX_TESTS = 60;
+const MAX_FINDINGS = 40;
+const MAX_PLANS = 12;
+
+export async function buildCoverageDigest(
+  repositoryId: string,
+): Promise<string> {
+  const [tests, findings, areas] = await Promise.all([
+    queries.getTestsByRepo(repositoryId),
+    queries.listFindingsByRepo(repositoryId, { limit: MAX_FINDINGS }),
+    queries.getFunctionalAreasTree(repositoryId),
+  ]);
+
+  const sections: string[] = [];
+
+  if (tests.length > 0) {
+    sections.push(
+      `EXISTING TESTS (${tests.length} total — do not re-plan these flows):\n` +
+        tests
+          .slice(0, MAX_TESTS)
+          .map((t) => `- ${t.name}${t.targetUrl ? ` (${t.targetUrl})` : ""}`)
+          .join("\n"),
+    );
+  }
+
+  if (findings.length > 0) {
+    sections.push(
+      `KNOWN FINDINGS (already reported — do not re-discover):\n` +
+        findings
+          .map(
+            (f) => `- [${f.severity}] ${f.title}${f.url ? ` @ ${f.url}` : ""}`,
+          )
+          .join("\n"),
+    );
+  }
+
+  // Flatten the area tree — plans can live on nested areas.
+  const flat: Array<{ name: string; agentPlan: string | null }> = [];
+  const walk = (nodes: typeof areas) => {
+    for (const node of nodes) {
+      flat.push({ name: node.name, agentPlan: node.agentPlan });
+      if (node.children?.length) walk(node.children);
+    }
+  };
+  walk(areas);
+
+  const plans = flat
+    .filter((a) => a.agentPlan)
+    .slice(0, MAX_PLANS)
+    .map((a) => `- ${a.name}: ${(a.agentPlan ?? "").slice(0, 200)}`);
+  if (plans.length > 0) {
+    sections.push(`AREA TEST PLANS (existing intent):\n${plans.join("\n")}`);
+  }
+
+  return sections.join("\n\n") || "(no existing coverage)";
+}

--- a/src/lib/explorer/keep.test.ts
+++ b/src/lib/explorer/keep.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { renderKeptTestCode, isKeepable } from "./keep";
+import type { ExplorerActionLog, ExplorerScenario } from "@/lib/db/schema";
+
+const scenario: ExplorerScenario = {
+  id: "it0-s0-abc",
+  title: "Create a project",
+  style: "normal",
+  steps: ["Open the form", "Fill the name", "Submit"],
+  rationale: "Core CRUD flow",
+  expectedOutcome: "Project appears in the list",
+};
+
+const log: ExplorerActionLog = {
+  scenarioId: scenario.id,
+  status: "passed",
+  steps: [
+    {
+      intent: "Open the create form",
+      action: "click",
+      selector: '[data-testid="new-project"]',
+      result: "ok",
+    },
+    {
+      intent: "Fill the project name",
+      action: "fill",
+      selector: "#name",
+      value: "Explorer Test",
+      result: "ok",
+    },
+    {
+      intent: "Try a dead-end button",
+      action: "click",
+      selector: "#nope",
+      result: "error",
+      note: "timeout",
+    },
+    { intent: "Submit", action: "press", value: "Enter", result: "ok" },
+  ],
+  summary: "Project visible in list",
+};
+
+describe("renderKeptTestCode", () => {
+  it("emits the runner contract signature", () => {
+    const code = renderKeptTestCode(scenario, log, "https://app.io/projects");
+    expect(code).toContain(
+      "export async function test(page, baseUrl, screenshotPath, stepLogger)",
+    );
+    expect(code).toContain('await page.goto("https://app.io/projects"');
+  });
+
+  it("replays only successful steps with stepLogger lines", () => {
+    const code = renderKeptTestCode(scenario, log, "https://app.io/");
+    expect(code).toContain('stepLogger.log("Open the create form")');
+    expect(code).toContain('.fill("Explorer Test"');
+    expect(code).toContain('keyboard.press("Enter")');
+    expect(code).not.toContain("#nope");
+  });
+
+  it("escapes quotes safely", () => {
+    const tricky: ExplorerActionLog = {
+      ...log,
+      steps: [
+        {
+          intent: 'Click "Save"',
+          action: "click",
+          selector: 'text=Say "hi"',
+          result: "ok",
+        },
+        { intent: "Confirm", action: "press", value: "Enter", result: "ok" },
+      ],
+    };
+    const code = renderKeptTestCode(scenario, tricky, "https://app.io/");
+    expect(code).toContain('text=Say \\"hi\\"');
+  });
+});
+
+describe("isKeepable", () => {
+  it("keeps passing logs with at least two ok steps", () => {
+    expect(isKeepable(log)).toBe(true);
+  });
+
+  it("rejects failed or trivial logs", () => {
+    expect(isKeepable({ ...log, status: "failed" })).toBe(false);
+    expect(isKeepable({ ...log, steps: [log.steps[0]] })).toBe(false);
+  });
+});

--- a/src/lib/explorer/keep.ts
+++ b/src/lib/explorer/keep.ts
@@ -1,0 +1,120 @@
+import type {
+  ExplorerActionLog,
+  ExplorerActionStep,
+  ExplorerScenario,
+} from "@/lib/db/schema";
+
+/**
+ * Keep-as-test: render a passing exploratory scenario's action log into a
+ * runnable test in the runner contract format
+ * (`export async function test(page, baseUrl, screenshotPath, stepLogger)`).
+ * Deterministic — the explorer's log already carries verified selectors and
+ * values, so no AI (and no request auth context) is needed in the detached
+ * pipeline. Generated tests are created quarantined for human review.
+ */
+
+function jsString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function lineFor(step: ExplorerActionStep): string[] {
+  const sel = step.selector ? jsString(step.selector) : null;
+  switch (step.action) {
+    case "click":
+      return sel
+        ? [`await page.locator(${sel}).first().click({ timeout: 10000 });`]
+        : [];
+    case "fill":
+      return sel
+        ? [
+            `await page.locator(${sel}).first().fill(${jsString(step.value ?? "")}, { timeout: 10000 });`,
+          ]
+        : [];
+    case "select":
+      return sel
+        ? [
+            `await page.locator(${sel}).first().selectOption(${jsString(step.value ?? "")}, { timeout: 10000 });`,
+          ]
+        : [];
+    case "press":
+      return [`await page.keyboard.press(${jsString(step.value || "Enter")});`];
+    case "navigate":
+      return [
+        `await page.goto(new URL(${jsString(step.value ?? "/")}, baseUrl).href, { waitUntil: 'domcontentloaded' });`,
+      ];
+    case "wait":
+      return [
+        `await page.waitForTimeout(${Math.min(Number(step.value ?? 1) * 1000, 8000)});`,
+      ];
+    default:
+      return [];
+  }
+}
+
+export function renderKeptTestCode(
+  scenario: ExplorerScenario,
+  log: ExplorerActionLog,
+  targetUrl: string,
+): string {
+  const body: string[] = [];
+  let shotIndex = 1;
+
+  // Only replay actions that succeeded — blocked/error steps were dead ends
+  // the tester recovered from, not part of the passing flow.
+  const steps = log.steps.filter((s) => s.result === "ok");
+
+  for (const step of steps) {
+    const code = lineFor(step);
+    if (code.length === 0) continue;
+    body.push(`  stepLogger.log(${jsString(step.intent || step.action)});`);
+    for (const line of code) body.push(`  ${line}`);
+    body.push(`  await settle();`);
+    // Screenshot checkpoints after state-changing actions.
+    if (["click", "navigate", "press", "select"].includes(step.action)) {
+      body.push(
+        `  await page.screenshot({ path: shot(${shotIndex}, ${jsString(
+          step.action,
+        )}), fullPage: true });`,
+      );
+      shotIndex++;
+    }
+    body.push("");
+  }
+
+  const header = [
+    `// Kept by the Explorer agent from a passing exploratory scenario.`,
+    `// Scenario: ${scenario.title.replace(/\n/g, " ")}`,
+    scenario.expectedOutcome
+      ? `// Expected outcome: ${scenario.expectedOutcome.replace(/\n/g, " ")}`
+      : null,
+    log.summary ? `// Observed: ${log.summary.replace(/\n/g, " ")}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return `${header}
+export async function test(page, baseUrl, screenshotPath, stepLogger) {
+  const shot = (n, slug) => screenshotPath.replace('.png', \`-\${n}-\${slug}.png\`);
+  async function settle() {
+    await page.waitForLoadState('networkidle', { timeout: 3000 }).catch(function () {});
+    await page.waitForTimeout(300);
+  }
+
+  stepLogger.log('Open target page');
+  await page.goto(${jsString(targetUrl)}, { waitUntil: 'domcontentloaded' });
+  await settle();
+  await page.screenshot({ path: shot(0, 'start'), fullPage: true });
+
+${body.join("\n")}
+  await page.screenshot({ path: shot(${shotIndex}, 'end'), fullPage: true });
+}
+`;
+}
+
+/** A log is keepable when it passed and actually did something replayable. */
+export function isKeepable(log: ExplorerActionLog): boolean {
+  return (
+    log.status === "passed" &&
+    log.steps.filter((s) => s.result === "ok").length >= 2
+  );
+}

--- a/src/lib/explorer/knowledge.ts
+++ b/src/lib/explorer/knowledge.ts
@@ -1,0 +1,63 @@
+import type { AgentKnowledge, AgentExperience } from "@/lib/db/schema";
+
+/**
+ * Prompt-injection helpers for the two explorer memory systems: knowledge
+ * (human hints) and experience (agent-learned notes). Both render to capped
+ * markdown blocks the planner/tester prompts embed verbatim.
+ *
+ * SECURITY: credentials are NEVER rendered here. Matched credentials flow
+ * through the deterministic login path (attemptLogin) only — they must not
+ * appear in prompts or aiPromptLogs.
+ */
+
+const MAX_KNOWLEDGE_CHARS = 4000;
+const MAX_EXPERIENCE_CHARS = 3000;
+
+export function renderKnowledgeBlock(notes: AgentKnowledge[]): string {
+  if (notes.length === 0) return "";
+  let block = "";
+  for (const note of notes) {
+    const entry = `### ${note.title} (matches ${note.urlPattern})\n${note.body.trim()}\n\n`;
+    if (block.length + entry.length > MAX_KNOWLEDGE_CHARS) break;
+    block += entry;
+  }
+  return block
+    ? `OPERATOR KNOWLEDGE for this page (authoritative hints — follow them):\n${block.trim()}`
+    : "";
+}
+
+export function renderExperienceBlock(rows: AgentExperience[]): string {
+  const lines: string[] = [];
+  let total = 0;
+  for (const row of rows) {
+    for (const note of row.notes.slice(-8)) {
+      const line = `- [${note.kind}] ${note.text.replace(/\s+/g, " ").slice(0, 240)}`;
+      if (total + line.length > MAX_EXPERIENCE_CHARS) break;
+      lines.push(line);
+      total += line.length;
+    }
+  }
+  return lines.length > 0
+    ? `LEARNED EXPERIENCE from previous runs on this page state (reuse what worked, avoid what failed):\n${lines.join("\n")}`
+    : "";
+}
+
+/** First matched note carrying credentials — the deterministic login input. */
+export function pickKnowledgeCredentials(
+  notes: AgentKnowledge[],
+): { email: string; password: string } | null {
+  for (const note of notes) {
+    if (note.credPassword) {
+      return { email: note.credEmail ?? "", password: note.credPassword };
+    }
+  }
+  return null;
+}
+
+/** Concatenated page-automation steps from matched notes (execution order =
+ *  note recency order as returned by the matcher). */
+export function collectPageAutomation(
+  notes: AgentKnowledge[],
+): NonNullable<AgentKnowledge["pageAutomation"]> {
+  return notes.flatMap((n) => n.pageAutomation ?? []).slice(0, 12);
+}

--- a/src/lib/explorer/planner.ts
+++ b/src/lib/explorer/planner.ts
@@ -1,0 +1,116 @@
+import { generateWithAI } from "@/lib/ai";
+import type { AIProviderConfig } from "@/lib/ai";
+import { parseAiJson } from "@/lib/ai/json-parse";
+import type { ExplorerScenario, ExplorerStyle } from "@/lib/db/schema";
+import type { RangerPageMap } from "@/lib/playwright/ranger";
+import { condensePageMap } from "./research";
+import { STYLE_FRAGMENTS } from "./styles";
+import { MAX_SCENARIOS_PER_ITERATION } from "./supervisor";
+
+/**
+ * Explorer planner: one AI call per iteration turning the current page map
+ * (+ memory + coverage) into a handful of exploratory scenarios in the
+ * iteration's planning style. No browser access — plain JSON generation.
+ */
+
+const PLANNER_SYSTEM_PROMPT = `You are an exploratory QA planner. Given a rendered page map of a web app, draft test scenarios a skilled manual tester would run RIGHT NOW on this page.
+
+Rules:
+- Base scenarios ONLY on elements listed in the page map. Never invent controls.
+- Each scenario is 2-6 concrete steps a tester performs on THIS page (navigation to a directly-linked page is allowed).
+- Every scenario states an expected outcome that can be verified from the UI.
+- Skip anything the coverage section already covers — mark nothing twice.
+- NEVER plan destructive account-level actions (delete account, cancel subscription) or real payments.
+- Respond with JSON only: {"scenarios": [{"title": string, "steps": string[], "rationale": string, "expectedOutcome": string}]}
+- At most ${MAX_SCENARIOS_PER_ITERATION} scenarios. Fewer, sharper scenarios beat many shallow ones.`;
+
+export interface PlanScenariosInput {
+  pageMap: RangerPageMap;
+  style: ExplorerStyle;
+  iteration: number;
+  knowledgeBlock: string;
+  experienceBlock: string;
+  coverageDigest: string;
+  /** Titles of scenarios already executed this session (avoid repeats). */
+  priorScenarioTitles: string[];
+  repositoryId: string;
+  signal?: AbortSignal;
+  onLogCreated?: (logId: string) => void;
+}
+
+function isPlannerOutput(
+  value: unknown,
+): value is { scenarios: Array<Record<string, unknown>> } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    Array.isArray((value as { scenarios?: unknown }).scenarios)
+  );
+}
+
+export async function planScenarios(
+  config: AIProviderConfig,
+  input: PlanScenariosInput,
+): Promise<ExplorerScenario[]> {
+  const sections = [
+    STYLE_FRAGMENTS[input.style],
+    `CURRENT PAGE MAP:\n${condensePageMap(input.pageMap)}`,
+  ];
+  if (input.knowledgeBlock) sections.push(input.knowledgeBlock);
+  if (input.experienceBlock) sections.push(input.experienceBlock);
+  sections.push(
+    `COVERAGE (skip what is already covered):\n${input.coverageDigest}`,
+  );
+  if (input.priorScenarioTitles.length > 0) {
+    sections.push(
+      `SCENARIOS ALREADY RUN THIS SESSION (do not repeat):\n${input.priorScenarioTitles
+        .slice(-30)
+        .map((t) => `- ${t}`)
+        .join("\n")}`,
+    );
+  }
+  sections.push(
+    `Draft up to ${MAX_SCENARIOS_PER_ITERATION} scenarios in the style above. JSON only.`,
+  );
+
+  const raw = await generateWithAI(
+    config,
+    sections.join("\n\n"),
+    PLANNER_SYSTEM_PROMPT,
+    {
+      actionType: "explorer_plan",
+      repositoryId: input.repositoryId,
+      responseFormat: "json_object",
+      signal: input.signal,
+      onLogCreated: input.onLogCreated,
+    },
+  );
+
+  const parsed = parseAiJson(raw, isPlannerOutput, {
+    source: "explorer-planner",
+  });
+  if (!parsed) return [];
+
+  return parsed.scenarios
+    .slice(0, MAX_SCENARIOS_PER_ITERATION)
+    .map((s, i): ExplorerScenario | null => {
+      const title = typeof s.title === "string" ? s.title.trim() : "";
+      const steps = Array.isArray(s.steps)
+        ? s.steps.filter((x): x is string => typeof x === "string").slice(0, 8)
+        : [];
+      if (!title || steps.length === 0) return null;
+      return {
+        id: `it${input.iteration}-s${i}-${crypto.randomUUID().slice(0, 8)}`,
+        title: title.slice(0, 160),
+        style: input.style,
+        steps,
+        rationale:
+          typeof s.rationale === "string" ? s.rationale.slice(0, 400) : "",
+        expectedOutcome:
+          typeof s.expectedOutcome === "string"
+            ? s.expectedOutcome.slice(0, 400)
+            : undefined,
+      };
+    })
+    .filter((s): s is ExplorerScenario => s !== null);
+}

--- a/src/lib/explorer/research.ts
+++ b/src/lib/explorer/research.ts
@@ -1,0 +1,106 @@
+import { browsePageMap, type RangerPageMap } from "@/lib/playwright/ranger";
+import { hashState, headingsDigest, normalizeUrl } from "./state";
+
+/**
+ * Explorer research phase: observe the current page. Pure reuse of the ranger
+ * page-map extraction (live rendered DOM over the EB's CDP endpoint) plus the
+ * page-state identity the rest of the loop keys on.
+ */
+
+export interface ResearchResult {
+  pageMap: RangerPageMap;
+  stateHash: string;
+  normalizedUrl: string;
+  headingsDigest: string;
+  headings: string[];
+}
+
+export async function researchPage(
+  cdpUrl: string,
+  url: string,
+  viewport?: { width: number; height: number },
+): Promise<ResearchResult> {
+  const pageMap = await browsePageMap(cdpUrl, url, viewport);
+  const headings = pageMap.headings.filter((h) => h.level <= 2);
+  return {
+    pageMap,
+    stateHash: hashState(pageMap.finalUrl || url, pageMap.headings),
+    normalizedUrl: normalizeUrl(pageMap.finalUrl || url),
+    headingsDigest: headingsDigest(pageMap.headings),
+    headings: headings.map((h) => h.text).slice(0, 8),
+  };
+}
+
+/** Rank the page map's same-origin links for the exploration frontier:
+ *  labeled, shallow, nav-like paths first; assets and visited states skipped.
+ *  `visited` holds normalized URLs already explored. */
+export function extractFrontierLinks(
+  map: RangerPageMap,
+  baseOrigin: string,
+  visited: Set<string>,
+  count = 5,
+): string[] {
+  const seen = new Set<string>();
+  const candidates: Array<{ url: string; score: number }> = [];
+  for (const link of map.links) {
+    let url: URL;
+    try {
+      url = new URL(link.href, map.finalUrl || map.url);
+    } catch {
+      continue;
+    }
+    if (url.origin !== baseOrigin) continue;
+    url.hash = "";
+    const normalized = normalizeUrl(url.href);
+    if (visited.has(normalized) || seen.has(normalized)) continue;
+    if (/\.(png|jpe?g|svg|css|js|pdf|zip)(\?|$)/i.test(url.pathname)) continue;
+    if (/\b(logout|signout|sign-out)\b/i.test(url.pathname)) continue;
+    seen.add(normalized);
+    const depth = url.pathname.split("/").filter(Boolean).length;
+    const score = (link.text ? 0 : 5) + depth;
+    candidates.push({ url: url.href, score });
+  }
+  candidates.sort((a, b) => a.score - b.score);
+  return candidates.slice(0, count).map((c) => c.url);
+}
+
+/** Condense a page map into the planner/tester prompt block. Caps every list
+ *  so a huge page can't blow the prompt budget. */
+export function condensePageMap(map: RangerPageMap): string {
+  const lines: string[] = [
+    `URL: ${map.finalUrl || map.url}`,
+    `Title: ${map.title ?? "(none)"}`,
+  ];
+  if (map.headings.length > 0) {
+    lines.push(
+      `Headings: ${map.headings
+        .slice(0, 10)
+        .map((h) => `h${h.level} "${h.text.slice(0, 60)}"`)
+        .join(", ")}`,
+    );
+  }
+  for (const form of map.forms.slice(0, 6)) {
+    const inputs = form.inputs
+      .slice(0, 12)
+      .map((i) => i.label || i.name || i.id || i.type || i.tag)
+      .join(", ");
+    lines.push(
+      `Form${form.name ? ` "${form.name}"` : ""} (${form.method.toUpperCase()}${form.action ? ` ${form.action}` : ""}): ${inputs}`,
+    );
+  }
+  if (map.buttons.length > 0) {
+    lines.push(`Buttons: ${map.buttons.slice(0, 25).join(" | ")}`);
+  }
+  if (map.links.length > 0) {
+    lines.push(
+      `Links: ${map.links
+        .slice(0, 30)
+        .map((l) => `"${l.text.slice(0, 40)}"→${l.href.slice(0, 60)}`)
+        .join(", ")}`,
+    );
+  }
+  if (map.testIds.length > 0) {
+    lines.push(`Test ids: ${map.testIds.slice(0, 30).join(", ")}`);
+  }
+  return lines.join("\n");
+}

--- a/src/lib/explorer/state.test.ts
+++ b/src/lib/explorer/state.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { normalizeUrl, headingsDigest, hashState } from "./state";
+
+describe("normalizeUrl", () => {
+  it("strips query, hash, and trailing slash", () => {
+    expect(normalizeUrl("https://app.io/users/?tab=all#top")).toBe(
+      "https://app.io/users",
+    );
+  });
+
+  it("collapses numeric and uuid-ish path segments to :id", () => {
+    expect(normalizeUrl("https://app.io/users/123")).toBe(
+      "https://app.io/users/:id",
+    );
+    expect(
+      normalizeUrl(
+        "https://app.io/orders/0f8fad5b-d9cb-469f-a165-70867728950e/items",
+      ),
+    ).toBe("https://app.io/orders/:id/items");
+  });
+
+  it("lowercases host and path but preserves structure", () => {
+    expect(normalizeUrl("https://App.IO/Admin/Users")).toBe(
+      "https://app.io/admin/users",
+    );
+  });
+
+  it("passes through unparseable input", () => {
+    expect(normalizeUrl("not a url")).toBe("not a url");
+  });
+});
+
+describe("headingsDigest", () => {
+  it("keeps only h1/h2, lowercased and deduped", () => {
+    expect(
+      headingsDigest([
+        { level: 1, text: "  Dashboard " },
+        { level: 2, text: "Recent Activity" },
+        { level: 2, text: "Recent Activity" },
+        { level: 3, text: "Ignored H3" },
+      ]),
+    ).toBe("dashboard | recent activity");
+  });
+
+  it("is empty for no main headings", () => {
+    expect(headingsDigest([{ level: 3, text: "x" }])).toBe("");
+  });
+});
+
+describe("hashState", () => {
+  const headings = [{ level: 1, text: "Dashboard" }];
+
+  it("is stable across query strings and id segments", () => {
+    const a = hashState("https://app.io/users/123?tab=x", headings);
+    const b = hashState("https://app.io/users/456", headings);
+    expect(a).toBe(b);
+  });
+
+  it("differs when headings differ (SPA views on one URL)", () => {
+    const a = hashState("https://app.io/app", [{ level: 1, text: "Inbox" }]);
+    const b = hashState("https://app.io/app", [{ level: 1, text: "Settings" }]);
+    expect(a).not.toBe(b);
+  });
+
+  it("is 16 hex chars", () => {
+    expect(hashState("https://app.io/", [])).toMatch(/^[0-9a-f]{16}$/);
+  });
+});

--- a/src/lib/explorer/state.ts
+++ b/src/lib/explorer/state.ts
@@ -1,0 +1,51 @@
+import { createHash } from "crypto";
+
+/**
+ * Page-state identity for the explorer agent. A "state" is the normalized URL
+ * plus the page's main headings (h1/h2) — URLs alone are insufficient because
+ * SPAs show distinct views at one location, and headings alone are ambiguous
+ * across list/detail pages. State hashes key agent_experience rows and drive
+ * stuck-loop detection (same hash repeating = the agent is going in circles).
+ */
+
+export interface StateHeading {
+  level: number;
+  text: string;
+}
+
+/** Path segments that look like opaque identifiers get collapsed to ":id" so
+ *  /users/123 and /users/456 share one state (same view, different record). */
+const ID_SEGMENT_RE = /^(\d+|[0-9a-f]{8}-[0-9a-f-]{27,}|[0-9a-f]{16,})$/i;
+
+/** Strip query/hash noise + trailing slash and collapse id-like segments. */
+export function normalizeUrl(raw: string): string {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return raw.trim().toLowerCase();
+  }
+  const segments = url.pathname
+    .split("/")
+    .filter(Boolean)
+    .map((seg) => (ID_SEGMENT_RE.test(seg) ? ":id" : seg.toLowerCase()));
+  return `${url.origin.toLowerCase()}/${segments.join("/")}`;
+}
+
+/** Lowercased, deduped h1/h2 texts — the "what view is this" signal. */
+export function headingsDigest(headings: StateHeading[]): string {
+  const main = headings
+    .filter((h) => h.level <= 2 && h.text.trim())
+    .map((h) => h.text.replace(/\s+/g, " ").trim().toLowerCase().slice(0, 80));
+  return Array.from(new Set(main)).slice(0, 8).join(" | ");
+}
+
+/** Stable state hash: sha256(normalizedUrl + "\n" + headingsDigest), hex,
+ *  truncated to 16 chars (enough for per-repo uniqueness, short enough to
+ *  read in logs). */
+export function hashState(url: string, headings: StateHeading[]): string {
+  return createHash("sha256")
+    .update(`${normalizeUrl(url)}\n${headingsDigest(headings)}`)
+    .digest("hex")
+    .slice(0, 16);
+}

--- a/src/lib/explorer/styles.test.ts
+++ b/src/lib/explorer/styles.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import {
+  nextStyle,
+  parseStyleRotation,
+  ALL_STYLES,
+  STYLE_FRAGMENTS,
+} from "./styles";
+
+describe("nextStyle", () => {
+  it("cycles the default rotation normal → curious → psycho → normal", () => {
+    expect(nextStyle(undefined, 0)).toBe("normal");
+    expect(nextStyle(undefined, 1)).toBe("curious");
+    expect(nextStyle(undefined, 2)).toBe("psycho");
+    expect(nextStyle(undefined, 3)).toBe("normal");
+  });
+
+  it("respects a custom rotation and wraps", () => {
+    expect(nextStyle(["psycho", "normal"], 0)).toBe("psycho");
+    expect(nextStyle(["psycho", "normal"], 1)).toBe("normal");
+    expect(nextStyle(["psycho", "normal"], 2)).toBe("psycho");
+  });
+
+  it("falls back to defaults on an empty rotation", () => {
+    expect(nextStyle([], 0)).toBe("normal");
+  });
+});
+
+describe("parseStyleRotation", () => {
+  it("parses the persisted comma string", () => {
+    expect(parseStyleRotation("normal,curious,psycho")).toEqual(ALL_STYLES);
+    expect(parseStyleRotation("psycho, normal")).toEqual(["psycho", "normal"]);
+  });
+
+  it("drops unknown styles and falls back when nothing survives", () => {
+    expect(parseStyleRotation("psycho,bogus")).toEqual(["psycho"]);
+    expect(parseStyleRotation("bogus")).toEqual(ALL_STYLES);
+    expect(parseStyleRotation(null)).toEqual(ALL_STYLES);
+  });
+});
+
+describe("STYLE_FRAGMENTS", () => {
+  it("has a fragment for every style", () => {
+    for (const style of ALL_STYLES) {
+      expect(STYLE_FRAGMENTS[style]).toContain("STYLE:");
+    }
+  });
+});

--- a/src/lib/explorer/styles.ts
+++ b/src/lib/explorer/styles.ts
@@ -1,0 +1,56 @@
+import type { ExplorerStyle } from "@/lib/db/schema";
+
+/**
+ * Planning styles (explorbot's normal/curious/psycho): prompt fragments that
+ * steer the scenario planner toward a different coverage angle each loop
+ * iteration. Styles rotate — iteration i uses rotation[i % rotation.length].
+ */
+
+export const ALL_STYLES: ExplorerStyle[] = ["normal", "curious", "psycho"];
+
+export const STYLE_FRAGMENTS: Record<ExplorerStyle, string> = {
+  normal: `STYLE: NORMAL — complete user workflows.
+Plan the flows a real user runs daily: CRUD operations and full commit flows
+that end in a data or state change (create the record, submit the form, save
+the setting). Every scenario must drive to a verifiable outcome — a success
+message, a new row in a list, a changed value — not just page visits.`,
+  curious: `STYLE: CURIOUS — coverage gaps and less-obvious paths.
+Hunt for what earlier scenarios and existing tests missed: secondary buttons,
+bulk/batch actions, filters and sorting, pagination edges, empty states,
+cancel/back mid-flow, keyboard-only interaction, deep links. Prefer paths that
+combine two features (filter THEN edit, search THEN bulk-select).`,
+  psycho: `STYLE: PSYCHO — adversarial inputs and stress.
+Feed every reachable control hostile input, then COMMIT the form: empty
+required fields, absurdly long strings (500+ chars), HTML/script fragments
+("<b>x</b>", "'; DROP"), negative and huge numbers, unicode/emoji, past dates
+where future is expected, double-submits, rapid repeated clicks. The app must
+respond with graceful validation — crashes, raw error pages, silent data
+corruption, or unhandled console errors are findings.`,
+};
+
+/** Style for iteration i under the given rotation (wraps; safe fallbacks). */
+export function nextStyle(
+  rotation: ExplorerStyle[] | undefined,
+  iteration: number,
+): ExplorerStyle {
+  const order =
+    rotation && rotation.length > 0
+      ? rotation.filter((s): s is ExplorerStyle => s in STYLE_FRAGMENTS)
+      : ALL_STYLES;
+  const effective = order.length > 0 ? order : ALL_STYLES;
+  return effective[
+    ((iteration % effective.length) + effective.length) % effective.length
+  ];
+}
+
+/** Parse the persisted comma-separated rotation setting ("normal,psycho"). */
+export function parseStyleRotation(
+  raw: string | null | undefined,
+): ExplorerStyle[] {
+  if (!raw) return ALL_STYLES;
+  const parsed = raw
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter((s): s is ExplorerStyle => s in STYLE_FRAGMENTS);
+  return parsed.length > 0 ? parsed : ALL_STYLES;
+}

--- a/src/lib/explorer/supervisor.test.ts
+++ b/src/lib/explorer/supervisor.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { isStuck, isActionLooping } from "./supervisor";
+
+describe("isStuck", () => {
+  it("is false for fresh exploration (all states new)", () => {
+    expect(isStuck(["a", "b", "c", "d"])).toBe(false);
+  });
+
+  it("detects a state repeating three times in the recent window", () => {
+    expect(isStuck(["a", "x", "a", "b", "a"])).toBe(true);
+  });
+
+  it("ignores repeats outside the recent window", () => {
+    expect(isStuck(["a", "a", "b", "c", "d", "e", "f", "a"])).toBe(false);
+  });
+
+  it("is false on short history", () => {
+    expect(isStuck(["a", "a"])).toBe(false);
+  });
+});
+
+describe("isActionLooping", () => {
+  it("detects the same action+selector repeating", () => {
+    const steps = [
+      { action: "click", selector: "#save" },
+      { action: "click", selector: "#save" },
+      { action: "click", selector: "#save" },
+    ];
+    expect(isActionLooping(steps)).toBe(true);
+  });
+
+  it("is false when actions vary", () => {
+    const steps = [
+      { action: "click", selector: "#save" },
+      { action: "fill", selector: "#name" },
+      { action: "click", selector: "#save" },
+    ];
+    expect(isActionLooping(steps)).toBe(false);
+  });
+});

--- a/src/lib/explorer/supervisor.ts
+++ b/src/lib/explorer/supervisor.ts
@@ -1,0 +1,44 @@
+/**
+ * Explorer supervisor: cheap deterministic heuristics that keep the loop from
+ * running in circles or burning budget (explorbot's Pilot, heuristic-first —
+ * no AI call needed for the common stuck patterns).
+ */
+
+/** A state repeating this many times within the recent window = stuck. */
+const STUCK_REPEATS = 3;
+/** How much history the stuck check considers. */
+const STUCK_WINDOW = 6;
+
+/** Hard cap on tester actions per scenario (the per-scenario step budget). */
+export const MAX_ACTIONS_PER_SCENARIO = 14;
+
+/** Hard cap on scenarios executed per iteration. */
+export const MAX_SCENARIOS_PER_ITERATION = 5;
+
+/** True when the recent state history shows the loop revisiting the same page
+ *  state over and over — research keeps landing on a state we've already
+ *  explored, so more iterations won't find new ground. */
+export function isStuck(stateHistory: string[]): boolean {
+  if (stateHistory.length < STUCK_REPEATS) return false;
+  const recent = stateHistory.slice(-STUCK_WINDOW);
+  const counts = new Map<string, number>();
+  for (const hash of recent) {
+    const n = (counts.get(hash) ?? 0) + 1;
+    if (n >= STUCK_REPEATS) return true;
+    counts.set(hash, n);
+  }
+  return false;
+}
+
+/** True when the same (action, selector) pair keeps repeating at the tail of
+ *  an action log — the tester is hammering one control without progress. */
+export function isActionLooping(
+  steps: Array<{ action: string; selector?: string }>,
+  repeats = 3,
+): boolean {
+  if (steps.length < repeats) return false;
+  const tail = steps.slice(-repeats);
+  const key = (s: { action: string; selector?: string }) =>
+    `${s.action}|${s.selector ?? ""}`;
+  return tail.every((s) => key(s) === key(tail[0]));
+}

--- a/src/lib/explorer/tester.ts
+++ b/src/lib/explorer/tester.ts
@@ -239,12 +239,25 @@ export interface RunScenarioInput {
   onStep?: (step: ExplorerActionStep, index: number) => void;
 }
 
-export async function runScenario(
+/** Scenarios in an iteration are independent, and each tester turn is a
+ *  blocking AI call — the dominant cost is model latency, not browser CPU. So
+ *  we run several scenarios at once, each in its own browser context on the
+ *  SAME Embedded Browser, to parallelize those round-trips. */
+export const SCENARIO_CONCURRENCY = 3;
+
+/** Stop a scenario early once the app has refused this many actions in a row —
+ *  the tester is thrashing against a control that won't budge, and further
+ *  turns just burn AI calls. */
+const MAX_CONSECUTIVE_FAILURES = 4;
+
+/** The core adaptive loop, run against an already-navigated-capable page.
+ *  Browser/context lifecycle is owned by the caller so scenarios can share one
+ *  CDP connection and run concurrently. */
+async function runScenarioOnPage(
   config: AIProviderConfig,
-  cdpUrl: string,
+  page: Page,
   input: RunScenarioInput,
 ): Promise<ExplorerActionLog> {
-  const browser = await chromium.connectOverCDP(cdpUrl);
   const steps: ExplorerActionStep[] = [];
   const consoleErrors: string[] = [];
   const failedRequests: ExplorerActionLog["failedRequests"] = [];
@@ -252,10 +265,9 @@ export async function runScenario(
   let summary: string | undefined;
   let finalUrl: string | undefined;
   let finalStateHash: string | undefined;
+  let consecutiveFailures = 0;
 
   try {
-    const context = browser.contexts()[0] ?? (await browser.newContext());
-    const page = context.pages()[0] ?? (await context.newPage());
     const baseOrigin = new URL(input.targetUrl).origin;
 
     page.on("console", (msg) => {
@@ -371,6 +383,14 @@ export async function runScenario(
         summary = "tester repeated the same action without progress";
         break;
       }
+
+      consecutiveFailures =
+        outcome.result === "ok" ? 0 : consecutiveFailures + 1;
+      if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+        status = "stuck";
+        summary = `app refused ${consecutiveFailures} actions in a row`;
+        break;
+      }
     }
 
     if (status === "blocked" && steps.length >= MAX_ACTIONS_PER_SCENARIO) {
@@ -388,8 +408,9 @@ export async function runScenario(
       )
       .catch(() => [] as Array<{ level: number; text: string }>);
     finalStateHash = hashState(finalUrl, headings);
-  } finally {
-    await browser.close().catch(() => {});
+  } catch (err) {
+    status = "blocked";
+    summary = err instanceof Error ? err.message.slice(0, 200) : String(err);
   }
 
   return {
@@ -402,4 +423,98 @@ export async function runScenario(
     finalUrl,
     summary,
   };
+}
+
+/** Run one scenario end-to-end on its own CDP connection + default context.
+ *  Kept for single-scenario callers and back-compat. */
+export async function runScenario(
+  config: AIProviderConfig,
+  cdpUrl: string,
+  input: RunScenarioInput,
+): Promise<ExplorerActionLog> {
+  const browser = await chromium.connectOverCDP(cdpUrl);
+  try {
+    const context = browser.contexts()[0] ?? (await browser.newContext());
+    const page = context.pages()[0] ?? (await context.newPage());
+    return await runScenarioOnPage(config, page, input);
+  } finally {
+    await browser.close().catch(() => {});
+  }
+}
+
+/**
+ * Run a batch of scenarios against one Embedded Browser with bounded
+ * concurrency. Scenario 0 runs on the EB's default (screencast) context so the
+ * live view stays watchable; the rest run in isolated contexts seeded from the
+ * default context's storage state, so authentication carries over. `onComplete`
+ * fires as each scenario finishes (completion order) for live UI updates; the
+ * returned array is in input order.
+ */
+export async function runScenariosConcurrent(
+  config: AIProviderConfig,
+  cdpUrl: string,
+  inputs: RunScenarioInput[],
+  opts: {
+    concurrency?: number;
+    signal?: AbortSignal;
+    onComplete?: (
+      log: ExplorerActionLog,
+      index: number,
+    ) => void | Promise<void>;
+  } = {},
+): Promise<ExplorerActionLog[]> {
+  const results: ExplorerActionLog[] = new Array(inputs.length);
+  if (inputs.length === 0) return results;
+
+  const browser = await chromium.connectOverCDP(cdpUrl);
+  try {
+    const defaultCtx = browser.contexts()[0] ?? (await browser.newContext());
+    const defaultPage = defaultCtx.pages()[0] ?? (await defaultCtx.newPage());
+    // Snapshot the authed session so isolated contexts start logged-in too.
+    const storageState = await defaultCtx.storageState().catch(() => undefined);
+
+    let next = 0;
+    const worker = async () => {
+      for (;;) {
+        if (opts.signal?.aborted) return;
+        const i = next++;
+        if (i >= inputs.length) return;
+        let isolatedCtx: Awaited<ReturnType<typeof browser.newContext>> | null =
+          null;
+        let page: Page;
+        if (i === 0) {
+          page = defaultPage;
+        } else {
+          isolatedCtx = await browser.newContext(
+            storageState ? { storageState } : {},
+          );
+          page = await isolatedCtx.newPage();
+        }
+        let log: ExplorerActionLog;
+        try {
+          log = await runScenarioOnPage(config, page, inputs[i]);
+        } catch (err) {
+          log = {
+            scenarioId: inputs[i].scenario.id,
+            status: "blocked",
+            steps: [],
+            summary: err instanceof Error ? err.message : String(err),
+          };
+        } finally {
+          if (isolatedCtx) await isolatedCtx.close().catch(() => {});
+        }
+        results[i] = log;
+        await opts.onComplete?.(log, i);
+      }
+    };
+
+    const poolSize = Math.min(
+      opts.concurrency ?? SCENARIO_CONCURRENCY,
+      inputs.length,
+    );
+    await Promise.all(Array.from({ length: poolSize }, () => worker()));
+  } finally {
+    await browser.close().catch(() => {});
+  }
+  return results;
 }

--- a/src/lib/explorer/tester.ts
+++ b/src/lib/explorer/tester.ts
@@ -1,0 +1,405 @@
+import { chromium, type Page } from "playwright";
+import { generateWithAI } from "@/lib/ai";
+import type { AIProviderConfig } from "@/lib/ai";
+import { parseAiJson } from "@/lib/ai/json-parse";
+import type {
+  ExplorerActionLog,
+  ExplorerActionStep,
+  ExplorerScenario,
+  KnowledgePageAutomationStep,
+} from "@/lib/db/schema";
+import { hashState } from "./state";
+import { isActionLooping, MAX_ACTIONS_PER_SCENARIO } from "./supervisor";
+
+/**
+ * Explorer tester: executes one scenario against the live EB, AI-in-the-loop.
+ * Each turn the host extracts a compact interactable snapshot of the current
+ * page, asks the model for the SINGLE next action as JSON, executes it with
+ * Playwright over CDP, and repeats until the model declares pass/fail or the
+ * step budget runs out. Strategic control stays deterministic (host-side
+ * budgets, loop detection, evidence capture); only the tactical "what next"
+ * is AI-driven — which keeps every provider supported and yields an exact
+ * action log for findings and keep-as-test.
+ */
+
+const ACTION_TIMEOUT_MS = 10_000;
+const SETTLE_TIMEOUT_MS = 5_000;
+
+const TESTER_SYSTEM_PROMPT = `You are an exploratory tester driving a real browser one action at a time.
+Each turn you get: the scenario, the actions taken so far with results, and a snapshot of the current page's interactable elements.
+Reply with JSON only — the SINGLE next action:
+{"intent": string, "action": "click"|"fill"|"select"|"press"|"navigate"|"wait"|"pass"|"fail", "selector"?: string, "value"?: string, "note"?: string}
+
+Rules:
+- selector is a CSS selector or text=... / role=... Playwright selector taken from the snapshot. Never invent selectors.
+- "fill" needs selector + value. "press" value is a key like "Enter". "navigate" value is a same-origin URL or path.
+- Use "pass" when the expected outcome is visibly achieved (note = what you observed proving it).
+- Use "fail" when the app misbehaves: broken flow, error page, wrong result, validation that should exist but doesn't (note = what went wrong, be specific).
+- If an unexpected modal/cookie banner blocks you, dismiss it first.
+- Never perform destructive account-level actions or real payments.`;
+
+interface NextAction {
+  intent: string;
+  action:
+    | "click"
+    | "fill"
+    | "select"
+    | "press"
+    | "navigate"
+    | "wait"
+    | "pass"
+    | "fail";
+  selector?: string;
+  value?: string;
+  note?: string;
+}
+
+function isNextAction(value: unknown): value is NextAction {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.intent === "string" &&
+    typeof v.action === "string" &&
+    [
+      "click",
+      "fill",
+      "select",
+      "press",
+      "navigate",
+      "wait",
+      "pass",
+      "fail",
+    ].includes(v.action)
+  );
+}
+
+/** Compact interactable-elements snapshot for the tester prompt. Distinct
+ *  from the research map: includes live visibility + current URL each turn. */
+async function snapshotInteractables(page: Page): Promise<string> {
+  const snap = await page.evaluate(() => {
+    const text = (el: Element | null): string =>
+      (el?.textContent ?? "").replace(/\s+/g, " ").trim();
+    const vis = (el: Element): boolean => {
+      const r = (el as HTMLElement).getBoundingClientRect();
+      return r.width > 0 && r.height > 0;
+    };
+    const sel = (el: Element): string => {
+      const id = el.getAttribute("id");
+      if (id) return `#${CSS.escape(id)}`;
+      const tid = el.getAttribute("data-testid");
+      if (tid) return `[data-testid="${tid}"]`;
+      const name = el.getAttribute("name");
+      if (name) return `${el.tagName.toLowerCase()}[name="${name}"]`;
+      const t = text(el).slice(0, 40);
+      if (t) return `text=${t}`;
+      return el.tagName.toLowerCase();
+    };
+    const items: string[] = [];
+    document
+      .querySelectorAll(
+        "a[href],button,[role=button],input,select,textarea,[role=tab],[role=menuitem],[role=checkbox]",
+      )
+      .forEach((el) => {
+        if (items.length >= 60 || !vis(el)) return;
+        const tag = el.tagName.toLowerCase();
+        const type = el.getAttribute("type");
+        const label =
+          text(el) ||
+          el.getAttribute("aria-label") ||
+          el.getAttribute("placeholder") ||
+          el.getAttribute("value") ||
+          "";
+        items.push(
+          `${tag}${type ? `[${type}]` : ""} "${label.slice(0, 50)}" → ${sel(el)}`,
+        );
+      });
+    const headings = Array.from(document.querySelectorAll("h1,h2"))
+      .map((h) => text(h))
+      .filter(Boolean)
+      .slice(0, 6);
+    const alerts = Array.from(
+      document.querySelectorAll(
+        '[role=alert],.error,.alert,[aria-invalid="true"]',
+      ),
+    )
+      .map((e) => text(e))
+      .filter(Boolean)
+      .slice(0, 6);
+    return { items, headings, alerts, title: document.title };
+  });
+  const lines = [
+    `URL: ${page.url()}`,
+    `Title: ${snap.title}`,
+    snap.headings.length > 0 ? `Headings: ${snap.headings.join(" | ")}` : "",
+    snap.alerts.length > 0
+      ? `Visible alerts/errors: ${snap.alerts.join(" | ")}`
+      : "",
+    `Interactable elements:\n${snap.items.map((i) => `  ${i}`).join("\n")}`,
+  ];
+  return lines.filter(Boolean).join("\n");
+}
+
+/** Deterministic pre-steps from matched knowledge notes (cookie banners etc). */
+async function runPageAutomation(
+  page: Page,
+  steps: KnowledgePageAutomationStep[],
+): Promise<void> {
+  for (const step of steps) {
+    try {
+      if (step.action === "wait") {
+        await page.waitForTimeout(
+          Math.min(Number(step.value ?? 1) * 1000, 10_000),
+        );
+      } else if (step.action === "waitForSelector" && step.selector) {
+        await page.waitForSelector(step.selector, {
+          timeout: ACTION_TIMEOUT_MS,
+        });
+      } else if (step.action === "click" && step.selector) {
+        await page.click(step.selector, { timeout: ACTION_TIMEOUT_MS });
+      } else if (step.action === "fill" && step.selector) {
+        await page.fill(step.selector, step.value ?? "", {
+          timeout: ACTION_TIMEOUT_MS,
+        });
+      }
+    } catch {
+      // Automation steps are best-effort hints, never fatal.
+    }
+  }
+}
+
+async function executeAction(
+  page: Page,
+  action: NextAction,
+  baseOrigin: string,
+): Promise<{ result: ExplorerActionStep["result"]; note?: string }> {
+  try {
+    switch (action.action) {
+      case "click":
+        if (!action.selector) return { result: "error", note: "no selector" };
+        await page
+          .locator(action.selector)
+          .first()
+          .click({ timeout: ACTION_TIMEOUT_MS });
+        break;
+      case "fill":
+        if (!action.selector) return { result: "error", note: "no selector" };
+        await page
+          .locator(action.selector)
+          .first()
+          .fill(action.value ?? "", { timeout: ACTION_TIMEOUT_MS });
+        break;
+      case "select":
+        if (!action.selector) return { result: "error", note: "no selector" };
+        await page
+          .locator(action.selector)
+          .first()
+          .selectOption(action.value ?? "", { timeout: ACTION_TIMEOUT_MS });
+        break;
+      case "press":
+        await page.keyboard.press(action.value || "Enter");
+        break;
+      case "navigate": {
+        const target = new URL(action.value ?? "/", baseOrigin);
+        if (target.origin !== baseOrigin) {
+          return { result: "blocked", note: "cross-origin navigation refused" };
+        }
+        await page.goto(target.href, {
+          waitUntil: "domcontentloaded",
+          timeout: 30_000,
+        });
+        break;
+      }
+      case "wait":
+        await page.waitForTimeout(
+          Math.min(Number(action.value ?? 1) * 1000, 8_000),
+        );
+        break;
+      default:
+        return { result: "error", note: `unknown action ${action.action}` };
+    }
+    await page
+      .waitForLoadState("networkidle", { timeout: SETTLE_TIMEOUT_MS })
+      .catch(() => {});
+    return { result: "ok" };
+  } catch (err) {
+    return {
+      result: "error",
+      note: (err instanceof Error ? err.message : String(err)).slice(0, 200),
+    };
+  }
+}
+
+export interface RunScenarioInput {
+  scenario: ExplorerScenario;
+  targetUrl: string;
+  repositoryId: string;
+  knowledgeBlock: string;
+  pageAutomation: KnowledgePageAutomationStep[];
+  signal?: AbortSignal;
+  onStep?: (step: ExplorerActionStep, index: number) => void;
+}
+
+export async function runScenario(
+  config: AIProviderConfig,
+  cdpUrl: string,
+  input: RunScenarioInput,
+): Promise<ExplorerActionLog> {
+  const browser = await chromium.connectOverCDP(cdpUrl);
+  const steps: ExplorerActionStep[] = [];
+  const consoleErrors: string[] = [];
+  const failedRequests: ExplorerActionLog["failedRequests"] = [];
+  let status: ExplorerActionLog["status"] = "blocked";
+  let summary: string | undefined;
+  let finalUrl: string | undefined;
+  let finalStateHash: string | undefined;
+
+  try {
+    const context = browser.contexts()[0] ?? (await browser.newContext());
+    const page = context.pages()[0] ?? (await context.newPage());
+    const baseOrigin = new URL(input.targetUrl).origin;
+
+    page.on("console", (msg) => {
+      if (msg.type() !== "error" || consoleErrors.length >= 15) return;
+      const text = msg.text().replace(/\s+/g, " ").trim().slice(0, 200);
+      if (text && !consoleErrors.includes(text)) consoleErrors.push(text);
+    });
+    page.on("pageerror", (err) => {
+      if (consoleErrors.length >= 15) return;
+      const text = `${err.name}: ${err.message}`.slice(0, 200);
+      if (!consoleErrors.includes(text)) consoleErrors.push(text);
+    });
+    page.on("response", (response) => {
+      try {
+        const req = response.request();
+        const type = req.resourceType();
+        if (type !== "fetch" && type !== "xhr") return;
+        if (response.status() < 400 || failedRequests.length >= 20) return;
+        const url = new URL(response.url());
+        if (url.origin !== baseOrigin) return;
+        failedRequests.push({
+          url: url.pathname.slice(0, 120),
+          status: response.status(),
+          method: req.method(),
+        });
+      } catch {
+        // Best-effort observation.
+      }
+    });
+
+    // Start each scenario from the target page in a known state.
+    await page.goto(input.targetUrl, {
+      waitUntil: "domcontentloaded",
+      timeout: 30_000,
+    });
+    await page
+      .waitForLoadState("networkidle", { timeout: SETTLE_TIMEOUT_MS })
+      .catch(() => {});
+    await runPageAutomation(page, input.pageAutomation);
+
+    for (let turn = 0; turn < MAX_ACTIONS_PER_SCENARIO; turn++) {
+      if (input.signal?.aborted) {
+        status = "blocked";
+        summary = "aborted";
+        break;
+      }
+
+      const snapshot = await snapshotInteractables(page).catch(
+        () => `URL: ${page.url()}\n(snapshot failed)`,
+      );
+      const history =
+        steps.length > 0
+          ? steps
+              .map(
+                (s, i) =>
+                  `${i + 1}. [${s.result}] ${s.action}${s.selector ? ` ${s.selector}` : ""}${s.value ? ` = "${s.value.slice(0, 40)}"` : ""} — ${s.intent}${s.note ? ` (${s.note})` : ""}`,
+              )
+              .join("\n")
+          : "(none yet)";
+
+      const prompt = [
+        `SCENARIO: ${input.scenario.title}`,
+        `Steps to perform:\n${input.scenario.steps.map((s, i) => `${i + 1}. ${s}`).join("\n")}`,
+        input.scenario.expectedOutcome
+          ? `Expected outcome: ${input.scenario.expectedOutcome}`
+          : "",
+        input.knowledgeBlock,
+        `ACTIONS TAKEN SO FAR:\n${history}`,
+        `CURRENT PAGE:\n${snapshot}`,
+        `Turn ${turn + 1}/${MAX_ACTIONS_PER_SCENARIO}. Reply with the single next action as JSON.`,
+      ]
+        .filter(Boolean)
+        .join("\n\n");
+
+      const raw = await generateWithAI(config, prompt, TESTER_SYSTEM_PROMPT, {
+        actionType: "explorer_act",
+        repositoryId: input.repositoryId,
+        responseFormat: "json_object",
+        signal: input.signal,
+      });
+      const action = parseAiJson(raw, isNextAction, {
+        source: "explorer-tester",
+      });
+      if (!action) {
+        status = "blocked";
+        summary = "tester returned unparseable action";
+        break;
+      }
+
+      if (action.action === "pass" || action.action === "fail") {
+        status = action.action === "pass" ? "passed" : "failed";
+        summary = action.note ?? action.intent;
+        break;
+      }
+
+      const outcome = await executeAction(page, action, baseOrigin);
+      const step: ExplorerActionStep = {
+        intent: action.intent.slice(0, 200),
+        action: action.action,
+        selector: action.selector?.slice(0, 200),
+        value:
+          action.action === "fill" || action.action === "select"
+            ? action.value?.slice(0, 200)
+            : action.value?.slice(0, 120),
+        result: outcome.result,
+        note: outcome.note ?? action.note?.slice(0, 200),
+      };
+      steps.push(step);
+      input.onStep?.(step, steps.length - 1);
+
+      if (isActionLooping(steps)) {
+        status = "stuck";
+        summary = "tester repeated the same action without progress";
+        break;
+      }
+    }
+
+    if (status === "blocked" && steps.length >= MAX_ACTIONS_PER_SCENARIO) {
+      status = "stuck";
+      summary = "action budget exhausted before an outcome";
+    }
+
+    finalUrl = page.url();
+    const headings = await page
+      .evaluate(() =>
+        Array.from(document.querySelectorAll("h1,h2")).map((h) => ({
+          level: Number(h.tagName[1]),
+          text: (h.textContent ?? "").replace(/\s+/g, " ").trim(),
+        })),
+      )
+      .catch(() => [] as Array<{ level: number; text: string }>);
+    finalStateHash = hashState(finalUrl, headings);
+  } finally {
+    await browser.close().catch(() => {});
+  }
+
+  return {
+    scenarioId: input.scenario.id,
+    status,
+    steps,
+    consoleErrors: consoleErrors.length > 0 ? consoleErrors : undefined,
+    failedRequests: failedRequests.length > 0 ? failedRequests : undefined,
+    finalStateHash,
+    finalUrl,
+    summary,
+  };
+}

--- a/src/lib/explorer/url-match.test.ts
+++ b/src/lib/explorer/url-match.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { matchUrlPattern } from "./url-match";
+
+const URL_BASE = "https://app.io";
+
+describe("matchUrlPattern", () => {
+  it("exact matches the path only", () => {
+    expect(matchUrlPattern("/login", "exact", `${URL_BASE}/login`)).toBe(true);
+    expect(matchUrlPattern("/login", "exact", `${URL_BASE}/login/`)).toBe(true);
+    expect(matchUrlPattern("/login", "exact", `${URL_BASE}/login/2fa`)).toBe(
+      false,
+    );
+  });
+
+  it("'*' matches every page regardless of kind", () => {
+    expect(matchUrlPattern("*", "exact", `${URL_BASE}/anything`)).toBe(true);
+    expect(matchUrlPattern("*", "prefix", `${URL_BASE}/`)).toBe(true);
+  });
+
+  it("prefix wildcard matches the base and subpaths", () => {
+    expect(matchUrlPattern("/admin/*", "prefix", `${URL_BASE}/admin`)).toBe(
+      true,
+    );
+    expect(
+      matchUrlPattern("/admin/*", "prefix", `${URL_BASE}/admin/users/3`),
+    ).toBe(true);
+    expect(
+      matchUrlPattern("/admin/*", "prefix", `${URL_BASE}/administrator`),
+    ).toBe(false);
+  });
+
+  it("bare prefix behaves like a wildcard prefix", () => {
+    expect(matchUrlPattern("/admin", "prefix", `${URL_BASE}/admin/users`)).toBe(
+      true,
+    );
+  });
+
+  it("regex matches against the path", () => {
+    expect(
+      matchUrlPattern("^/users/\\d+$", "regex", `${URL_BASE}/users/42`),
+    ).toBe(true);
+    expect(
+      matchUrlPattern("^/users/\\d+$", "regex", `${URL_BASE}/users/abc`),
+    ).toBe(false);
+  });
+
+  it("malformed regex never matches (and never throws)", () => {
+    expect(matchUrlPattern("([unclosed", "regex", `${URL_BASE}/x`)).toBe(false);
+  });
+
+  it("empty pattern never matches", () => {
+    expect(matchUrlPattern("  ", "prefix", `${URL_BASE}/x`)).toBe(false);
+  });
+});

--- a/src/lib/explorer/url-match.ts
+++ b/src/lib/explorer/url-match.ts
@@ -1,0 +1,47 @@
+import type { KnowledgeMatchKind } from "@/lib/db/schema";
+
+/**
+ * URL-pattern matching for agent_knowledge notes. Patterns match against the
+ * page's pathname (plus search for exact/prefix when the pattern includes one).
+ *
+ *   exact  — "/login" matches /login only ("*" matches everything)
+ *   prefix — "/admin/*" matches /admin and anything under it; a bare "/admin"
+ *            behaves like "/admin/*" (prefix is the forgiving default)
+ *   regex  — pattern is a RegExp tested against the full path (invalid
+ *            patterns never match — bad user input must not break the loop)
+ */
+export function matchUrlPattern(
+  pattern: string,
+  matchKind: KnowledgeMatchKind,
+  url: string,
+): boolean {
+  const trimmed = pattern.trim();
+  if (!trimmed) return false;
+  if (trimmed === "*") return true;
+
+  let path: string;
+  try {
+    const u = new URL(url);
+    path = u.pathname.replace(/\/+$/, "") || "/";
+  } catch {
+    path = url;
+  }
+
+  if (matchKind === "regex") {
+    try {
+      return new RegExp(trimmed).test(path);
+    } catch {
+      return false;
+    }
+  }
+
+  const cleaned = trimmed.replace(/\/+$/, "") || "/";
+
+  if (matchKind === "exact") {
+    return path === cleaned;
+  }
+
+  // prefix (default): "/admin/*" or bare "/admin" match /admin + subpaths.
+  const base = cleaned.endsWith("/*") ? cleaned.slice(0, -2) || "/" : cleaned;
+  return path === base || path.startsWith(base === "/" ? "/" : `${base}/`);
+}

--- a/src/lib/scheduling/scheduler.ts
+++ b/src/lib/scheduling/scheduler.ts
@@ -36,6 +36,11 @@ export function ensureSchedulerStarted() {
       console.error("[scheduler] Error processing QA agent triggers:", error);
     }
     try {
+      await processDueExplorerTriggers();
+    } catch (error) {
+      console.error("[scheduler] Error processing explorer triggers:", error);
+    }
+    try {
       await processLaunchCohorts();
     } catch (error) {
       console.error("[scheduler] Error processing launch cohorts:", error);
@@ -159,5 +164,25 @@ async function processDueQaTriggers() {
     }
   } finally {
     qaProcessing = false;
+  }
+}
+
+let explorerProcessing = false;
+
+/** Fire due explorer cron triggers. The dispatch action owns nextRunAt
+ *  advancement, busy-skip, and target-URL resolution. */
+async function processDueExplorerTriggers() {
+  if (explorerProcessing) return;
+  explorerProcessing = true;
+  try {
+    // Import dynamically to avoid circular dependencies (same as QA above).
+    const { dispatchDueExplorerTriggers } =
+      await import("@/server/actions/explorer-agent");
+    const fired = await dispatchDueExplorerTriggers();
+    if (fired > 0) {
+      console.log(`[scheduler] Started ${fired} scheduled explorer session(s)`);
+    }
+  } finally {
+    explorerProcessing = false;
   }
 }

--- a/src/server/actions/ai-settings.ts
+++ b/src/server/actions/ai-settings.ts
@@ -74,6 +74,9 @@ export async function saveAISettings(data: {
   openaiModel?: string | null;
   pwAgentModel?: string | null;
   pwAgentTimeout?: number;
+  explorerMaxIterations?: number;
+  explorerStyleRotation?: string | null;
+  explorerModel?: string | null;
 }) {
   if (data.repositoryId) await requireRepoAccess(data.repositoryId);
   else await requireTeamAccess();

--- a/src/server/actions/explorer-agent.ts
+++ b/src/server/actions/explorer-agent.ts
@@ -1,0 +1,1769 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import * as queries from "@/lib/db/queries";
+import { requireRepoAccess, requireTeamAccess } from "@/lib/auth";
+import { assertQaAgentAccess } from "@/lib/billing/feature-access";
+import { getNextRunTime, isValidCron } from "@/lib/scheduling/cron";
+import {
+  assertSafeOutboundUrl,
+  SsrfBlockedError,
+} from "@/lib/security/outbound-url";
+import { emitAndPersistActivityEvent } from "@/lib/db/queries/activity-events";
+import { claimEmbeddedBrowserForAgent } from "./ai";
+import { releasePoolEB } from "./embedded-sessions";
+import { toProxyStreamUrl } from "@/lib/eb/stream-url";
+import { appendStreamToken } from "@/lib/eb/stream-token";
+import { injectStorageStateIntoEb } from "@/lib/eb/inject-storage-state";
+import {
+  findExistingAuthSetup,
+  loginWithCredsOnEb,
+  type ExistingAuthSetup,
+} from "@/lib/qa-agent/auth";
+import {
+  researchPage,
+  extractFrontierLinks,
+  type ResearchResult,
+} from "@/lib/explorer/research";
+import { planScenarios } from "@/lib/explorer/planner";
+import { runScenario } from "@/lib/explorer/tester";
+import { clusterFindings } from "@/lib/explorer/analyst";
+import { buildCoverageDigest } from "@/lib/explorer/coverage";
+import { renderKeptTestCode, isKeepable } from "@/lib/explorer/keep";
+import { explorerConfigFromSettings } from "@/lib/explorer/config";
+import {
+  renderKnowledgeBlock,
+  renderExperienceBlock,
+  pickKnowledgeCredentials,
+  collectPageAutomation,
+} from "@/lib/explorer/knowledge";
+import { nextStyle, parseStyleRotation } from "@/lib/explorer/styles";
+import {
+  isStuck,
+  MAX_SCENARIOS_PER_ITERATION,
+} from "@/lib/explorer/supervisor";
+import type {
+  ActivityEventType,
+  AgentSession,
+  AgentSessionMetadata,
+  AgentStepId,
+  AgentStepState,
+  ExperienceNote,
+  ExplorerActionLog,
+  ExplorerScenario,
+  ExplorerSessionTrigger,
+  ExplorerStyle,
+  KnowledgePageAutomationStep,
+  NewAgentKnowledge,
+  QaAuthState,
+} from "@/lib/db/schema";
+
+/**
+ * Explorer Agent — explorbot-style autonomous exploratory testing behind the
+ * /explorer page. Where the QA agent BUILDS a suite (discover → plan →
+ * generate → execute), the explorer TESTS the app directly: an iterative
+ * research → plan → act → analyze loop that drives a live Embedded Browser,
+ * records defect/UX findings, learns per-page-state experience for later
+ * runs, and finally keeps passing flows as quarantined tests.
+ *
+ *   explorer_setup      orchestrator  preflight (target URL, AI provider)
+ *   explorer_login      orchestrator  resolve auth (existing setup / creds)
+ *   ── per iteration i (repeated step entries, AgentStepState.iteration) ──
+ *   explorer_research   explorer      map the frontier page (live DOM via EB)
+ *   explorer_plan       planner       scenarios in the rotating style
+ *   explorer_act        explorer      AI-in-the-loop scenario execution
+ *   explorer_analyze    explorer      findings + experience write-back
+ *   ──────────────────────────────────────────────────────────────────────
+ *   explorer_keep       generator     passing flows → quarantined tests
+ *   explorer_summary    orchestrator  root-cause clustering + report
+ *
+ * Memory: agent_knowledge (human hints matched by URL pattern) is injected
+ * into planner/tester prompts; agent_experience (learned notes keyed by
+ * page-state hash) accumulates across sessions. The step machine runs
+ * detached and the page polls /api/explorer-agent/[sessionId].
+ */
+
+const EXPLORER_STEP_DEFINITIONS: Array<{
+  id: AgentStepId;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: "explorer_setup",
+    label: "Preflight",
+    description: "Validate target URL and AI provider",
+  },
+  {
+    id: "explorer_login",
+    label: "Login",
+    description: "Resolve authentication — existing setup or credentials",
+  },
+  {
+    id: "explorer_research",
+    label: "Research",
+    description: "Map the current page's rendered DOM",
+  },
+  {
+    id: "explorer_plan",
+    label: "Plan",
+    description: "Draft exploratory scenarios in the iteration's style",
+  },
+  {
+    id: "explorer_act",
+    label: "Act",
+    description: "Drive the browser through each scenario, adapting live",
+  },
+  {
+    id: "explorer_analyze",
+    label: "Analyze",
+    description: "Record findings and write back learned experience",
+  },
+  {
+    id: "explorer_keep",
+    label: "Keep",
+    description: "Save passing flows as quarantined tests",
+  },
+  {
+    id: "explorer_summary",
+    label: "Summary",
+    description: "Cluster findings by root cause and write the report",
+  },
+];
+
+const LOOP_STEP_IDS: AgentStepId[] = [
+  "explorer_research",
+  "explorer_plan",
+  "explorer_act",
+  "explorer_analyze",
+];
+
+const EB_CLAIM_TIMEOUT_MS = 5 * 60 * 1000;
+const MAX_ITERATIONS_CAP = 12;
+const DEFAULT_MAX_ITERATIONS = 4;
+
+// ── In-process registries (per session) ─────────────────────────────────────
+
+const activeControllers = new Map<string, AbortController>();
+
+/** EB held across the steps of one iteration (research claims, analyze
+ *  releases). On resume after a process restart the entry is simply absent
+ *  and the next step re-claims. */
+const sessionEbs = new Map<
+  string,
+  { runnerId: string; cdpUrl: string; authApplied: boolean }
+>();
+
+function getOrCreateController(sessionId: string): AbortController {
+  let controller = activeControllers.get(sessionId);
+  if (!controller || controller.signal.aborted) {
+    controller = new AbortController();
+    activeControllers.set(sessionId, controller);
+  }
+  return controller;
+}
+
+// ── Session helpers (QA-agent conventions) ──────────────────────────────────
+
+function emitActivity(
+  teamId: string,
+  repositoryId: string,
+  sessionId: string,
+  eventType: ActivityEventType,
+  summary: string,
+  opts?: {
+    stepId?: string;
+    detail?: Record<string, unknown>;
+    artifactType?: "test" | "build";
+    artifactId?: string;
+    artifactLabel?: string;
+    durationMs?: number;
+  },
+) {
+  emitAndPersistActivityEvent({
+    teamId,
+    repositoryId,
+    sessionId,
+    sourceType: "explorer_agent",
+    eventType,
+    summary,
+    stepId: opts?.stepId ?? null,
+    agentType: "explorer",
+    detail: opts?.detail ?? null,
+    artifactType: opts?.artifactType ?? null,
+    artifactId: opts?.artifactId ?? null,
+    artifactLabel: opts?.artifactLabel ?? null,
+    durationMs: opts?.durationMs ?? null,
+    promptLogId: null,
+  }).catch((err) => console.error("[Explorer] activity emit error:", err));
+}
+
+/** Patch a step entry by ARRAY INDEX — loop step ids repeat across
+ *  iterations, so ids alone are ambiguous. */
+async function updateStepAt(
+  sessionId: string,
+  index: number,
+  update: Partial<AgentStepState>,
+) {
+  const session = await queries.getAgentSession(sessionId);
+  if (!session || !session.steps[index]) return;
+  const steps = [...session.steps];
+  steps[index] = { ...steps[index], ...update };
+  await queries.updateAgentSession(sessionId, {
+    steps,
+    currentStepId:
+      update.status === "active"
+        ? steps[index].id
+        : (session.currentStepId ?? undefined),
+  });
+}
+
+async function setStepActiveAt(sessionId: string, index: number) {
+  await updateStepAt(sessionId, index, {
+    status: "active",
+    startedAt: new Date().toISOString(),
+    error: undefined,
+  });
+}
+
+async function setStepCompletedAt(
+  sessionId: string,
+  index: number,
+  result?: Record<string, unknown>,
+) {
+  await updateStepAt(sessionId, index, {
+    status: "completed",
+    completedAt: new Date().toISOString(),
+    ...(result ? { result } : {}),
+  });
+}
+
+async function setStepFailedAt(
+  sessionId: string,
+  index: number,
+  error: string,
+) {
+  await updateStepAt(sessionId, index, {
+    status: "failed",
+    completedAt: new Date().toISOString(),
+    error,
+  });
+  await queries.updateAgentSession(sessionId, {
+    status: "failed",
+    completedAt: new Date(),
+  });
+}
+
+/** Skip every remaining loop step (stuck/budget early-exit) so the pipeline
+ *  falls through to keep/summary. */
+async function skipRemainingLoopSteps(sessionId: string, reason: string) {
+  const session = await queries.getAgentSession(sessionId);
+  if (!session) return;
+  const steps = session.steps.map((s) =>
+    LOOP_STEP_IDS.includes(s.id) && s.status === "pending"
+      ? {
+          ...s,
+          status: "skipped" as const,
+          completedAt: new Date().toISOString(),
+          result: { reason },
+        }
+      : s,
+  );
+  await queries.updateAgentSession(sessionId, { steps });
+}
+
+async function mergeMetadata(
+  sessionId: string,
+  patch: Partial<AgentSessionMetadata>,
+) {
+  const session = await queries.getAgentSession(sessionId);
+  if (!session) return;
+  await queries.updateAgentSession(sessionId, {
+    metadata: { ...session.metadata, ...patch },
+  });
+}
+
+function proxiedStream(raw: string | null | undefined): string | undefined {
+  if (!raw) return undefined;
+  const proxied = toProxyStreamUrl(raw) ?? raw;
+  return appendStreamToken(proxied, process.env.STREAM_AUTH_TOKEN) || undefined;
+}
+
+async function isStopped(
+  sessionId: string,
+  signal: AbortSignal,
+): Promise<boolean> {
+  if (signal.aborted) return true;
+  const session = await queries.getAgentSession(sessionId);
+  if (!session) return true;
+  if (session.status === "cancelled" || session.status === "paused") {
+    activeControllers.get(sessionId)?.abort();
+    return true;
+  }
+  return false;
+}
+
+function credentialsFrom(
+  metadata: AgentSessionMetadata,
+): { email: string; password: string } | undefined {
+  if (
+    metadata.credsProvided &&
+    typeof metadata.quickstartEmail === "string" &&
+    typeof metadata.quickstartPassword === "string" &&
+    metadata.quickstartEmail &&
+    metadata.quickstartPassword
+  ) {
+    return {
+      email: metadata.quickstartEmail,
+      password: metadata.quickstartPassword,
+    };
+  }
+  return undefined;
+}
+
+// ── EB lifecycle (one EB spans research → act within an iteration) ──────────
+
+async function claimSessionEb(
+  sessionId: string,
+): Promise<{ runnerId: string; cdpUrl: string; authApplied: boolean } | null> {
+  const held = sessionEbs.get(sessionId);
+  if (held) return held;
+  const eb = await claimEmbeddedBrowserForAgent(EB_CLAIM_TIMEOUT_MS, () => {
+    mergeMetadata(sessionId, { queuedForBrowser: true }).catch(() => {});
+  }).catch(() => undefined);
+  await mergeMetadata(sessionId, {
+    queuedForBrowser: false,
+    ...(eb ? { streamUrl: proxiedStream(eb.streamUrl) } : {}),
+  });
+  if (!eb) return null;
+  const entry = {
+    runnerId: eb.runnerId,
+    cdpUrl: eb.cdpUrl,
+    authApplied: false,
+  };
+  sessionEbs.set(sessionId, entry);
+  return entry;
+}
+
+async function releaseSessionEb(sessionId: string) {
+  const held = sessionEbs.get(sessionId);
+  sessionEbs.delete(sessionId);
+  await mergeMetadata(sessionId, { streamUrl: undefined }).catch(() => {});
+  if (held) await releasePoolEB(held.runnerId).catch(() => {});
+}
+
+/** Apply the resolved auth to a freshly-claimed EB: inject the storage state
+ *  when one exists, else perform a live credential login. Best-effort — a
+ *  failed application degrades to exploring the public surface. */
+async function applyAuthToEb(
+  sessionId: string,
+  eb: { cdpUrl: string; authApplied: boolean },
+  metadata: AgentSessionMetadata,
+): Promise<void> {
+  if (eb.authApplied) return;
+  eb.authApplied = true;
+  const auth = metadata.explorerAuth;
+  const targetUrl = metadata.explorerTargetUrl;
+  if (!targetUrl) return;
+  try {
+    if (auth?.storageStateId) {
+      const row = await queries
+        .getStorageState(auth.storageStateId)
+        .catch(() => null);
+      if (row?.storageStateJson) {
+        await injectStorageStateIntoEb(eb.cdpUrl, row.storageStateJson);
+        return;
+      }
+    }
+    const credentials = credentialsFrom(metadata);
+    if (credentials) {
+      await loginWithCredsOnEb({
+        cdpUrl: eb.cdpUrl,
+        targetUrl,
+        loginUrl: auth?.loginUrl,
+        credentials,
+      });
+    }
+  } catch (err) {
+    console.warn("[Explorer] auth application failed:", err);
+  }
+}
+
+// ── Steps ────────────────────────────────────────────────────────────────────
+
+async function runExplorerSetup(
+  sessionId: string,
+  teamId: string,
+  repositoryId: string,
+  stepIndex: number,
+): Promise<boolean> {
+  await setStepActiveAt(sessionId, stepIndex);
+  emitActivity(teamId, repositoryId, sessionId, "step:start", "Preflight", {
+    stepId: "explorer_setup",
+  });
+
+  const session = await queries.getAgentSession(sessionId);
+  if (!session) return false;
+  if (!session.metadata.explorerTargetUrl) {
+    await setStepFailedAt(sessionId, stepIndex, "No target URL configured");
+    return false;
+  }
+
+  const aiSettings = await queries.getAISettings(repositoryId);
+  if (!aiSettings.provider || aiSettings.provider === "none") {
+    await setStepFailedAt(
+      sessionId,
+      stepIndex,
+      "No AI provider configured — set one under Settings → AI",
+    );
+    return false;
+  }
+
+  await setStepCompletedAt(sessionId, stepIndex, {
+    targetUrl: session.metadata.explorerTargetUrl,
+    aiProvider: aiSettings.provider,
+    maxIterations: session.metadata.explorerMaxIterations,
+    styleRotation: (session.metadata.explorerStyleRotation ?? []).join(","),
+  });
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:complete",
+    `Preflight OK — AI: ${aiSettings.provider}, budget: ${session.metadata.explorerMaxIterations} iterations`,
+    { stepId: "explorer_setup" },
+  );
+  return true;
+}
+
+async function runExplorerLogin(
+  sessionId: string,
+  teamId: string,
+  repositoryId: string,
+  stepIndex: number,
+  _signal: AbortSignal,
+): Promise<boolean> {
+  await setStepActiveAt(sessionId, stepIndex);
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:start",
+    "Resolving authentication",
+    { stepId: "explorer_login" },
+  );
+
+  const session = await queries.getAgentSession(sessionId);
+  if (!session?.metadata.explorerTargetUrl) return false;
+
+  // Credentials can come from the start form or from a matched knowledge note
+  // (explorbot's credential hints). The session form wins.
+  let credentials = credentialsFrom(session.metadata);
+  if (!credentials) {
+    const notes = await queries
+      .matchKnowledgeForUrl(repositoryId, session.metadata.explorerTargetUrl)
+      .catch(() => []);
+    const fromKnowledge = pickKnowledgeCredentials(notes);
+    if (fromKnowledge?.password) {
+      credentials = fromKnowledge;
+      await mergeMetadata(sessionId, {
+        credsProvided: true,
+        quickstartEmail: fromKnowledge.email,
+        quickstartPassword: fromKnowledge.password,
+      });
+    }
+  }
+
+  const existing = await findExistingAuthSetup(repositoryId).catch(
+    (): ExistingAuthSetup => ({ defaultSetupInUse: false }),
+  );
+
+  let auth: QaAuthState;
+  if (existing.storageStateId) {
+    auth = {
+      strategy: "existing_setup",
+      validated: false,
+      storageStateId: existing.storageStateId,
+      setupTestId: existing.setupTestId,
+      defaultSetupInUse: existing.defaultSetupInUse,
+      notes: "Storage state injected into each iteration's browser",
+    };
+  } else if (credentials) {
+    auth = {
+      strategy: "creds_untested",
+      validated: false,
+      notes: "Live login performed on each iteration's browser",
+    };
+  } else {
+    auth = {
+      strategy: "public_only",
+      validated: false,
+      notes: "No credentials or setup — exploring the public surface",
+    };
+  }
+
+  await mergeMetadata(sessionId, { explorerAuth: auth });
+  await setStepCompletedAt(sessionId, stepIndex, { strategy: auth.strategy });
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:complete",
+    `Auth resolved: ${auth.strategy.replace(/_/g, " ")}`,
+    { stepId: "explorer_login" },
+  );
+  return true;
+}
+
+async function runExplorerResearch(
+  sessionId: string,
+  teamId: string,
+  repositoryId: string,
+  stepIndex: number,
+  iteration: number,
+  signal: AbortSignal,
+): Promise<boolean> {
+  await setStepActiveAt(sessionId, stepIndex);
+  const session = await queries.getAgentSession(sessionId);
+  if (!session?.metadata.explorerTargetUrl) return false;
+  const meta = session.metadata;
+  const explorerTargetUrl = session.metadata.explorerTargetUrl;
+
+  // Budget/stuck exit BEFORE claiming a browser.
+  const history = meta.explorerStateHistory ?? [];
+  if (isStuck(history)) {
+    await mergeMetadata(sessionId, { explorerStuck: true });
+    await updateStepAt(sessionId, stepIndex, {
+      status: "skipped",
+      completedAt: new Date().toISOString(),
+      result: { reason: "loop detected — same page state repeating" },
+    });
+    await skipRemainingLoopSteps(
+      sessionId,
+      "loop detected — same page state repeating",
+    );
+    emitActivity(
+      teamId,
+      repositoryId,
+      sessionId,
+      "step:complete",
+      "Exploration stopped early: the loop kept landing on the same page state",
+      { stepId: "explorer_research" },
+    );
+    return true;
+  }
+
+  const frontier = [...(meta.explorerFrontier ?? [])];
+  const visited = new Set(meta.explorerVisitedUrls ?? []);
+  const targetUrl =
+    iteration === 0
+      ? explorerTargetUrl
+      : (frontier.shift() ?? explorerTargetUrl);
+
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:start",
+    `Iteration ${iteration + 1}: researching ${targetUrl}`,
+    { stepId: "explorer_research" },
+  );
+
+  const eb = await claimSessionEb(sessionId);
+  if (!eb) {
+    await setStepFailedAt(
+      sessionId,
+      stepIndex,
+      "No embedded browser available",
+    );
+    return false;
+  }
+  if (signal.aborted) return false;
+  await applyAuthToEb(sessionId, eb, meta);
+
+  let research: ResearchResult;
+  try {
+    research = await researchPage(eb.cdpUrl, targetUrl);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    await setStepFailedAt(sessionId, stepIndex, `Research failed: ${msg}`);
+    return false;
+  }
+
+  visited.add(research.normalizedUrl);
+  const baseOrigin = new URL(explorerTargetUrl).origin;
+  const newLinks = extractFrontierLinks(research.pageMap, baseOrigin, visited);
+  const mergedFrontier = Array.from(new Set([...frontier, ...newLinks])).slice(
+    0,
+    30,
+  );
+
+  await mergeMetadata(sessionId, {
+    explorerPageMap: research.pageMap as unknown as Record<string, unknown>,
+    explorerCurrentState: {
+      hash: research.stateHash,
+      url: research.pageMap.finalUrl || targetUrl,
+      headings: research.headings,
+    },
+    explorerStateHistory: [...history, research.stateHash].slice(-20),
+    explorerFrontier: mergedFrontier,
+    explorerVisitedUrls: Array.from(visited).slice(-60),
+  });
+
+  // Record the visit (experience row exists even before any notes are learned).
+  await queries
+    .recordExperience({
+      repositoryId,
+      teamId,
+      stateHash: research.stateHash,
+      normalizedUrl: research.normalizedUrl,
+      headingsDigest: research.headingsDigest,
+      sessionId,
+    })
+    .catch((err) => console.warn("[Explorer] experience record failed:", err));
+
+  await setStepCompletedAt(sessionId, stepIndex, {
+    url: research.pageMap.finalUrl || targetUrl,
+    stateHash: research.stateHash,
+    forms: research.pageMap.forms.length,
+    buttons: research.pageMap.buttons.length,
+    links: research.pageMap.links.length,
+    frontierSize: mergedFrontier.length,
+  });
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:complete",
+    `Mapped ${research.pageMap.finalUrl || targetUrl}: ${research.pageMap.forms.length} forms, ${research.pageMap.buttons.length} buttons`,
+    { stepId: "explorer_research" },
+  );
+  return true;
+}
+
+async function runExplorerPlan(
+  sessionId: string,
+  teamId: string,
+  repositoryId: string,
+  stepIndex: number,
+  iteration: number,
+  signal: AbortSignal,
+): Promise<boolean> {
+  await setStepActiveAt(sessionId, stepIndex);
+  const session = await queries.getAgentSession(sessionId);
+  if (!session) return false;
+  const meta = session.metadata;
+  const pageMap = meta.explorerPageMap as
+    | Parameters<typeof planScenarios>[1]["pageMap"]
+    | undefined;
+  const state = meta.explorerCurrentState;
+  if (!pageMap || !state) {
+    await setStepFailedAt(
+      sessionId,
+      stepIndex,
+      "No research output to plan from",
+    );
+    return false;
+  }
+
+  const style = nextStyle(meta.explorerStyleRotation, iteration);
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:start",
+    `Iteration ${iteration + 1}: planning (${style} style)`,
+    { stepId: "explorer_plan" },
+  );
+
+  const [knowledge, experience, coverageDigest] = await Promise.all([
+    queries.matchKnowledgeForUrl(repositoryId, state.url).catch(() => []),
+    queries
+      .listExperienceByStates(repositoryId, meta.explorerStateHistory ?? [])
+      .catch(() => []),
+    buildCoverageDigest(repositoryId).catch(() => "(coverage unavailable)"),
+  ]);
+
+  const priorTitles = Object.values(meta.explorerActionLogs ?? {})
+    .map((l) => l.scenarioId)
+    .concat((meta.explorerCurrentPlan ?? []).map((s) => s.title));
+
+  const settings = await queries.getAISettings(repositoryId);
+  const config = explorerConfigFromSettings(settings);
+
+  let scenarios: ExplorerScenario[];
+  try {
+    scenarios = await planScenarios(config, {
+      pageMap,
+      style,
+      iteration,
+      knowledgeBlock: renderKnowledgeBlock(knowledge),
+      experienceBlock: renderExperienceBlock(experience),
+      coverageDigest,
+      priorScenarioTitles: priorTitles,
+      repositoryId,
+      signal,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    await setStepFailedAt(sessionId, stepIndex, `Planner failed: ${msg}`);
+    return false;
+  }
+
+  if (scenarios.length === 0) {
+    // Nothing new to try on this page — skip act/analyze for this iteration.
+    await updateStepAt(sessionId, stepIndex, {
+      status: "completed",
+      completedAt: new Date().toISOString(),
+      result: { scenarios: 0, style, note: "nothing new to plan here" },
+    });
+    await mergeMetadata(sessionId, { explorerCurrentPlan: [] });
+    emitActivity(
+      teamId,
+      repositoryId,
+      sessionId,
+      "step:complete",
+      `Iteration ${iteration + 1}: no new scenarios on this page`,
+      { stepId: "explorer_plan" },
+    );
+    return true;
+  }
+
+  await mergeMetadata(sessionId, { explorerCurrentPlan: scenarios });
+  await setStepCompletedAt(sessionId, stepIndex, {
+    scenarios: scenarios.length,
+    style,
+    titles: scenarios.map((s) => s.title),
+  });
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:complete",
+    `Iteration ${iteration + 1}: ${scenarios.length} ${style} scenarios drafted`,
+    { stepId: "explorer_plan" },
+  );
+  return true;
+}
+
+async function runExplorerAct(
+  sessionId: string,
+  teamId: string,
+  repositoryId: string,
+  stepIndex: number,
+  iteration: number,
+  signal: AbortSignal,
+): Promise<boolean> {
+  await setStepActiveAt(sessionId, stepIndex);
+  const session = await queries.getAgentSession(sessionId);
+  if (!session?.metadata.explorerTargetUrl) return false;
+  const meta = session.metadata;
+  const scenarios = (meta.explorerCurrentPlan ?? []).filter((s) => !s.skipped);
+  const state = meta.explorerCurrentState;
+
+  if (scenarios.length === 0 || !state) {
+    await updateStepAt(sessionId, stepIndex, {
+      status: "skipped",
+      completedAt: new Date().toISOString(),
+      result: { reason: "no scenarios planned" },
+    });
+    return true;
+  }
+
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:start",
+    `Iteration ${iteration + 1}: executing ${scenarios.length} scenarios`,
+    { stepId: "explorer_act" },
+  );
+
+  const eb = await claimSessionEb(sessionId);
+  if (!eb) {
+    await setStepFailedAt(
+      sessionId,
+      stepIndex,
+      "No embedded browser available",
+    );
+    return false;
+  }
+  await applyAuthToEb(sessionId, eb, meta);
+
+  const [knowledge, settings] = await Promise.all([
+    queries.matchKnowledgeForUrl(repositoryId, state.url).catch(() => []),
+    queries.getAISettings(repositoryId),
+  ]);
+  const config = explorerConfigFromSettings(settings);
+  const knowledgeBlock = renderKnowledgeBlock(knowledge);
+  const pageAutomation: KnowledgePageAutomationStep[] =
+    collectPageAutomation(knowledge);
+
+  const substeps: NonNullable<AgentStepState["substeps"]> = scenarios.map(
+    (s) => ({ label: s.title, status: "pending", agent: "explorer" }),
+  );
+  await updateStepAt(sessionId, stepIndex, { substeps: [...substeps] });
+
+  const logs: Record<string, ExplorerActionLog> = {
+    ...(meta.explorerActionLogs ?? {}),
+  };
+  const newFindingIds: string[] = [...(meta.explorerFindingIds ?? [])];
+  let passed = 0;
+  let failed = 0;
+
+  for (
+    let i = 0;
+    i < Math.min(scenarios.length, MAX_SCENARIOS_PER_ITERATION);
+    i++
+  ) {
+    if (await isStopped(sessionId, signal)) return false;
+    const scenario = scenarios[i];
+    substeps[i] = { ...substeps[i], status: "running" };
+    await updateStepAt(sessionId, stepIndex, { substeps: [...substeps] });
+
+    const startedAt = Date.now();
+    let log: ExplorerActionLog;
+    try {
+      log = await runScenario(config, eb.cdpUrl, {
+        scenario,
+        targetUrl: state.url,
+        repositoryId,
+        knowledgeBlock,
+        pageAutomation,
+        signal,
+      });
+    } catch (err) {
+      log = {
+        scenarioId: scenario.id,
+        status: "blocked",
+        steps: [],
+        summary: err instanceof Error ? err.message : String(err),
+      };
+    }
+    logs[scenario.id] = log;
+
+    // Findings: failed scenarios are defects; console/network anomalies on a
+    // passing scenario are logged as low-severity observations.
+    if (log.status === "failed") {
+      failed++;
+      const finding = await queries
+        .createAgentFinding({
+          repositoryId,
+          teamId,
+          sessionId,
+          kind: "defect",
+          severity: scenario.style === "psycho" ? "medium" : "high",
+          title: `${scenario.title} — ${log.summary?.slice(0, 100) ?? "failed"}`,
+          description: [
+            `Scenario (${scenario.style}): ${scenario.title}`,
+            scenario.expectedOutcome
+              ? `Expected: ${scenario.expectedOutcome}`
+              : null,
+            `Observed: ${log.summary ?? "the flow failed"}`,
+            `Final URL: ${log.finalUrl ?? state.url}`,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+          pageStateHash: log.finalStateHash ?? state.hash,
+          url: log.finalUrl ?? state.url,
+          scenario,
+          evidence: {
+            consoleErrors: log.consoleErrors,
+            failedRequests: log.failedRequests,
+            actionSteps: log.steps.slice(-8),
+          },
+          status: "open",
+        })
+        .catch(() => null);
+      if (finding) {
+        newFindingIds.push(finding.id);
+        emitActivity(
+          teamId,
+          repositoryId,
+          sessionId,
+          "substep:update",
+          `Finding: ${finding.title}`,
+          { stepId: "explorer_act", detail: { findingId: finding.id } },
+        );
+      }
+    } else if (
+      log.status === "passed" &&
+      ((log.consoleErrors?.length ?? 0) > 0 ||
+        (log.failedRequests?.length ?? 0) > 0)
+    ) {
+      passed++;
+      const finding = await queries
+        .createAgentFinding({
+          repositoryId,
+          teamId,
+          sessionId,
+          kind: "defect",
+          severity: "low",
+          title: `Console/network errors during "${scenario.title}"`,
+          description: [
+            `The scenario passed, but the app surfaced errors while it ran.`,
+            log.consoleErrors?.length
+              ? `Console: ${log.consoleErrors.slice(0, 5).join(" | ")}`
+              : null,
+            log.failedRequests?.length
+              ? `Failed requests: ${log.failedRequests
+                  .slice(0, 5)
+                  .map((r) => `${r.method} ${r.url} → ${r.status}`)
+                  .join(" | ")}`
+              : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+          pageStateHash: log.finalStateHash ?? state.hash,
+          url: log.finalUrl ?? state.url,
+          scenario,
+          evidence: {
+            consoleErrors: log.consoleErrors,
+            failedRequests: log.failedRequests,
+          },
+          status: "open",
+        })
+        .catch(() => null);
+      if (finding) newFindingIds.push(finding.id);
+    } else if (log.status === "passed") {
+      passed++;
+    }
+
+    substeps[i] = {
+      ...substeps[i],
+      status: log.status === "passed" ? "done" : "error",
+      detail: `${log.status}${log.summary ? ` — ${log.summary.slice(0, 120)}` : ""}`,
+      durationMs: Date.now() - startedAt,
+    };
+    await updateStepAt(sessionId, stepIndex, { substeps: [...substeps] });
+    await mergeMetadata(sessionId, {
+      explorerActionLogs: logs,
+      explorerFindingIds: newFindingIds,
+    });
+  }
+
+  await setStepCompletedAt(sessionId, stepIndex, {
+    executed: Math.min(scenarios.length, MAX_SCENARIOS_PER_ITERATION),
+    passed,
+    failed,
+  });
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:complete",
+    `Iteration ${iteration + 1}: ${passed} passed, ${failed} failed`,
+    { stepId: "explorer_act" },
+  );
+  return true;
+}
+
+async function runExplorerAnalyze(
+  sessionId: string,
+  teamId: string,
+  repositoryId: string,
+  stepIndex: number,
+  iteration: number,
+): Promise<boolean> {
+  await setStepActiveAt(sessionId, stepIndex);
+  const session = await queries.getAgentSession(sessionId);
+  if (!session) return false;
+  const meta = session.metadata;
+  const state = meta.explorerCurrentState;
+  const plan = meta.explorerCurrentPlan ?? [];
+  const logs = meta.explorerActionLogs ?? {};
+
+  // Experience write-back: what worked and what failed on this page state.
+  if (state) {
+    const notes: ExperienceNote[] = [];
+    for (const scenario of plan) {
+      const log = logs[scenario.id];
+      if (!log) continue;
+      if (log.status === "passed") {
+        notes.push({
+          kind: "resolution",
+          text: `"${scenario.title}" works${log.summary ? `: ${log.summary.slice(0, 160)}` : ""}`,
+          scenarioStyle: scenario.style,
+          sessionId,
+          at: new Date().toISOString(),
+        });
+      } else if (log.status === "failed") {
+        notes.push({
+          kind: "failure",
+          text: `"${scenario.title}" fails${log.summary ? `: ${log.summary.slice(0, 160)}` : ""}`,
+          scenarioStyle: scenario.style,
+          sessionId,
+          at: new Date().toISOString(),
+        });
+      } else if (log.status === "stuck") {
+        notes.push({
+          kind: "observation",
+          text: `"${scenario.title}" got stuck — avoid this approach`,
+          scenarioStyle: scenario.style,
+          sessionId,
+          at: new Date().toISOString(),
+        });
+      }
+    }
+    if (notes.length > 0) {
+      await queries
+        .appendExperienceNotes(repositoryId, state.hash, notes)
+        .catch((err) =>
+          console.warn("[Explorer] experience write-back failed:", err),
+        );
+    }
+  }
+
+  // The iteration is over: advance the cursor and release the EB so the pool
+  // isn't held while the next iteration queues (it re-claims).
+  await mergeMetadata(sessionId, {
+    explorerIteration: iteration + 1,
+    explorerCurrentPlan: [],
+  });
+  await releaseSessionEb(sessionId);
+
+  await setStepCompletedAt(sessionId, stepIndex, {
+    iteration: iteration + 1,
+    findingsSoFar: (meta.explorerFindingIds ?? []).length,
+  });
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:complete",
+    `Iteration ${iteration + 1} complete`,
+    { stepId: "explorer_analyze" },
+  );
+  return true;
+}
+
+async function runExplorerKeep(
+  sessionId: string,
+  teamId: string,
+  repositoryId: string,
+  stepIndex: number,
+): Promise<boolean> {
+  await setStepActiveAt(sessionId, stepIndex);
+  const session = await queries.getAgentSession(sessionId);
+  if (!session?.metadata.explorerTargetUrl) return false;
+  const meta = session.metadata;
+  const explorerTargetUrl = session.metadata.explorerTargetUrl;
+  const logs = meta.explorerActionLogs ?? {};
+
+  // Reconstruct scenario objects from findings + kept plan metadata: the
+  // authoritative copy of each executed scenario travels on its action-log
+  // finding OR the current plan; we keep a per-scenario record in the log map.
+  const allScenarios = new Map<string, ExplorerScenario>();
+  for (const f of await queries
+    .listFindingsBySession(sessionId)
+    .catch(() => [])) {
+    if (f.scenario) allScenarios.set(f.scenario.id, f.scenario);
+  }
+  for (const s of meta.explorerCurrentPlan ?? []) allScenarios.set(s.id, s);
+
+  const keepable = Object.values(logs).filter(isKeepable);
+  if (keepable.length === 0) {
+    await updateStepAt(sessionId, stepIndex, {
+      status: "completed",
+      completedAt: new Date().toISOString(),
+      result: { kept: 0, note: "no passing flows worth keeping" },
+    });
+    return true;
+  }
+
+  // All kept tests live under one "Explorer" area.
+  let areaId: string | undefined;
+  try {
+    const areas = await queries.getFunctionalAreasByRepo(repositoryId);
+    const existing = areas.find((a) => a.name === "Explorer");
+    areaId = existing
+      ? existing.id
+      : (await queries.createFunctionalArea({ repositoryId, name: "Explorer" }))
+          .id;
+  } catch (err) {
+    console.warn("[Explorer] area resolution failed:", err);
+  }
+
+  const keptIds: string[] = [];
+  for (const log of keepable) {
+    const scenario = allScenarios.get(log.scenarioId);
+    if (!scenario) continue;
+    try {
+      const code = renderKeptTestCode(
+        scenario,
+        log,
+        log.finalUrl ?? explorerTargetUrl,
+      );
+      const test = await queries.createTest({
+        repositoryId,
+        functionalAreaId: areaId,
+        name: `Explorer: ${scenario.title.slice(0, 120)}`,
+        code,
+        targetUrl: explorerTargetUrl,
+        quarantined: true,
+      });
+      keptIds.push(test.id);
+      emitActivity(
+        teamId,
+        repositoryId,
+        sessionId,
+        "artifact:created",
+        `Kept test: ${scenario.title}`,
+        {
+          stepId: "explorer_keep",
+          artifactType: "test",
+          artifactId: test.id,
+          artifactLabel: scenario.title,
+        },
+      );
+    } catch (err) {
+      console.warn("[Explorer] keep failed for scenario:", err);
+    }
+  }
+
+  await mergeMetadata(sessionId, { explorerKeptTestIds: keptIds });
+  await setStepCompletedAt(sessionId, stepIndex, { kept: keptIds.length });
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:complete",
+    `Kept ${keptIds.length} passing flows as quarantined tests`,
+    { stepId: "explorer_keep" },
+  );
+  return true;
+}
+
+async function runExplorerSummary(
+  sessionId: string,
+  teamId: string,
+  repositoryId: string,
+  stepIndex: number,
+  signal: AbortSignal,
+): Promise<boolean> {
+  await setStepActiveAt(sessionId, stepIndex);
+  const session = await queries.getAgentSession(sessionId);
+  if (!session) return false;
+  const meta = session.metadata;
+
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "step:start",
+    "Clustering findings by root cause",
+    { stepId: "explorer_summary" },
+  );
+
+  const findings = await queries
+    .listFindingsBySession(sessionId)
+    .catch(() => []);
+  const settings = await queries.getAISettings(repositoryId);
+  const config = explorerConfigFromSettings(settings);
+
+  const report = await clusterFindings(config, {
+    findings,
+    iterationsRun: meta.explorerIteration ?? 0,
+    repositoryId,
+    signal,
+  });
+
+  // Back-fill cluster labels + refined severity/kind onto the finding rows.
+  for (const cluster of report.clusters) {
+    await queries
+      .updateFindingCluster(cluster.findingIds, {
+        rootCauseCluster: cluster.rootCause,
+        severity: cluster.severity,
+        kind: cluster.kind,
+      })
+      .catch(() => {});
+  }
+
+  await mergeMetadata(sessionId, { explorerReport: report });
+  await setStepCompletedAt(sessionId, stepIndex, {
+    findings: report.totalFindings,
+    clusters: report.clusters.length,
+    iterations: report.iterationsRun,
+    kept: (meta.explorerKeptTestIds ?? []).length,
+  });
+  await queries.updateAgentSession(sessionId, {
+    status: "completed",
+    completedAt: new Date(),
+  });
+  emitActivity(
+    teamId,
+    repositoryId,
+    sessionId,
+    "session:complete",
+    `Exploration complete: ${report.totalFindings} findings in ${report.clusters.length} clusters across ${report.iterationsRun} iterations`,
+  );
+  return true;
+}
+
+// ── Pipeline driver ──────────────────────────────────────────────────────────
+
+function buildExplorerSteps(maxIterations: number): AgentStepState[] {
+  const def = (id: AgentStepId) =>
+    EXPLORER_STEP_DEFINITIONS.find((d) => d.id === id)!;
+  const steps: AgentStepState[] = [];
+  for (const id of ["explorer_setup", "explorer_login"] as AgentStepId[]) {
+    const d = def(id);
+    steps.push({
+      id,
+      status: steps.length === 0 ? "active" : "pending",
+      label: d.label,
+      description: d.description,
+    });
+  }
+  for (let i = 0; i < maxIterations; i++) {
+    for (const id of LOOP_STEP_IDS) {
+      const d = def(id);
+      steps.push({
+        id,
+        status: "pending",
+        label: d.label,
+        description: d.description,
+        iteration: i,
+      });
+    }
+  }
+  for (const id of ["explorer_keep", "explorer_summary"] as AgentStepId[]) {
+    const d = def(id);
+    steps.push({
+      id,
+      status: "pending",
+      label: d.label,
+      description: d.description,
+    });
+  }
+  return steps;
+}
+
+async function executeExplorerPipeline(
+  sessionId: string,
+  teamId: string,
+  repositoryId: string,
+) {
+  const controller = getOrCreateController(sessionId);
+  const signal = controller.signal;
+
+  try {
+    for (;;) {
+      if (await isStopped(sessionId, signal)) return;
+      const session = await queries.getAgentSession(sessionId);
+      if (!session) return;
+      // Resume-safe: always run the first not-yet-finished step entry.
+      const index = session.steps.findIndex(
+        (s) => s.status === "pending" || s.status === "active",
+      );
+      if (index === -1) return; // every step resolved
+      const step = session.steps[index];
+      const iteration = step.iteration ?? 0;
+
+      let ok = false;
+      switch (step.id) {
+        case "explorer_setup":
+          ok = await runExplorerSetup(sessionId, teamId, repositoryId, index);
+          break;
+        case "explorer_login":
+          ok = await runExplorerLogin(
+            sessionId,
+            teamId,
+            repositoryId,
+            index,
+            signal,
+          );
+          break;
+        case "explorer_research":
+          ok = await runExplorerResearch(
+            sessionId,
+            teamId,
+            repositoryId,
+            index,
+            iteration,
+            signal,
+          );
+          break;
+        case "explorer_plan":
+          ok = await runExplorerPlan(
+            sessionId,
+            teamId,
+            repositoryId,
+            index,
+            iteration,
+            signal,
+          );
+          break;
+        case "explorer_act":
+          ok = await runExplorerAct(
+            sessionId,
+            teamId,
+            repositoryId,
+            index,
+            iteration,
+            signal,
+          );
+          break;
+        case "explorer_analyze":
+          ok = await runExplorerAnalyze(
+            sessionId,
+            teamId,
+            repositoryId,
+            index,
+            iteration,
+          );
+          break;
+        case "explorer_keep":
+          ok = await runExplorerKeep(sessionId, teamId, repositoryId, index);
+          break;
+        case "explorer_summary":
+          ok = await runExplorerSummary(
+            sessionId,
+            teamId,
+            repositoryId,
+            index,
+            signal,
+          );
+          break;
+        default:
+          // Unknown step (never expected) — fail loudly rather than spin.
+          await setStepFailedAt(sessionId, index, `Unknown step ${step.id}`);
+          return;
+      }
+      if (!ok) return;
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error("[Explorer] pipeline error:", err);
+    const session = await queries.getAgentSession(sessionId).catch(() => null);
+    const index = session?.steps.findIndex((s) => s.status === "active") ?? -1;
+    if (index !== -1) {
+      await setStepFailedAt(sessionId, index, msg).catch(() => {});
+    } else {
+      await queries
+        .updateAgentSession(sessionId, {
+          status: "failed",
+          completedAt: new Date(),
+        })
+        .catch(() => {});
+    }
+    emitActivity(
+      teamId,
+      repositoryId,
+      sessionId,
+      "session:error",
+      `Explorer failed: ${msg}`,
+    );
+  } finally {
+    activeControllers.delete(sessionId);
+    await releaseSessionEb(sessionId).catch(() => {});
+  }
+}
+
+// ── Public actions ───────────────────────────────────────────────────────────
+
+export interface StartExplorerInput {
+  repositoryId: string;
+  targetUrl: string;
+  maxIterations?: number;
+  styleRotation?: ExplorerStyle[];
+  email?: string;
+  password?: string;
+}
+
+async function startExplorerCore(
+  teamId: string,
+  input: StartExplorerInput,
+  trigger: ExplorerSessionTrigger,
+): Promise<{ sessionId: string }> {
+  const targetUrl = input.targetUrl.trim().replace(/\/+$/, "");
+  if (!/^https?:\/\//i.test(targetUrl)) {
+    throw new Error("Target URL must start with http(s)://");
+  }
+  try {
+    await assertSafeOutboundUrl(targetUrl);
+  } catch (err) {
+    if (err instanceof SsrfBlockedError) {
+      throw new Error(`URL rejected: ${err.message}`);
+    }
+    throw err;
+  }
+
+  // One active explorer session per repo.
+  const existing = await queries.getActiveAgentSession(
+    input.repositoryId,
+    "explorer",
+  );
+  if (existing) {
+    activeControllers.get(existing.id)?.abort();
+    await queries.updateAgentSession(existing.id, {
+      status: "cancelled",
+      completedAt: new Date(),
+    });
+    await releaseSessionEb(existing.id).catch(() => {});
+  }
+
+  const settings = await queries.getAISettings(input.repositoryId);
+  const maxIterations = Math.max(
+    1,
+    Math.min(
+      input.maxIterations ??
+        settings.explorerMaxIterations ??
+        DEFAULT_MAX_ITERATIONS,
+      MAX_ITERATIONS_CAP,
+    ),
+  );
+  const styleRotation =
+    input.styleRotation && input.styleRotation.length > 0
+      ? input.styleRotation
+      : parseStyleRotation(settings.explorerStyleRotation);
+  const credsProvided = Boolean(input.email?.trim() && input.password);
+
+  const session = await queries.createAgentSession({
+    repositoryId: input.repositoryId,
+    teamId,
+    kind: "explorer",
+    status: "active",
+    currentStepId: "explorer_setup",
+    steps: buildExplorerSteps(maxIterations),
+    metadata: {
+      explorerTargetUrl: targetUrl,
+      explorerMaxIterations: maxIterations,
+      explorerIteration: 0,
+      explorerStyleRotation: styleRotation,
+      explorerTrigger: trigger,
+      credsProvided,
+      ...(credsProvided
+        ? {
+            quickstartEmail: input.email!.trim(),
+            quickstartPassword: input.password!,
+          }
+        : {}),
+    },
+  });
+
+  emitActivity(
+    teamId,
+    input.repositoryId,
+    session.id,
+    "session:start",
+    `Explorer started on ${targetUrl} (${maxIterations} iterations, ${styleRotation.join("→")})`,
+  );
+
+  executeExplorerPipeline(session.id, teamId, input.repositoryId).catch((err) =>
+    console.error("[Explorer] unhandled:", err),
+  );
+
+  return { sessionId: session.id };
+}
+
+export async function startExplorerAgent(
+  input: StartExplorerInput,
+): Promise<{ sessionId: string }> {
+  const { team } = await requireRepoAccess(input.repositoryId);
+  assertQaAgentAccess(team.plan);
+  const result = await startExplorerCore(team.id, input, "manual");
+  revalidatePath("/explorer");
+  return result;
+}
+
+async function requireExplorerSession(sessionId: string): Promise<{
+  session: AgentSession;
+  teamId: string;
+}> {
+  const { team } = await requireTeamAccess();
+  const session = await queries.getAgentSession(sessionId);
+  if (!session || session.kind !== "explorer") {
+    throw new Error("Explorer session not found");
+  }
+  if (session.teamId && session.teamId !== team.id) {
+    throw new Error("Explorer session not found");
+  }
+  return { session, teamId: team.id };
+}
+
+export async function getExplorerSession(
+  sessionId: string,
+): Promise<AgentSession | null> {
+  try {
+    const { session } = await requireExplorerSession(sessionId);
+    return session;
+  } catch {
+    return null;
+  }
+}
+
+export async function getLatestExplorerSession(
+  repositoryId: string,
+): Promise<AgentSession | null> {
+  await requireRepoAccess(repositoryId);
+  const session = await queries.getLatestAgentSession(repositoryId, "explorer");
+  return session ?? null;
+}
+
+export async function getRecentExplorerSessions(
+  repositoryId: string,
+  limit = 10,
+): Promise<AgentSession[]> {
+  await requireRepoAccess(repositoryId);
+  return queries.getRecentAgentSessions(repositoryId, "explorer", limit);
+}
+
+export async function pauseExplorerAgent(
+  sessionId: string,
+): Promise<{ success: boolean }> {
+  const { session } = await requireExplorerSession(sessionId);
+  if (session.status !== "active") return { success: false };
+  activeControllers.get(sessionId)?.abort();
+  await queries.updateAgentSession(sessionId, { status: "paused" });
+  await releaseSessionEb(sessionId).catch(() => {});
+  revalidatePath("/explorer");
+  return { success: true };
+}
+
+export async function resumeExplorerAgent(
+  sessionId: string,
+): Promise<{ success: boolean }> {
+  const { session, teamId } = await requireExplorerSession(sessionId);
+  if (session.status !== "paused") return { success: false };
+  // Re-open the interrupted step so the resume-safe driver re-runs it.
+  const steps = session.steps.map((s) =>
+    s.status === "active" ? { ...s, status: "pending" as const } : s,
+  );
+  await queries.updateAgentSession(sessionId, { status: "active", steps });
+  executeExplorerPipeline(sessionId, teamId, session.repositoryId).catch(
+    (err) => console.error("[Explorer] unhandled:", err),
+  );
+  revalidatePath("/explorer");
+  return { success: true };
+}
+
+export async function cancelExplorerAgent(
+  sessionId: string,
+): Promise<{ success: boolean }> {
+  const { session, teamId } = await requireExplorerSession(sessionId);
+  activeControllers.get(sessionId)?.abort();
+  await queries.updateAgentSession(sessionId, {
+    status: "cancelled",
+    completedAt: new Date(),
+  });
+  await releaseSessionEb(sessionId).catch(() => {});
+  emitActivity(
+    teamId,
+    session.repositoryId,
+    sessionId,
+    "session:error",
+    "Explorer cancelled by user",
+  );
+  revalidatePath("/explorer");
+  return { success: true };
+}
+
+// ── Findings actions ─────────────────────────────────────────────────────────
+
+export async function listExplorerFindings(sessionId: string) {
+  const { session } = await requireExplorerSession(sessionId);
+  return queries.listFindingsBySession(session.id);
+}
+
+export async function listRepoFindings(repositoryId: string) {
+  await requireRepoAccess(repositoryId);
+  return queries.listFindingsByRepo(repositoryId);
+}
+
+export async function setFindingStatus(
+  findingId: string,
+  status: "open" | "triaged" | "dismissed" | "kept",
+): Promise<{ success: boolean }> {
+  const { team } = await requireTeamAccess();
+  const finding = await queries.getAgentFinding(findingId);
+  if (!finding || finding.teamId !== team.id) return { success: false };
+  await queries.updateFindingStatus(findingId, status);
+  revalidatePath("/explorer");
+  return { success: true };
+}
+
+// ── Knowledge CRUD (the /explorer knowledge editor + MCP learn tool) ────────
+
+export async function listExplorerKnowledge(repositoryId: string) {
+  await requireRepoAccess(repositoryId);
+  const rows = await queries.listKnowledgeByRepo(repositoryId);
+  // Never ship passwords to the client — presence flag only.
+  return rows.map(({ credPassword, ...rest }) => ({
+    ...rest,
+    hasCredentials: Boolean(credPassword),
+  }));
+}
+
+export interface UpsertKnowledgeInput {
+  id?: string;
+  repositoryId: string;
+  title: string;
+  urlPattern: string;
+  matchKind: "exact" | "prefix" | "regex";
+  body: string;
+  credEmail?: string;
+  /** Only sent when (re)setting the password; omitted = keep existing. */
+  credPassword?: string;
+  pageAutomation?: KnowledgePageAutomationStep[];
+  enabled?: boolean;
+}
+
+export async function upsertExplorerKnowledge(
+  input: UpsertKnowledgeInput,
+): Promise<{ id: string }> {
+  const { team } = await requireRepoAccess(input.repositoryId);
+  if (!input.title.trim() || !input.urlPattern.trim() || !input.body.trim()) {
+    throw new Error("Title, URL pattern, and body are required");
+  }
+  const patch = {
+    title: input.title.trim().slice(0, 200),
+    urlPattern: input.urlPattern.trim().slice(0, 300),
+    matchKind: input.matchKind,
+    body: input.body.slice(0, 20_000),
+    credEmail: input.credEmail?.trim() || null,
+    ...(input.credPassword !== undefined
+      ? { credPassword: input.credPassword || null }
+      : {}),
+    pageAutomation: input.pageAutomation ?? null,
+    enabled: input.enabled ?? true,
+  } satisfies Partial<NewAgentKnowledge>;
+
+  if (input.id) {
+    const existing = await queries.getKnowledge(input.id);
+    if (!existing || existing.repositoryId !== input.repositoryId) {
+      throw new Error("Knowledge note not found");
+    }
+    await queries.updateKnowledge(input.id, patch);
+    revalidatePath("/explorer");
+    return { id: input.id };
+  }
+  const created = await queries.createKnowledge({
+    ...patch,
+    repositoryId: input.repositoryId,
+    teamId: team.id,
+    credPassword: input.credPassword || null,
+  });
+  revalidatePath("/explorer");
+  return { id: created.id };
+}
+
+export async function deleteExplorerKnowledge(
+  id: string,
+  repositoryId: string,
+): Promise<{ success: boolean }> {
+  await requireRepoAccess(repositoryId);
+  const existing = await queries.getKnowledge(id);
+  if (!existing || existing.repositoryId !== repositoryId) {
+    return { success: false };
+  }
+  await queries.deleteKnowledge(id);
+  revalidatePath("/explorer");
+  return { success: true };
+}
+
+export async function listExplorerExperience(repositoryId: string) {
+  await requireRepoAccess(repositoryId);
+  return queries.listExperienceByRepo(repositoryId);
+}
+
+// ── Trigger config + scheduled dispatch ─────────────────────────────────────
+
+export interface ExplorerTriggerConfigInput {
+  repositoryId: string;
+  scheduleEnabled: boolean;
+  cronExpression?: string | null;
+  maxIterations?: number;
+}
+
+export async function getExplorerTriggerConfig(repositoryId: string) {
+  await requireRepoAccess(repositoryId);
+  return (await queries.getExplorerTrigger(repositoryId)) ?? null;
+}
+
+export async function updateExplorerTriggerConfig(
+  input: ExplorerTriggerConfigInput,
+): Promise<{ success: boolean }> {
+  const { team } = await requireRepoAccess(input.repositoryId);
+  assertQaAgentAccess(team.plan);
+
+  let nextRunAt: Date | null = null;
+  if (input.scheduleEnabled) {
+    if (!input.cronExpression || !isValidCron(input.cronExpression)) {
+      throw new Error(
+        "A valid cron expression is required to enable the schedule",
+      );
+    }
+    nextRunAt = getNextRunTime(input.cronExpression);
+  }
+
+  await queries.upsertExplorerTrigger(input.repositoryId, team.id, {
+    scheduleEnabled: input.scheduleEnabled,
+    cronExpression: input.cronExpression ?? null,
+    maxIterations: Math.max(
+      1,
+      Math.min(input.maxIterations ?? 4, MAX_ITERATIONS_CAP),
+    ),
+    nextRunAt,
+  });
+  revalidatePath("/explorer");
+  return { success: true };
+}
+
+/** Fire due explorer cron triggers. Called from the scheduler tick alongside
+ *  the QA-agent trigger dispatch — no user session (system context). */
+export async function dispatchDueExplorerTriggers(): Promise<number> {
+  const due = await queries.getDueExplorerTriggers().catch(() => []);
+  let fired = 0;
+  for (const trigger of due) {
+    const nextRunAt = trigger.cronExpression
+      ? getNextRunTime(trigger.cronExpression)
+      : null;
+    try {
+      // Skip (but re-arm) when a session is already running for this repo.
+      const active = await queries.getActiveAgentSession(
+        trigger.repositoryId,
+        "explorer",
+      );
+      if (active) {
+        await queries.markExplorerTriggerFired(trigger.id, { nextRunAt });
+        continue;
+      }
+      const repo = await queries.getRepository(trigger.repositoryId);
+      const branchBaseUrls = (repo?.branchBaseUrls ?? {}) as Record<
+        string,
+        string
+      >;
+      const targetUrl =
+        (repo?.defaultBranch
+          ? branchBaseUrls[repo.defaultBranch]
+          : undefined) ??
+        branchBaseUrls.main ??
+        Object.values(branchBaseUrls)[0];
+      if (!targetUrl) {
+        await queries.markExplorerTriggerFired(trigger.id, { nextRunAt });
+        continue;
+      }
+      const { sessionId } = await startExplorerCore(
+        trigger.teamId,
+        {
+          repositoryId: trigger.repositoryId,
+          targetUrl,
+          maxIterations: trigger.maxIterations,
+        },
+        "schedule",
+      );
+      await queries.markExplorerTriggerFired(trigger.id, {
+        nextRunAt,
+        lastRunAt: new Date(),
+        lastSessionId: sessionId,
+      });
+      fired++;
+    } catch (err) {
+      console.error("[Explorer] trigger dispatch failed:", err);
+      await queries
+        .markExplorerTriggerFired(trigger.id, { nextRunAt })
+        .catch(() => {});
+    }
+  }
+  return fired;
+}

--- a/src/server/actions/explorer-agent.ts
+++ b/src/server/actions/explorer-agent.ts
@@ -26,7 +26,10 @@ import {
   type ResearchResult,
 } from "@/lib/explorer/research";
 import { planScenarios } from "@/lib/explorer/planner";
-import { runScenario } from "@/lib/explorer/tester";
+import {
+  runScenariosConcurrent,
+  SCENARIO_CONCURRENCY,
+} from "@/lib/explorer/tester";
 import { clusterFindings } from "@/lib/explorer/analyst";
 import { buildCoverageDigest } from "@/lib/explorer/coverage";
 import { renderKeptTestCode, isKeepable } from "@/lib/explorer/keep";
@@ -72,6 +75,9 @@ import type {
  *   explorer_research   explorer      map the frontier page (live DOM via EB)
  *   explorer_plan       planner       scenarios in the rotating style
  *   explorer_act        explorer      AI-in-the-loop scenario execution
+ *                                     (scenarios run concurrently — isolated
+ *                                     authed contexts on one EB — since each
+ *                                     tester turn is a blocking model call)
  *   explorer_analyze    explorer      findings + experience write-back
  *   ──────────────────────────────────────────────────────────────────────
  *   explorer_keep       generator     passing flows → quarantined tests
@@ -798,153 +804,160 @@ async function runExplorerAct(
   const pageAutomation: KnowledgePageAutomationStep[] =
     collectPageAutomation(knowledge);
 
-  const substeps: NonNullable<AgentStepState["substeps"]> = scenarios.map(
-    (s) => ({ label: s.title, status: "pending", agent: "explorer" }),
-  );
+  const capped = scenarios.slice(0, MAX_SCENARIOS_PER_ITERATION);
+  if (await isStopped(sessionId, signal)) return false;
+
+  // All capped scenarios run in one concurrent batch — show them all active.
+  const substeps: NonNullable<AgentStepState["substeps"]> = capped.map((s) => ({
+    label: s.title,
+    status: "running",
+    agent: "explorer",
+  }));
   await updateStepAt(sessionId, stepIndex, { substeps: [...substeps] });
 
   const logs: Record<string, ExplorerActionLog> = {
     ...(meta.explorerActionLogs ?? {}),
   };
   const newFindingIds: string[] = [...(meta.explorerFindingIds ?? [])];
+  const startedAt = Date.now();
   let passed = 0;
   let failed = 0;
 
-  for (
-    let i = 0;
-    i < Math.min(scenarios.length, MAX_SCENARIOS_PER_ITERATION);
-    i++
-  ) {
-    if (await isStopped(sessionId, signal)) return false;
-    const scenario = scenarios[i];
-    substeps[i] = { ...substeps[i], status: "running" };
-    await updateStepAt(sessionId, stepIndex, { substeps: [...substeps] });
+  // Scenario execution runs concurrently (the AI round-trips are the cost);
+  // the per-scenario bookkeeping below is serialized on one chain so the
+  // shared substeps array + session-metadata read-modify-write never race.
+  let writeChain: Promise<void> = Promise.resolve();
 
-    const startedAt = Date.now();
-    let log: ExplorerActionLog;
-    try {
-      log = await runScenario(config, eb.cdpUrl, {
-        scenario,
-        targetUrl: state.url,
-        repositoryId,
-        knowledgeBlock,
-        pageAutomation,
-        signal,
-      });
-    } catch (err) {
-      log = {
-        scenarioId: scenario.id,
-        status: "blocked",
-        steps: [],
-        summary: err instanceof Error ? err.message : String(err),
-      };
-    }
-    logs[scenario.id] = log;
+  await runScenariosConcurrent(
+    config,
+    eb.cdpUrl,
+    capped.map((scenario) => ({
+      scenario,
+      targetUrl: state.url,
+      repositoryId,
+      knowledgeBlock,
+      pageAutomation,
+      signal,
+    })),
+    {
+      concurrency: SCENARIO_CONCURRENCY,
+      signal,
+      onComplete: (log, i) => {
+        writeChain = writeChain.then(async () => {
+          const scenario = capped[i];
+          logs[scenario.id] = log;
 
-    // Findings: failed scenarios are defects; console/network anomalies on a
-    // passing scenario are logged as low-severity observations.
-    if (log.status === "failed") {
-      failed++;
-      const finding = await queries
-        .createAgentFinding({
-          repositoryId,
-          teamId,
-          sessionId,
-          kind: "defect",
-          severity: scenario.style === "psycho" ? "medium" : "high",
-          title: `${scenario.title} — ${log.summary?.slice(0, 100) ?? "failed"}`,
-          description: [
-            `Scenario (${scenario.style}): ${scenario.title}`,
-            scenario.expectedOutcome
-              ? `Expected: ${scenario.expectedOutcome}`
-              : null,
-            `Observed: ${log.summary ?? "the flow failed"}`,
-            `Final URL: ${log.finalUrl ?? state.url}`,
-          ]
-            .filter(Boolean)
-            .join("\n"),
-          pageStateHash: log.finalStateHash ?? state.hash,
-          url: log.finalUrl ?? state.url,
-          scenario,
-          evidence: {
-            consoleErrors: log.consoleErrors,
-            failedRequests: log.failedRequests,
-            actionSteps: log.steps.slice(-8),
-          },
-          status: "open",
-        })
-        .catch(() => null);
-      if (finding) {
-        newFindingIds.push(finding.id);
-        emitActivity(
-          teamId,
-          repositoryId,
-          sessionId,
-          "substep:update",
-          `Finding: ${finding.title}`,
-          { stepId: "explorer_act", detail: { findingId: finding.id } },
-        );
-      }
-    } else if (
-      log.status === "passed" &&
-      ((log.consoleErrors?.length ?? 0) > 0 ||
-        (log.failedRequests?.length ?? 0) > 0)
-    ) {
-      passed++;
-      const finding = await queries
-        .createAgentFinding({
-          repositoryId,
-          teamId,
-          sessionId,
-          kind: "defect",
-          severity: "low",
-          title: `Console/network errors during "${scenario.title}"`,
-          description: [
-            `The scenario passed, but the app surfaced errors while it ran.`,
-            log.consoleErrors?.length
-              ? `Console: ${log.consoleErrors.slice(0, 5).join(" | ")}`
-              : null,
-            log.failedRequests?.length
-              ? `Failed requests: ${log.failedRequests
-                  .slice(0, 5)
-                  .map((r) => `${r.method} ${r.url} → ${r.status}`)
-                  .join(" | ")}`
-              : null,
-          ]
-            .filter(Boolean)
-            .join("\n"),
-          pageStateHash: log.finalStateHash ?? state.hash,
-          url: log.finalUrl ?? state.url,
-          scenario,
-          evidence: {
-            consoleErrors: log.consoleErrors,
-            failedRequests: log.failedRequests,
-          },
-          status: "open",
-        })
-        .catch(() => null);
-      if (finding) newFindingIds.push(finding.id);
-    } else if (log.status === "passed") {
-      passed++;
-    }
+          // Findings: failed scenarios are defects; console/network anomalies
+          // on a passing scenario are low-severity observations.
+          if (log.status === "failed") {
+            failed++;
+            const finding = await queries
+              .createAgentFinding({
+                repositoryId,
+                teamId,
+                sessionId,
+                kind: "defect",
+                severity: scenario.style === "psycho" ? "medium" : "high",
+                title: `${scenario.title} — ${log.summary?.slice(0, 100) ?? "failed"}`,
+                description: [
+                  `Scenario (${scenario.style}): ${scenario.title}`,
+                  scenario.expectedOutcome
+                    ? `Expected: ${scenario.expectedOutcome}`
+                    : null,
+                  `Observed: ${log.summary ?? "the flow failed"}`,
+                  `Final URL: ${log.finalUrl ?? state.url}`,
+                ]
+                  .filter(Boolean)
+                  .join("\n"),
+                pageStateHash: log.finalStateHash ?? state.hash,
+                url: log.finalUrl ?? state.url,
+                scenario,
+                evidence: {
+                  consoleErrors: log.consoleErrors,
+                  failedRequests: log.failedRequests,
+                  actionSteps: log.steps.slice(-8),
+                },
+                status: "open",
+              })
+              .catch(() => null);
+            if (finding) {
+              newFindingIds.push(finding.id);
+              emitActivity(
+                teamId,
+                repositoryId,
+                sessionId,
+                "substep:update",
+                `Finding: ${finding.title}`,
+                { stepId: "explorer_act", detail: { findingId: finding.id } },
+              );
+            }
+          } else if (
+            log.status === "passed" &&
+            ((log.consoleErrors?.length ?? 0) > 0 ||
+              (log.failedRequests?.length ?? 0) > 0)
+          ) {
+            passed++;
+            const finding = await queries
+              .createAgentFinding({
+                repositoryId,
+                teamId,
+                sessionId,
+                kind: "defect",
+                severity: "low",
+                title: `Console/network errors during "${scenario.title}"`,
+                description: [
+                  `The scenario passed, but the app surfaced errors while it ran.`,
+                  log.consoleErrors?.length
+                    ? `Console: ${log.consoleErrors.slice(0, 5).join(" | ")}`
+                    : null,
+                  log.failedRequests?.length
+                    ? `Failed requests: ${log.failedRequests
+                        .slice(0, 5)
+                        .map((r) => `${r.method} ${r.url} → ${r.status}`)
+                        .join(" | ")}`
+                    : null,
+                ]
+                  .filter(Boolean)
+                  .join("\n"),
+                pageStateHash: log.finalStateHash ?? state.hash,
+                url: log.finalUrl ?? state.url,
+                scenario,
+                evidence: {
+                  consoleErrors: log.consoleErrors,
+                  failedRequests: log.failedRequests,
+                },
+                status: "open",
+              })
+              .catch(() => null);
+            if (finding) newFindingIds.push(finding.id);
+          } else if (log.status === "passed") {
+            passed++;
+          }
 
-    substeps[i] = {
-      ...substeps[i],
-      status: log.status === "passed" ? "done" : "error",
-      detail: `${log.status}${log.summary ? ` — ${log.summary.slice(0, 120)}` : ""}`,
-      durationMs: Date.now() - startedAt,
-    };
-    await updateStepAt(sessionId, stepIndex, { substeps: [...substeps] });
-    await mergeMetadata(sessionId, {
-      explorerActionLogs: logs,
-      explorerFindingIds: newFindingIds,
-    });
-  }
+          substeps[i] = {
+            ...substeps[i],
+            status: log.status === "passed" ? "done" : "error",
+            detail: `${log.status}${log.summary ? ` — ${log.summary.slice(0, 120)}` : ""}`,
+          };
+          await updateStepAt(sessionId, stepIndex, {
+            substeps: [...substeps],
+          });
+          await mergeMetadata(sessionId, {
+            explorerActionLogs: logs,
+            explorerFindingIds: newFindingIds,
+          });
+        });
+        return writeChain;
+      },
+    },
+  );
 
   await setStepCompletedAt(sessionId, stepIndex, {
-    executed: Math.min(scenarios.length, MAX_SCENARIOS_PER_ITERATION),
+    executed: capped.length,
     passed,
     failed,
+    durationMs: Date.now() - startedAt,
+    concurrency: Math.min(SCENARIO_CONCURRENCY, capped.length),
   });
   emitActivity(
     teamId,


### PR DESCRIPTION
## Summary

Implements the Explorer Agent, an autonomous exploratory-testing system (explorbot-style) that runs alongside the existing QA Agent. The explorer iteratively researches pages, plans scenarios in rotating styles, executes them against a live Embedded Browser with AI-in-the-loop action selection, records findings, learns per-page experience, and keeps passing flows as quarantined tests.

## Key Changes

**Core Agent Implementation**
- `src/server/actions/explorer-agent.ts` (1769 lines) — main orchestrator: session lifecycle, step machine (setup → login → loop iterations → keep → summary), EB lifecycle management, activity emission
- `src/lib/explorer/` — modular subsystems:
  - `research.ts` — page observation via ranger page-map extraction
  - `planner.ts` — AI scenario generation in rotating styles (normal/curious/psycho)
  - `tester.ts` — AI-in-the-loop action loop: observe DOM → model returns JSON action → Playwright-over-CDP executes
  - `analyst.ts` — findings clustering by root cause + severity refinement
  - `keep.ts` — deterministic test code generation from action logs
  - `supervisor.ts` — heuristic stuck/loop detection (no AI needed)
  - `styles.ts`, `state.ts`, `coverage.ts`, `knowledge.ts`, `config.ts` — supporting utilities
  - `url-match.ts` — URL pattern matching for knowledge notes

**Database Schema & Queries**
- `src/lib/db/schema.ts` — new tables: `agent_knowledge` (human hints), `agent_experience` (learned notes), `agent_findings` (defects/UX issues), `explorer_triggers` (cron scheduling); new `AgentSessionKind = "explorer"` and step IDs; AI settings columns for explorer config
- `src/lib/db/queries/agent-knowledge.ts`, `agent-experience.ts`, `explorer.ts` — domain queries with AES-256-GCM encryption for stored credentials

**UI Components**
- `src/app/(app)/explorer/page.tsx` — main `/explorer` page (server-rendered, fetches initial session/knowledge/experience)
- `src/components/explorer/` — client components:
  - `explorer-client.tsx` — main control panel (target URL, max iterations, auth form, tabs for timeline/findings/knowledge/experience)
  - `use-explorer-agent.ts` — client hook: starts/controls session via server actions, polls `/api/explorer-agent/[sessionId]`
  - `explorer-timeline.tsx` — step visualization (setup/login prefix, loop iterations grouped, keep/summary suffix)
  - `explorer-findings-panel.tsx` — findings list with severity badges, status management
  - `knowledge-editor.tsx` — CRUD for human knowledge notes (URL patterns, credentials)
  - `experience-viewer.tsx` — read-only view of learned page-state notes

**API & Integration**
- `src/app/api/explorer-agent/[sessionId]/route.ts` — polling endpoint returns session + findings
- `src/app/api/v1/[...slug]/route.ts` — REST API: `GET /api/v1/explorer/:sessionId`, `POST /api/v1/repos/:repoId/explorer`
- `packages/mcp-server/src/server.ts` — MCP tools: `lastest_explorer` (start), `lastest_explorer_status` (poll), `lastest_explorer_pause/resume/cancel`
- `packages/mcp-server/src/client.ts` — client methods for MCP integration

**Scheduling & Settings**
- `src/lib/scheduling/scheduler.ts` — `processDueExplorerTriggers()` for cron-based runs
- `src/components/settings/ai-settings-card.tsx` — UI for explorer config (max iterations, style rotation, model override)
- `src/server/actions/ai-settings.ts` — persist explorer settings

**Crypto & Utilities**
- `src/lib/crypto-fields.ts` — encryption helpers for knowledge credentials
- Unit tests: `keep.test.ts

https://claude.ai/code/session_01UjkKbtSW4BRJvqZMeYD4iJ