### PR TITLE
feat(agents): Agents console as the entry point for agent work

### DIFF
--- a/plugins/qa-agent/src/data/tasks.ts
+++ b/plugins/qa-agent/src/data/tasks.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray } from "drizzle-orm";
+import { and, asc, count, desc, eq, inArray } from "drizzle-orm";
 
 import type { QaTaskStatus, QaTaskTestRef } from "../types";
 import { qaAgentTasks, type NewQaAgentTask, type QaAgentTask } from "../schema";
@@ -76,6 +76,44 @@ export async function getQaTasksByRepoRows(
       .limit(terminalLimit),
   ]);
   return [...open, ...terminal];
+}
+
+/**
+ * What the Agents console needs from the queue: the tasks pushed back for a
+ * human, plus how many are waiting to be picked up.
+ *
+ * Deliberately NOT `getQaTasksByRepoRows` — the console renders two numbers
+ * and a short list, and it is a `force-dynamic` page hit on every navigation.
+ * Pulling every task on the repo to filter two of them in JS is the shape
+ * flagged on #97; a filtered select plus a `count(*)` is the same answer for
+ * a fraction of the rows.
+ */
+export async function getQaConsoleQueueRows(
+  db: QaAgentDb,
+  repositoryId: string,
+): Promise<{ needsInput: QaAgentTask[]; queuedCount: number }> {
+  const [needsInput, queued] = await Promise.all([
+    db
+      .select()
+      .from(qaAgentTasks)
+      .where(
+        and(
+          eq(qaAgentTasks.repositoryId, repositoryId),
+          eq(qaAgentTasks.status, "needs_input"),
+        ),
+      )
+      .orderBy(desc(qaAgentTasks.updatedAt)),
+    db
+      .select({ n: count() })
+      .from(qaAgentTasks)
+      .where(
+        and(
+          eq(qaAgentTasks.repositoryId, repositoryId),
+          eq(qaAgentTasks.status, "queued"),
+        ),
+      ),
+  ]);
+  return { needsInput, queuedCount: Number(queued[0]?.n ?? 0) };
 }
 
 /** Oldest queued task for a repo — what the dispatcher picks up next. */

--- a/plugins/qa-agent/src/reads.ts
+++ b/plugins/qa-agent/src/reads.ts
@@ -1,5 +1,9 @@
 import { orm } from "./data/db";
-import { getQaTaskRow, getQaTasksByRepoRows } from "./data/tasks";
+import {
+  getQaConsoleQueueRows,
+  getQaTaskRow,
+  getQaTasksByRepoRows,
+} from "./data/tasks";
 import { getQaAgentTriggerRow } from "./data/triggers";
 import type { QaAgentTask, QaAgentTriggerRow } from "./schema";
 import { qaAgentWiring } from "./wiring";
@@ -22,6 +26,16 @@ export async function getQaTasksByRepo(
   opts: { terminalLimit?: number } = {},
 ): Promise<QaAgentTask[]> {
   return getQaTasksByRepoRows(orm(qaAgentWiring().data), repositoryId, opts);
+}
+
+/**
+ * The Agents console's slice of the queue — `needs_input` tasks and the queued
+ * count, without pulling the whole board. See `getQaConsoleQueueRows`.
+ */
+export async function getQaConsoleQueue(
+  repositoryId: string,
+): Promise<{ needsInput: QaAgentTask[]; queuedCount: number }> {
+  return getQaConsoleQueueRows(orm(qaAgentWiring().data), repositoryId);
 }
 
 /** One task by id (the v1 API's post-create echo). */

--- a/plugins/qa-agent/src/ui/qa-agent-upgrade-gate.tsx
+++ b/plugins/qa-agent/src/ui/qa-agent-upgrade-gate.tsx
@@ -1,3 +1,4 @@
+import type { ComponentType } from "react";
 import Link from "next/link";
 import {
   Badge,
@@ -270,25 +271,30 @@ function DoneScreenPreview() {
 export function QaAgentUpgradeGate({
   currentPlanName,
   requiredPlanName,
+  title = "QA Agent",
+  icon: Icon = Bot,
+  description = "An orchestrated agent team — scout, planner, generator, healer — that discovers your app, plans coverage against testing best practices, and builds a complete E2E suite you can watch and steer.",
 }: {
   /** Display name of the team's current plan (e.g. "Free"). */
   currentPlanName: string;
   /** Display name of the plan required to unlock (e.g. "Pro"). */
   requiredPlanName: string;
+  /** Heading shown above the preview. `/agents` is the gated door now, so it
+   *  passes its own name rather than inheriting this page's. The preview
+   *  below is unchanged either way — a QA run is what the plan unlocks. */
+  title?: string;
+  icon?: ComponentType<{ className?: string }>;
+  description?: string;
 }) {
   return (
     <div className="flex-1 overflow-auto p-6">
       <div className="mx-auto max-w-5xl space-y-6">
         <header className="space-y-1">
           <h1 className="flex items-center gap-2 text-2xl font-semibold">
-            <Bot className="h-6 w-6" />
-            QA Agent
+            <Icon className="h-6 w-6" />
+            {title}
           </h1>
-          <p className="text-sm text-muted-foreground">
-            An orchestrated agent team — scout, planner, generator, healer —
-            that discovers your app, plans coverage against testing best
-            practices, and builds a complete E2E suite you can watch and steer.
-          </p>
+          <p className="text-sm text-muted-foreground">{description}</p>
         </header>
 
         {/* Upgrade CTA */}

--- a/src/app/(app)/agents/page.tsx
+++ b/src/app/(app)/agents/page.tsx
@@ -1,0 +1,106 @@
+import Link from "next/link";
+import { Network } from "lucide-react";
+import { getCurrentSession } from "@/lib/auth";
+import {
+  FLEET_AGENT_KINDS,
+  getSelectedRepository,
+  getTeamRunUsage,
+  listLiveAgentSessions,
+  listRecentSettledAgentSessions,
+} from "@/lib/db/queries";
+import { getQaTasksByRepo } from "@lastest/plugin-qa-agent/reads";
+import {
+  escalationsFrom,
+  idleRow,
+  rowFromSession,
+  sortRoster,
+  summarise,
+  type FleetAgentKind,
+  type FleetRow,
+} from "@/lib/agents/fleet";
+import { AgentsConsole } from "@/components/agents/agents-console-client";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * The Agents console — one roster for every agent working the selected repo.
+ *
+ * This is the only sidebar entry for agent work: the QA agent and the Explorer
+ * are reached by drilling through a row rather than by their own nav items.
+ *
+ * Explorer rows are absent from this PR. They live in the explorer plugin's
+ * own table and arrive through `src/lib/core/explorer-reads.ts`, which is the
+ * next change in the stack — until then the Explorer keeps its sidebar entry.
+ */
+export default async function AgentsPage() {
+  const session = await getCurrentSession();
+  const teamId = session?.team?.id;
+  const userId = session?.user?.id;
+
+  const selectedRepo = teamId
+    ? await getSelectedRepository(userId, teamId)
+    : null;
+
+  if (!selectedRepo) {
+    return (
+      <div className="flex-1 p-6 overflow-auto">
+        <div className="max-w-4xl mx-auto space-y-6">
+          <header>
+            <h1 className="text-2xl font-semibold flex items-center gap-2">
+              <Network className="h-6 w-6" />
+              Agents
+            </h1>
+          </header>
+          <div className="rounded-lg border border-dashed p-10 text-center text-sm text-muted-foreground">
+            Connect and select a repository first — agents work inside a repo.{" "}
+            <Link href="/tests" className="underline">
+              Add a repository
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const [liveSessions, settled, tasks, runUsage] = await Promise.all([
+    listLiveAgentSessions(selectedRepo.id).catch(() => []),
+    listRecentSettledAgentSessions(selectedRepo.id).catch(() => []),
+    getQaTasksByRepo(selectedRepo.id).catch(() => []),
+    teamId ? getTeamRunUsage(teamId).catch(() => null) : Promise.resolve(null),
+  ]);
+
+  // One row per live session, plus an idle row for every kind that has none —
+  // the roster is the whole fleet, not just what happens to be running.
+  const liveRows = liveSessions.map(rowFromSession);
+  const kindsWithLiveRow = new Set<FleetAgentKind>(liveRows.map((r) => r.kind));
+  const rows: FleetRow[] = sortRoster([
+    ...liveRows,
+    ...FLEET_AGENT_KINDS.filter(
+      (k: FleetAgentKind) => !kindsWithLiveRow.has(k),
+    ).map(idleRow),
+  ]);
+
+  return (
+    <AgentsConsole
+      repositoryName={selectedRepo.fullName ?? selectedRepo.name}
+      rows={rows}
+      summary={summarise(rows)}
+      escalations={escalationsFrom(rows, tasks)}
+      settled={settled.map((s) => ({
+        id: s.id,
+        kind: s.kind,
+        status: s.status,
+        completedAt: s.completedAt ?? s.createdAt ?? null,
+      }))}
+      queuedCount={tasks.filter((t) => t.status === "queued").length}
+      runUsage={
+        runUsage
+          ? {
+              used: runUsage.runMinutesThisMonth,
+              quota: runUsage.monthlyRunQuota,
+            }
+          : null
+      }
+    />
+  );
+}

--- a/src/app/(app)/agents/page.tsx
+++ b/src/app/(app)/agents/page.tsx
@@ -8,7 +8,7 @@ import {
   listLiveAgentSessions,
   listRecentSettledAgentSessions,
 } from "@/lib/db/queries";
-import { getQaTasksByRepo } from "@lastest/plugin-qa-agent/reads";
+import { getQaConsoleQueue } from "@lastest/plugin-qa-agent/reads";
 import {
   escalationsFrom,
   idleRow,
@@ -48,10 +48,16 @@ export default async function AgentsPage() {
   // The console is the gated surface now, not just `/qa-agent`. Gate before
   // anything else so teams below the required plan always land on the upgrade
   // screen — including before a repo is selected, matching `/qa-agent`.
-  if (team && !hasQaAgentAccess(team.plan, isBillingEnabled())) {
+  //
+  // A request that resolves no team is gated too, on the free plan. Making the
+  // check conditional on `team` would let it through and leave the "select a
+  // repository" branch below as the only thing stopping it, which is a
+  // coincidence of `getSelectedRepository(undefined, undefined)` returning
+  // null rather than an access decision.
+  if (!hasQaAgentAccess(team?.plan ?? "free", isBillingEnabled())) {
     return (
       <QaAgentUpgradeGate
-        currentPlanName={planConfig(team.plan).name}
+        currentPlanName={planConfig(team?.plan ?? "free").name}
         requiredPlanName={qaAgentMinPlanName()}
         title="Agents"
         icon={Network}
@@ -85,10 +91,16 @@ export default async function AgentsPage() {
     );
   }
 
-  const [liveSessions, settled, tasks, runUsage] = await Promise.all([
+  const [liveSessions, settled, queue, runUsage] = await Promise.all([
     listLiveAgentSessions(selectedRepo.id).catch(() => []),
     listRecentSettledAgentSessions(selectedRepo.id).catch(() => []),
-    getQaTasksByRepo(selectedRepo.id).catch(() => []),
+    // Only the two things the console renders — the escalations and the queued
+    // count — rather than every task on the repo. This page is
+    // `force-dynamic`, so the query runs on every navigation.
+    getQaConsoleQueue(selectedRepo.id).catch(() => ({
+      needsInput: [],
+      queuedCount: 0,
+    })),
     teamId ? getTeamRunUsage(teamId).catch(() => null) : Promise.resolve(null),
   ]);
 
@@ -108,14 +120,14 @@ export default async function AgentsPage() {
       repositoryName={selectedRepo.fullName ?? selectedRepo.name}
       rows={rows}
       summary={summarise(rows)}
-      escalations={escalationsFrom(rows, tasks)}
+      escalations={escalationsFrom(rows, queue.needsInput)}
       settled={settled.map((s) => ({
         id: s.id,
         kind: s.kind,
         status: s.status,
         completedAt: s.completedAt ?? s.createdAt ?? null,
       }))}
-      queuedCount={tasks.filter((t) => t.status === "queued").length}
+      queuedCount={queue.queuedCount}
       runUsage={
         runUsage
           ? {

--- a/src/app/(app)/agents/page.tsx
+++ b/src/app/(app)/agents/page.tsx
@@ -19,6 +19,13 @@ import {
   type FleetRow,
 } from "@/lib/agents/fleet";
 import { AgentsConsole } from "@/components/agents/agents-console-client";
+import { QaAgentUpgradeGate } from "@lastest/plugin-qa-agent/ui/qa-agent-upgrade-gate";
+import {
+  hasQaAgentAccess,
+  qaAgentMinPlanName,
+} from "@/lib/billing/feature-access";
+import { isBillingEnabled } from "@/lib/billing/enabled";
+import { planConfig } from "@/lib/billing/plans";
 
 export const dynamic = "force-dynamic";
 
@@ -34,8 +41,24 @@ export const dynamic = "force-dynamic";
  */
 export default async function AgentsPage() {
   const session = await getCurrentSession();
-  const teamId = session?.team?.id;
+  const team = session?.team;
+  const teamId = team?.id;
   const userId = session?.user?.id;
+
+  // The console is the gated surface now, not just `/qa-agent`. Gate before
+  // anything else so teams below the required plan always land on the upgrade
+  // screen — including before a repo is selected, matching `/qa-agent`.
+  if (team && !hasQaAgentAccess(team.plan, isBillingEnabled())) {
+    return (
+      <QaAgentUpgradeGate
+        currentPlanName={planConfig(team.plan).name}
+        requiredPlanName={qaAgentMinPlanName()}
+        title="Agents"
+        icon={Network}
+        description="One roster for every agent working your repo — what each is doing, what it is waiting on you for, and the browsers they are holding while they wait."
+      />
+    );
+  }
 
   const selectedRepo = teamId
     ? await getSelectedRepository(userId, teamId)

--- a/src/app/(app)/qa-agent/page.tsx
+++ b/src/app/(app)/qa-agent/page.tsx
@@ -19,6 +19,7 @@ import type { AgentSession } from "@/lib/db/schema";
 import type { QaSessionRow } from "@lastest/plugin-qa-agent/types";
 import { getEnvironmentConfig } from "@/server/actions/environment";
 import { QaAgentClient } from "@lastest/plugin-qa-agent/ui/qa-agent-client";
+import { AgentBreadcrumb } from "@/components/agents/agent-breadcrumb";
 import { QaAgentUpgradeGate } from "@lastest/plugin-qa-agent/ui/qa-agent-upgrade-gate";
 import { BrowserViewer } from "@/components/embedded-browser/browser-viewer-client";
 import {
@@ -148,7 +149,8 @@ export default async function QaAgentPage() {
     <div className="flex-1 p-6 overflow-auto">
       <div className="max-w-5xl mx-auto space-y-6">
         <header className="space-y-1">
-          <h1 className="text-2xl font-semibold flex items-center gap-2">
+          <AgentBreadcrumb current="QA agent" />
+          <h1 className="text-2xl font-semibold flex items-center gap-2 pt-1">
             <Bot className="h-6 w-6" />
             QA Agent
           </h1>

--- a/src/components/agents/agent-breadcrumb.tsx
+++ b/src/components/agents/agent-breadcrumb.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+import { ChevronRight, Network } from "lucide-react";
+
+/**
+ * "Agents › <this agent>" — the way back out of a drill-through.
+ *
+ * Once `/agents` is the only sidebar entry for agent work, an agent page is
+ * reached by opening a roster row, so it needs a visible parent. Shared by the
+ * QA agent page and (in the next change in the stack) the Explorer page.
+ */
+export function AgentBreadcrumb({ current }: { current: string }) {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="flex items-center gap-1.5 text-xs text-muted-foreground"
+    >
+      <Link
+        href="/agents"
+        className="inline-flex items-center gap-1.5 hover:text-foreground"
+      >
+        <Network className="h-3.5 w-3.5" />
+        Agents
+      </Link>
+      <ChevronRight className="h-3 w-3" aria-hidden />
+      <span className="text-foreground">{current}</span>
+    </nav>
+  );
+}

--- a/src/components/agents/agents-console-client.tsx
+++ b/src/components/agents/agents-console-client.tsx
@@ -1,0 +1,373 @@
+"use client";
+
+import Link from "next/link";
+import {
+  Bot,
+  CheckCircle2,
+  ChevronRight,
+  Circle,
+  Compass,
+  ListTodo,
+  Network,
+  Play,
+  UserRound,
+  XCircle,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { timeAgo } from "@/lib/utils";
+import type {
+  Escalation,
+  FleetAgentKind,
+  FleetRow,
+  FleetState,
+  FleetSummary,
+} from "@/lib/agents/fleet";
+
+const KIND_ICONS: Record<FleetAgentKind, typeof Bot> = {
+  qa: Bot,
+  ranger: Play,
+  play: Play,
+  quickstart: Bot,
+  explorer: Compass,
+};
+
+const STATE_META: Record<
+  FleetState,
+  { label: string; dot: string; text: string; pulse: boolean }
+> = {
+  working: {
+    label: "Working",
+    dot: "bg-info",
+    text: "text-info",
+    pulse: true,
+  },
+  blocked: {
+    label: "Blocked on you",
+    dot: "bg-warning",
+    text: "text-warning",
+    pulse: true,
+  },
+  paused: {
+    label: "Paused",
+    dot: "bg-warning",
+    text: "text-warning",
+    pulse: false,
+  },
+  idle: {
+    label: "Idle",
+    dot: "bg-muted-foreground/40",
+    text: "text-muted-foreground",
+    pulse: false,
+  },
+};
+
+function StatusDot({ state }: { state: FleetState }) {
+  const meta = STATE_META[state];
+  return (
+    <span className="relative flex h-2.5 w-2.5 shrink-0">
+      {meta.pulse && (
+        <span
+          className={`animate-ping absolute inline-flex h-full w-full rounded-full opacity-60 ${meta.dot}`}
+        />
+      )}
+      <span
+        className={`relative inline-flex rounded-full h-2.5 w-2.5 ${meta.dot}`}
+      />
+    </span>
+  );
+}
+
+function FleetRowItem({ row }: { row: FleetRow }) {
+  const Icon = KIND_ICONS[row.kind];
+  const meta = STATE_META[row.state];
+  const blocked = row.state === "blocked";
+  return (
+    <Link
+      href={row.href}
+      className={`flex items-center gap-3 rounded-md border p-3 transition-colors hover:bg-muted/50 ${
+        blocked ? "border-warning/40 bg-warning/5" : ""
+      }`}
+    >
+      <StatusDot state={row.state} />
+      <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">{row.label}</span>
+          <span className={`text-xs ${meta.text}`}>{meta.label}</span>
+          {row.role && (
+            <Badge variant="outline" className="text-[10px] px-1.5">
+              {row.role}
+            </Badge>
+          )}
+          {row.holdsBrowser && (
+            <Badge
+              variant="outline"
+              className="text-[10px] px-1.5 text-muted-foreground"
+              title="Holding an embedded browser from the pool"
+            >
+              browser
+            </Badge>
+          )}
+        </div>
+        <div className="truncate text-xs text-muted-foreground">
+          {row.narration ??
+            (row.state === "idle"
+              ? "Idle — open to give it something to do"
+              : "Starting up…")}
+        </div>
+      </div>
+      {row.progress !== null && row.state !== "idle" && (
+        <div className="hidden w-28 shrink-0 sm:block">
+          <div className="flex items-baseline justify-between">
+            <span className="font-mono text-[11px] text-muted-foreground">
+              {row.startedAt ? timeAgo(row.startedAt) : ""}
+            </span>
+            <span className="font-mono text-[11px] font-medium">
+              {row.progress}%
+            </span>
+          </div>
+          <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-primary/20">
+            <div
+              className="h-full bg-primary"
+              style={{ width: `${row.progress}%` }}
+            />
+          </div>
+        </div>
+      )}
+      <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/60" />
+    </Link>
+  );
+}
+
+function SettledRow({
+  entry,
+}: {
+  entry: {
+    id: string;
+    kind: FleetAgentKind;
+    status: string;
+    completedAt: Date | null;
+  };
+}) {
+  const ok = entry.status === "completed";
+  return (
+    <div className="flex items-center gap-2 py-1.5 text-sm">
+      {ok ? (
+        <CheckCircle2 className="h-4 w-4 shrink-0 text-success" />
+      ) : (
+        <XCircle className="h-4 w-4 shrink-0 text-muted-foreground" />
+      )}
+      <span className="font-medium">{entry.kind}</span>
+      <span className="min-w-0 flex-1 truncate text-muted-foreground">
+        {entry.status}
+      </span>
+      {entry.completedAt && (
+        <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
+          {timeAgo(entry.completedAt)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function AgentsConsole({
+  repositoryName,
+  rows,
+  summary,
+  escalations,
+  settled,
+  queuedCount,
+  runUsage,
+}: {
+  repositoryName: string;
+  rows: FleetRow[];
+  summary: FleetSummary;
+  escalations: Escalation[];
+  settled: Array<{
+    id: string;
+    kind: FleetAgentKind;
+    status: string;
+    completedAt: Date | null;
+  }>;
+  queuedCount: number;
+  runUsage: { used: number; quota: number } | null;
+}) {
+  const minutePct =
+    runUsage && runUsage.quota > 0
+      ? Math.min(100, Math.round((runUsage.used / runUsage.quota) * 100))
+      : null;
+
+  return (
+    <div className="flex-1 overflow-auto p-6">
+      <div className="mx-auto max-w-6xl space-y-4">
+        <header className="flex flex-wrap items-start gap-4">
+          <div className="min-w-0 flex-1">
+            <h1 className="flex items-center gap-2 text-2xl font-semibold">
+              <Network className="h-6 w-6" />
+              Agents
+            </h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Every agent working{" "}
+              <span className="font-mono text-foreground">
+                {repositoryName}
+              </span>{" "}
+              — what it is doing, and what it needs from you. Open one for its
+              full workspace.
+            </p>
+          </div>
+        </header>
+
+        <Card>
+          <CardContent className="flex flex-wrap items-center gap-x-6 gap-y-3 py-4 text-sm">
+            <span className="flex items-center gap-2">
+              <span className="h-2.5 w-2.5 rounded-full bg-info" />
+              <span className="font-semibold">{summary.working}</span>
+              <span className="text-muted-foreground">working</span>
+            </span>
+            <span className="flex items-center gap-2">
+              <span className="h-2.5 w-2.5 rounded-full bg-warning" />
+              <span className="font-semibold">{summary.blocked}</span>
+              <span className="text-muted-foreground">blocked on you</span>
+            </span>
+            <span className="flex items-center gap-2">
+              <span className="h-2.5 w-2.5 rounded-full bg-muted-foreground/40" />
+              <span className="font-semibold">
+                {summary.idle + summary.paused}
+              </span>
+              <span className="text-muted-foreground">at rest</span>
+            </span>
+            <span className="text-muted-foreground">
+              <span className="font-semibold text-foreground">
+                {summary.browsersHeld}
+              </span>{" "}
+              browser{summary.browsersHeld === 1 ? "" : "s"} held
+            </span>
+            {minutePct !== null && runUsage && (
+              <span className="flex items-center gap-2 text-muted-foreground">
+                Run minutes
+                <span className="h-1.5 w-24 overflow-hidden rounded-full bg-primary/20">
+                  <span
+                    className="block h-full bg-primary"
+                    style={{ width: `${minutePct}%` }}
+                  />
+                </span>
+                <span className="font-mono text-xs font-medium text-foreground">
+                  {runUsage.used} / {runUsage.quota}
+                </span>
+              </span>
+            )}
+          </CardContent>
+        </Card>
+
+        <div className="grid gap-4 lg:grid-cols-[1fr_360px]">
+          <Card>
+            <CardContent className="space-y-2 pt-0">
+              <div className="flex items-center gap-2 pb-1">
+                <span className="text-base font-semibold">Fleet</span>
+                <span className="text-sm text-muted-foreground">
+                  {rows.length} agent{rows.length === 1 ? "" : "s"}
+                </span>
+              </div>
+              {rows.map((row) => (
+                <FleetRowItem key={row.id} row={row} />
+              ))}
+            </CardContent>
+          </Card>
+
+          <div className="space-y-4">
+            <Card className={escalations.length > 0 ? "border-warning/40" : ""}>
+              <CardContent className="space-y-3 pt-0">
+                <div className="flex items-center gap-2">
+                  <UserRound className="h-4 w-4 text-warning" />
+                  <span className="text-sm font-semibold">Waiting on you</span>
+                  {escalations.length > 0 && (
+                    <span className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-warning px-1.5 font-mono text-[10px] font-semibold text-white">
+                      {escalations.length}
+                    </span>
+                  )}
+                </div>
+                {escalations.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    Nothing is blocked. Agents will queue a question here when
+                    they hit one.
+                  </p>
+                ) : (
+                  escalations.map((e) => (
+                    <Link
+                      key={e.id}
+                      href={e.href}
+                      className="block rounded-md border p-3 transition-colors hover:bg-muted/50"
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium">{e.label}</span>
+                        {e.holdsBrowser && (
+                          <Badge
+                            variant="outline"
+                            className="text-[10px] px-1.5 text-muted-foreground"
+                          >
+                            holding a browser
+                          </Badge>
+                        )}
+                        {e.since && (
+                          <span className="ml-auto shrink-0 font-mono text-[11px] text-muted-foreground">
+                            {timeAgo(e.since)}
+                          </span>
+                        )}
+                      </div>
+                      <p className="mt-1 text-sm">{e.question}</p>
+                    </Link>
+                  ))
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardContent className="space-y-2 pt-0">
+                <div className="flex items-center gap-2">
+                  <ListTodo className="h-4 w-4 text-muted-foreground" />
+                  <span className="text-sm font-semibold">Next up</span>
+                  <span className="text-sm text-muted-foreground">
+                    {queuedCount} queued
+                  </span>
+                  <Button
+                    asChild
+                    variant="ghost"
+                    size="sm"
+                    className="ml-auto h-7"
+                  >
+                    <Link href="/qa-agent">Open queue</Link>
+                  </Button>
+                </div>
+                {queuedCount === 0 && (
+                  <p className="text-sm text-muted-foreground">
+                    The direction queue is empty.
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+
+            {settled.length > 0 && (
+              <Card>
+                <CardContent className="pt-0">
+                  <div className="flex items-center gap-2 pb-1">
+                    <Circle className="h-4 w-4 text-muted-foreground" />
+                    <span className="text-sm font-semibold">
+                      Recently settled
+                    </span>
+                  </div>
+                  <div className="divide-y">
+                    {settled.map((entry) => (
+                      <SettledRow key={entry.id} entry={entry} />
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/agents/agents-console-client.tsx
+++ b/src/components/agents/agents-console-client.tsx
@@ -238,11 +238,17 @@ export function AgentsConsole({
               </span>
               <span className="text-muted-foreground">at rest</span>
             </span>
-            <span className="text-muted-foreground">
+            {/* Derived from run state, not read back from the EB pool — see
+                `FleetSummary.browsersHeld`. Labelled as an estimate so the
+                number is not mistaken for live pool capacity. */}
+            <span
+              className="text-muted-foreground"
+              title="Estimated from what each agent is doing — not read from the browser pool."
+            >
               <span className="font-semibold text-foreground">
-                {summary.browsersHeld}
+                ~{summary.browsersHeld}
               </span>{" "}
-              browser{summary.browsersHeld === 1 ? "" : "s"} held
+              browser{summary.browsersHeld === 1 ? "" : "s"} held (est.)
             </span>
             {minutePct !== null && runUsage && (
               <span className="flex items-center gap-2 text-muted-foreground">

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -17,8 +17,8 @@ import {
   ShieldCheck,
   GitCommit,
   Wrench,
-  Bot,
   Compass,
+  Network,
   Lock,
   Waypoints,
 } from "lucide-react";
@@ -82,7 +82,7 @@ const definitionNav = [
 
 const executionNav = [
   { name: "Runs", href: "/run", icon: Play },
-  { name: "QA Agent", href: "/qa-agent", icon: Bot },
+  { name: "Agents", href: "/agents", icon: Network },
   { name: "Explorer", href: "/explorer", icon: Compass },
   { name: "Compare", href: "/compare", icon: GitCompare },
   { name: "Impact", href: "/analytics/impact", icon: TrendingDown },
@@ -268,7 +268,7 @@ export function Sidebar({
               const isActive =
                 pathname === item.href || pathname.startsWith(item.href);
               const isVerify = item.name === "Verify";
-              const isLockedQaAgent = item.name === "QA Agent" && qaAgentLocked;
+              const isLockedQaAgent = item.name === "Agents" && qaAgentLocked;
               return (
                 <li key={item.name}>
                   <Link
@@ -291,7 +291,7 @@ export function Sidebar({
                             : "bg-primary/10 text-primary ring-primary/20",
                         )}
                         aria-label="Pro feature"
-                        title="QA Agent is available on the Pro plan"
+                        title="The QA agent is available on the Pro plan"
                       >
                         <Lock className="h-2.5 w-2.5" />
                         Pro

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -119,7 +119,7 @@ export function Sidebar({
   const earlyAdopter = team?.earlyAdopterMode ?? false;
   const gamificationEnabled = team?.gamificationEnabled ?? false;
   const verifyPhaseEnabled = team?.verifyPhaseEnabled ?? false;
-  // QA Agent is a Pro-tier feature — surface a lock on the nav item so the
+  // Agents is a Pro-tier feature — surface a lock on the nav item so the
   // gated destination doesn't look identical to unlocked pages.
   const qaAgentLocked = team
     ? !hasQaAgentAccess(team.plan, billingEnabled)
@@ -291,7 +291,7 @@ export function Sidebar({
                             : "bg-primary/10 text-primary ring-primary/20",
                         )}
                         aria-label="Pro feature"
-                        title="The QA agent is available on the Pro plan"
+                        title="The Agents console is available on the Pro plan"
                       >
                         <Lock className="h-2.5 w-2.5" />
                         Pro

--- a/src/lib/agents/fleet.test.ts
+++ b/src/lib/agents/fleet.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+import type { AgentSession, AgentStepState } from "@/lib/db/schema";
+import {
+  deriveState,
+  escalationsFrom,
+  rowFromSession,
+  sortRoster,
+  summarise,
+  type EscalatableTaskLike,
+  type FleetRow,
+} from "./fleet";
+
+function step(over: Partial<AgentStepState> = {}): AgentStepState {
+  return {
+    id: "qa_plan",
+    status: "completed",
+    label: "Plan",
+    description: "Design a risk-prioritized test plan",
+    ...over,
+  } as AgentStepState;
+}
+
+function session(over: Partial<AgentSession> = {}): AgentSession {
+  return {
+    id: "s1",
+    repositoryId: "r1",
+    teamId: "t1",
+    kind: "qa",
+    status: "active",
+    currentStepId: null,
+    steps: [step()],
+    metadata: {},
+    createdAt: new Date("2026-08-27T10:00:00Z"),
+    updatedAt: null,
+    completedAt: null,
+    ...over,
+  } as AgentSession;
+}
+
+describe("deriveState", () => {
+  it("separates a human gate from a user-initiated pause", () => {
+    const blocked = session({
+      steps: [step({ status: "completed" }), step({ status: "waiting_user" })],
+    });
+    const paused = session({ status: "paused" });
+
+    expect(deriveState(blocked)).toBe("blocked");
+    expect(deriveState(paused)).toBe("paused");
+  });
+
+  it("treats a settled session as idle regardless of its steps", () => {
+    expect(deriveState(session({ status: "completed" }))).toBe("idle");
+    expect(deriveState(session({ status: "failed" }))).toBe("idle");
+  });
+});
+
+describe("rowFromSession", () => {
+  it("counts a blocked agent as still holding its browser", () => {
+    // The whole point of the capacity read-out: a run parked on a human gate
+    // has not released its embedded browser, so it costs pool capacity.
+    const row = rowFromSession(
+      session({ steps: [step({ status: "waiting_user" })] }),
+    );
+    expect(row.state).toBe("blocked");
+    expect(row.holdsBrowser).toBe(true);
+  });
+
+  it("does not count a paused agent as holding a browser", () => {
+    expect(rowFromSession(session({ status: "paused" })).holdsBrowser).toBe(
+      false,
+    );
+  });
+
+  it("narrates the freshest running substep over the step itself", () => {
+    const row = rowFromSession(
+      session({
+        steps: [
+          step({
+            status: "active",
+            label: "Generate",
+            substeps: [
+              { label: "test 1", status: "done" },
+              { label: "test 6", detail: "apply coupon", status: "running" },
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ] as any,
+          }),
+        ],
+      }),
+    );
+    expect(row.narration).toBe("Generate — apply coupon");
+  });
+
+  it("reports progress on the same formula the QA page uses", () => {
+    const row = rowFromSession(
+      session({
+        steps: [
+          step({ status: "completed" }),
+          step({ status: "skipped" }),
+          step({ status: "active" }),
+          step({ status: "pending" }),
+        ],
+      }),
+    );
+    expect(row.progress).toBe(50);
+  });
+});
+
+describe("sortRoster", () => {
+  it("puts what needs a human above what is merely running", () => {
+    const rows: FleetRow[] = [
+      rowFromSession(session({ id: "working" })),
+      rowFromSession(
+        session({ id: "blocked", steps: [step({ status: "waiting_user" })] }),
+      ),
+      rowFromSession(session({ id: "paused", status: "paused" })),
+    ];
+    expect(sortRoster(rows).map((r) => r.id)).toEqual([
+      "blocked",
+      "working",
+      "paused",
+    ]);
+  });
+});
+
+describe("summarise", () => {
+  it("counts held browsers across working and blocked rows only", () => {
+    const rows = [
+      rowFromSession(session({ id: "a" })),
+      rowFromSession(
+        session({ id: "b", steps: [step({ status: "waiting_user" })] }),
+      ),
+      rowFromSession(session({ id: "c", status: "paused" })),
+    ];
+    expect(summarise(rows)).toMatchObject({
+      working: 1,
+      blocked: 1,
+      paused: 1,
+      browsersHeld: 2,
+    });
+  });
+});
+
+describe("escalationsFrom", () => {
+  const task = (over: Partial<EscalatableTaskLike> = {}): EscalatableTaskLike =>
+    ({
+      id: "t1",
+      repositoryId: "r1",
+      teamId: "team",
+      title: "Which coupon codes are safe to burn?",
+      description: null,
+      status: "needs_input",
+      source: "user",
+      createdByName: null,
+      createdById: null,
+      sessionId: null,
+      agentReply: null,
+      tests: null,
+      createdAt: new Date("2026-08-27T09:00:00Z"),
+      updatedAt: new Date("2026-08-27T09:30:00Z"),
+      startedAt: null,
+      completedAt: null,
+      ...over,
+    }) as EscalatableTaskLike;
+
+  it("merges blocked sessions and pushed-back tasks, oldest first", () => {
+    const rows = [
+      rowFromSession(
+        session({
+          id: "s-blocked",
+          createdAt: new Date("2026-08-27T11:00:00Z"),
+          steps: [step({ status: "waiting_user" })],
+        }),
+      ),
+    ];
+    const out = escalationsFrom(rows, [task()]);
+    expect(out.map((e) => e.id)).toEqual(["task:t1", "s-blocked"]);
+  });
+
+  it("ignores tasks that are not waiting on a human", () => {
+    expect(escalationsFrom([], [task({ status: "queued" })])).toEqual([]);
+  });
+
+  it("marks only the session escalation as holding a browser", () => {
+    const rows = [
+      rowFromSession(
+        session({ id: "s", steps: [step({ status: "waiting_user" })] }),
+      ),
+    ];
+    const out = escalationsFrom(rows, [task()]);
+    expect(out.find((e) => e.id === "s")?.holdsBrowser).toBe(true);
+    expect(out.find((e) => e.id === "task:t1")?.holdsBrowser).toBe(false);
+  });
+
+  it("prefers the agent's reply over the task title as the question", () => {
+    const out = escalationsFrom([], [task({ agentReply: "Need fresh codes" })]);
+    expect(out[0].question).toBe("Need fresh codes");
+  });
+});

--- a/src/lib/agents/fleet.test.ts
+++ b/src/lib/agents/fleet.test.ts
@@ -191,6 +191,27 @@ describe("escalationsFrom", () => {
     expect(out.find((e) => e.id === "task:t1")?.holdsBrowser).toBe(false);
   });
 
+  it("sorts an escalation with no timestamp last, not first", () => {
+    const rows = [
+      rowFromSession(
+        session({
+          id: "s-blocked",
+          createdAt: new Date("2026-08-27T11:00:00Z"),
+          steps: [step({ status: "waiting_user" })],
+        }),
+      ),
+    ];
+    const undated = task({ id: "t-undated", createdAt: null, updatedAt: null });
+    const out = escalationsFrom(rows, [task(), undated]);
+    // Oldest-first among the dated ones; the undated one brings up the rear
+    // rather than pinning to the top as "waiting since 1970".
+    expect(out.map((e) => e.id)).toEqual([
+      "task:t1",
+      "s-blocked",
+      "task:t-undated",
+    ]);
+  });
+
   it("prefers the agent's reply over the task title as the question", () => {
     const out = escalationsFrom([], [task({ agentReply: "Need fresh codes" })]);
     expect(out[0].question).toBe("Need fresh codes");

--- a/src/lib/agents/fleet.ts
+++ b/src/lib/agents/fleet.ts
@@ -55,7 +55,16 @@ export interface FleetRow {
   startedAt: Date | null;
   /** Only set when `state === "blocked"` — what the agent is waiting for. */
   blockedOn: string | null;
-  /** True while the agent is holding an embedded browser. */
+  /**
+   * Whether this agent is *expected* to be holding an embedded browser.
+   *
+   * Inferred from the run's own state (`working` or `blocked`), NOT read back
+   * from the EB pool — core has no pool handle on a page render, and the pool
+   * service is a separate process. It is therefore an estimate: an agent whose
+   * browser already crashed still reports true, and a run between claims
+   * reports true before it holds anything. The console labels the derived
+   * count as an estimate rather than as pool capacity.
+   */
   holdsBrowser: boolean;
 }
 
@@ -182,7 +191,12 @@ export interface FleetSummary {
   blocked: number;
   paused: number;
   idle: number;
-  /** Browsers currently held by this repo's agents. */
+  /**
+   * Estimated browsers held by this repo's agents — the count of rows whose
+   * `holdsBrowser` is inferred true. See the field's note: this is derived
+   * from run state, not read from the EB pool, so it is an upper bound on
+   * capacity actually in use.
+   */
   browsersHeld: number;
 }
 
@@ -263,7 +277,16 @@ export function escalationsFrom(
       holdsBrowser: false,
     }));
 
-  return [...fromSessions, ...fromTasks].sort(
-    (a, b) => (a.since?.getTime() ?? 0) - (b.since?.getTime() ?? 0),
-  );
+  // Oldest first — the thing that has been waiting longest is the thing to
+  // answer next. An escalation with no timestamp sorts LAST rather than
+  // pinning to the top forever: `?? 0` would make "unknown" read as "waiting
+  // since 1970".
+  return [...fromSessions, ...fromTasks].sort((a, b) => {
+    const at = a.since?.getTime();
+    const bt = b.since?.getTime();
+    if (at === undefined || Number.isNaN(at))
+      return bt === undefined || Number.isNaN(bt) ? 0 : 1;
+    if (bt === undefined || Number.isNaN(bt)) return -1;
+    return at - bt;
+  });
 }

--- a/src/lib/agents/fleet.ts
+++ b/src/lib/agents/fleet.ts
@@ -1,0 +1,269 @@
+import type {
+  AgentSession,
+  AgentSessionKind,
+  AgentStepState,
+} from "@/lib/db/schema";
+
+/**
+ * The slice of a QA-agent task this module needs.
+ *
+ * `qa_agent_tasks` belongs to `@lastest/plugin-qa-agent`, and core may not
+ * import a plugin's row type — so the escalation merge narrows it the way
+ * `@lastest/coverage-model` narrows its rows (`CellLike`, `DimensionLike`).
+ * The caller passes `QaAgentTask[]` straight in; it is structurally assignable.
+ */
+export interface EscalatableTaskLike {
+  id: string;
+  title: string;
+  status: string;
+  agentReply: string | null;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+}
+
+/**
+ * The Agents console's view model.
+ *
+ * Pure derivation — no DB, no clock beyond what the caller passes in — so the
+ * roster rules are unit-testable without a database. The page composes rows
+ * from two sources that cannot be joined in SQL: core's `agent_sessions` and
+ * the explorer plugin's own table, read through
+ * `src/lib/core/explorer-reads.ts`. Both arrive here as `FleetRow`s.
+ */
+
+/** What the roster groups on. Deliberately not `AgentSessionStatus`: "paused"
+ *  and "waiting for a human" are the same DB status but opposite meanings to
+ *  whoever is reading the console. */
+export type FleetState = "working" | "blocked" | "paused" | "idle";
+
+export interface FleetRow {
+  /** Stable per-row key. Session id where there is a live session. */
+  id: string;
+  /** Which agent this is, for the label and the drill-through target. */
+  kind: FleetAgentKind;
+  /** Display name — "QA agent", "Explorer", … */
+  label: string;
+  state: FleetState;
+  /** One line of what it is doing right now, already flattened. */
+  narration: string | null;
+  /** 0-100, or null for agents that do not report step progress. */
+  progress: number | null;
+  /** Sub-agent role of the active step, when the session reports one. */
+  role: string | null;
+  /** Where "Open" goes. */
+  href: string;
+  startedAt: Date | null;
+  /** Only set when `state === "blocked"` — what the agent is waiting for. */
+  blockedOn: string | null;
+  /** True while the agent is holding an embedded browser. */
+  holdsBrowser: boolean;
+}
+
+/** Core kinds plus the plugin-owned explorer. */
+export type FleetAgentKind = AgentSessionKind | "explorer";
+
+const KIND_LABELS: Record<FleetAgentKind, string> = {
+  qa: "QA agent",
+  ranger: "Ranger",
+  play: "Play agent",
+  quickstart: "QuickStart",
+  explorer: "Explorer",
+};
+
+const KIND_HREFS: Record<FleetAgentKind, string> = {
+  qa: "/qa-agent",
+  ranger: "/run",
+  play: "/tests",
+  quickstart: "/",
+  explorer: "/explorer",
+};
+
+export function fleetLabel(kind: FleetAgentKind): string {
+  return KIND_LABELS[kind];
+}
+
+/**
+ * The step a session is "at" — the first non-settled one, matching what
+ * `PhaseTimeline` highlights so the console and the drill-through never
+ * disagree about which phase is current.
+ */
+export function activeStep(session: AgentSession): AgentStepState | undefined {
+  return session.steps.find(
+    (s) =>
+      s.status === "active" ||
+      s.status === "waiting_user" ||
+      s.status === "failed",
+  );
+}
+
+/**
+ * One line of narration: the active step plus its freshest running substep.
+ *
+ * Mirrors `sessionNarration` in `qa-agent-header.tsx`. That copy stays where it
+ * is — it is a client component and this module is imported by the server page
+ * — but the two must produce the same sentence for the same session.
+ */
+export function sessionNarration(session: AgentSession): string | null {
+  const step = activeStep(session);
+  if (!step) return null;
+  const running = [...(step.substeps ?? [])]
+    .reverse()
+    .find((s) => s.status === "running");
+  if (running) return `${step.label} — ${running.detail ?? running.label}`;
+  return `${step.label} — ${step.description}`;
+}
+
+/** Same formula as `use-qa-agent.ts` so the console's bar matches the page's. */
+export function sessionProgress(session: AgentSession): number {
+  const done = session.steps.filter(
+    (s) => s.status === "completed" || s.status === "skipped",
+  ).length;
+  const total = session.steps.length;
+  return total > 0 ? Math.round((done / total) * 100) : 0;
+}
+
+/**
+ * A blocked agent is one whose current step is a human gate. It is NOT the
+ * same as `status === "paused"` — a paused agent was stopped by a person and
+ * has released its browser, while a blocked one is mid-run and still holding
+ * it. The console separates them because the second costs pool capacity and
+ * the first does not.
+ */
+export function deriveState(session: AgentSession): FleetState {
+  if (session.status === "paused") return "paused";
+  if (session.status !== "active") return "idle";
+  return activeStep(session)?.status === "waiting_user" ? "blocked" : "working";
+}
+
+/** Build a roster row from a core `agent_sessions` row. */
+export function rowFromSession(session: AgentSession): FleetRow {
+  const step = activeStep(session);
+  const state = deriveState(session);
+  const role =
+    [...(step?.substeps ?? [])].reverse().find((s) => s.agent)?.agent ?? null;
+  return {
+    id: session.id,
+    kind: session.kind,
+    label: KIND_LABELS[session.kind],
+    state,
+    narration: sessionNarration(session),
+    progress: sessionProgress(session),
+    role,
+    href: KIND_HREFS[session.kind],
+    startedAt: session.createdAt ?? null,
+    blockedOn:
+      state === "blocked" ? (step?.description ?? step?.label ?? null) : null,
+    // A run holds its browser for as long as it is not settled — including
+    // while it waits on a human, which is the whole point of showing this.
+    holdsBrowser: state === "working" || state === "blocked",
+  };
+}
+
+/** A kind with no live session still gets a row, so the roster shows the whole
+ *  fleet rather than only what happens to be running. */
+export function idleRow(kind: FleetAgentKind): FleetRow {
+  return {
+    id: `idle:${kind}`,
+    kind,
+    label: KIND_LABELS[kind],
+    state: "idle",
+    narration: null,
+    progress: null,
+    role: null,
+    href: KIND_HREFS[kind],
+    startedAt: null,
+    blockedOn: null,
+    holdsBrowser: false,
+  };
+}
+
+export interface FleetSummary {
+  working: number;
+  blocked: number;
+  paused: number;
+  idle: number;
+  /** Browsers currently held by this repo's agents. */
+  browsersHeld: number;
+}
+
+export function summarise(rows: FleetRow[]): FleetSummary {
+  return {
+    working: rows.filter((r) => r.state === "working").length,
+    blocked: rows.filter((r) => r.state === "blocked").length,
+    paused: rows.filter((r) => r.state === "paused").length,
+    idle: rows.filter((r) => r.state === "idle").length,
+    browsersHeld: rows.filter((r) => r.holdsBrowser).length,
+  };
+}
+
+/**
+ * Roster order: the rows that need a human first, then what is running, then
+ * everything at rest. Within a group, most recently started first.
+ */
+const STATE_ORDER: Record<FleetState, number> = {
+  blocked: 0,
+  working: 1,
+  paused: 2,
+  idle: 3,
+};
+
+export function sortRoster(rows: FleetRow[]): FleetRow[] {
+  return [...rows].sort((a, b) => {
+    const byState = STATE_ORDER[a.state] - STATE_ORDER[b.state];
+    if (byState !== 0) return byState;
+    return (b.startedAt?.getTime() ?? 0) - (a.startedAt?.getTime() ?? 0);
+  });
+}
+
+/**
+ * Everything an agent is waiting on a human for, in one list.
+ *
+ * Two sources, deliberately merged: a session parked on a `waiting_user` step,
+ * and a `qa_tasks` row the agent pushed back with `needs_input`. They are the
+ * same thing to whoever has to answer them.
+ */
+export interface Escalation {
+  id: string;
+  kind: FleetAgentKind;
+  label: string;
+  question: string;
+  href: string;
+  since: Date | null;
+  /** True when answering this frees a browser back to the pool. */
+  holdsBrowser: boolean;
+}
+
+export function escalationsFrom(
+  rows: FleetRow[],
+  tasks: EscalatableTaskLike[],
+): Escalation[] {
+  const fromSessions: Escalation[] = rows
+    .filter((r) => r.state === "blocked")
+    .map((r) => ({
+      id: r.id,
+      kind: r.kind,
+      label: r.label,
+      question: r.blockedOn ?? "Waiting for a decision",
+      href: r.href,
+      since: r.startedAt,
+      holdsBrowser: r.holdsBrowser,
+    }));
+
+  const fromTasks: Escalation[] = tasks
+    .filter((t) => t.status === "needs_input")
+    .map((t) => ({
+      id: `task:${t.id}`,
+      kind: "qa" as const,
+      label: KIND_LABELS.qa,
+      question: t.agentReply ?? t.title,
+      href: "/qa-agent",
+      since: t.updatedAt ?? t.createdAt ?? null,
+      // A task pushed back to the queue is not holding anything — the run that
+      // raised it has already ended.
+      holdsBrowser: false,
+    }));
+
+  return [...fromSessions, ...fromTasks].sort(
+    (a, b) => (a.since?.getTime() ?? 0) - (b.since?.getTime() ?? 0),
+  );
+}

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -41,4 +41,5 @@ export * from "./queries/billing";
 // qa_tasks/qa_agent_triggers moved to plugins/qa-agent/src/data/ (RFC §9
 // phase 4) — server components and routes read them through
 // @lastest/plugin-qa-agent/reads, actions through the plugin's own handle.
+export * from "./queries/agents-fleet";
 export * from "./queries/coverage";

--- a/src/lib/db/queries/agents-fleet.ts
+++ b/src/lib/db/queries/agents-fleet.ts
@@ -1,0 +1,79 @@
+import { db } from "../index";
+import { agentSessions } from "../schema";
+import type { AgentSession, AgentSessionKind } from "../schema";
+import { and, desc, eq, inArray, or } from "drizzle-orm";
+import { decryptAgentSessionRow } from "./integrations";
+
+/**
+ * Fleet-wide reads over `agent_sessions`.
+ *
+ * The existing readers in `./integrations.ts` are all single-kind: the QA page
+ * asks for its own `kind: "qa"` session, the play agent for its own. The
+ * Agents console is the first surface that wants *every* kind at once, so the
+ * cross-kind selects live here rather than growing `integrations.ts` a set of
+ * near-duplicate signatures.
+ *
+ * Explorer runs are deliberately absent — they live in the explorer plugin's
+ * own `explorer_sessions` table, which core cannot select from
+ * (`core-scope.md` §6). The console composes them in from
+ * `src/lib/core/explorer-reads.ts` instead.
+ */
+
+/** Kinds that can appear as a row on the fleet roster. */
+export const FLEET_AGENT_KINDS: AgentSessionKind[] = [
+  "qa",
+  "ranger",
+  "play",
+  "quickstart",
+];
+
+/**
+ * Every live (active or paused) session on a repo, any kind, newest first.
+ *
+ * Unlike `getActiveAgentSession` this does NOT sweep stuck sessions first —
+ * the console is a read-only view rendered on every navigation, and the sweep
+ * is a write. `getActiveAgentSession` still runs it on the pages that drive an
+ * agent, which is enough to keep the table honest.
+ */
+export async function listLiveAgentSessions(
+  repositoryId: string,
+): Promise<AgentSession[]> {
+  const rows = await db
+    .select()
+    .from(agentSessions)
+    .where(
+      and(
+        eq(agentSessions.repositoryId, repositoryId),
+        inArray(agentSessions.kind, FLEET_AGENT_KINDS),
+        or(
+          eq(agentSessions.status, "active"),
+          eq(agentSessions.status, "paused"),
+        ),
+      ),
+    )
+    .orderBy(desc(agentSessions.createdAt));
+  return rows.map(decryptAgentSessionRow);
+}
+
+/**
+ * The most recent settled session per kind, for the console's "Settled today"
+ * strip. One query, capped — the console only ever renders a handful.
+ */
+export async function listRecentSettledAgentSessions(
+  repositoryId: string,
+  limit = 8,
+): Promise<AgentSession[]> {
+  const rows = await db
+    .select()
+    .from(agentSessions)
+    .where(
+      and(
+        eq(agentSessions.repositoryId, repositoryId),
+        inArray(agentSessions.kind, FLEET_AGENT_KINDS),
+        inArray(agentSessions.status, ["completed", "failed", "cancelled"]),
+      ),
+    )
+    .orderBy(desc(agentSessions.completedAt), desc(agentSessions.createdAt))
+    .limit(limit);
+  return rows.map(decryptAgentSessionRow);
+}

--- a/src/lib/db/queries/agents-fleet.ts
+++ b/src/lib/db/queries/agents-fleet.ts
@@ -1,7 +1,7 @@
 import { db } from "../index";
 import { agentSessions } from "../schema";
 import type { AgentSession, AgentSessionKind } from "../schema";
-import { and, desc, eq, inArray, or } from "drizzle-orm";
+import { and, desc, eq, inArray, or, sql } from "drizzle-orm";
 import { decryptAgentSessionRow } from "./integrations";
 
 /**
@@ -56,8 +56,16 @@ export async function listLiveAgentSessions(
 }
 
 /**
- * The most recent settled session per kind, for the console's "Settled today"
- * strip. One query, capped — the console only ever renders a handful.
+ * The most recently settled sessions on a repo, any kind, for the console's
+ * "Settled today" strip. One query, capped — the console only ever renders a
+ * handful.
+ *
+ * NOT partitioned per kind: a repo that settled eight QA sessions and no
+ * Ranger runs gets eight QA rows, which is what "most recent" means and what
+ * the strip renders. Ordering is `completed_at DESC NULLS LAST` — a settled
+ * row can carry a null `completedAt` (a cancel that never stamped it), and
+ * Postgres sorts nulls FIRST under a bare `DESC`, which would float exactly
+ * the least informative rows to the top of a "recent" list.
  */
 export async function listRecentSettledAgentSessions(
   repositoryId: string,
@@ -73,7 +81,10 @@ export async function listRecentSettledAgentSessions(
         inArray(agentSessions.status, ["completed", "failed", "cancelled"]),
       ),
     )
-    .orderBy(desc(agentSessions.completedAt), desc(agentSessions.createdAt))
+    .orderBy(
+      sql`${agentSessions.completedAt} DESC NULLS LAST`,
+      desc(agentSessions.createdAt),
+    )
     .limit(limit);
   return rows.map(decryptAgentSessionRow);
 }

--- a/src/lib/db/queries/integrations.ts
+++ b/src/lib/db/queries/integrations.ts
@@ -253,9 +253,11 @@ export async function upsertComposeConfig(
 // encrypt on write, decrypt on read at this query layer so every consumer (and
 // mergeMetadata's read-merge-rewrite cycle) works with plaintext. The email is
 // left plaintext (low-sensitivity identifier shown in the QuickStart UI).
-function decryptAgentSessionRow<T extends { metadata: AgentSessionMetadata }>(
-  row: T,
-): T {
+// Exported for `./agents-fleet.ts`, which runs its own cross-kind selects and
+// must apply the same decrypt-on-read as every reader in this module.
+export function decryptAgentSessionRow<
+  T extends { metadata: AgentSessionMetadata },
+>(row: T): T {
   return { ...row, metadata: decryptSessionMetadata(row.metadata) };
 }
 


### PR DESCRIPTION
**Stack: 1 of 2.** Base is `feat/pharma-readyness`. The Explorer half is #114, stacked on this branch — core and plugin changes stay separate PRs per `core-scope.md` / RFC §7.2.

## What this adds

`/agents` — one roster of every agent working the selected repo, with what each is doing and what it is waiting on a human for. The sidebar's **QA Agent** entry becomes **Agents**; the QA agent page is now reached by drilling through a roster row and gains a breadcrumb back out.

## The idea worth reviewing

`paused` and `blocked on a human` are the same `agent_sessions.status` but opposite things to whoever reads the console:

- a **paused** run was stopped by a person and has released its embedded browser
- a **blocked** run is mid-flight, parked on a `waiting_user` step, and is **still holding** it

`deriveState()` splits them, and the capacity read-out counts held browsers — so an unanswered question shows up as pool capacity you cannot use. That is the argument for having a console at all, and it is the thing to push back on if you disagree.

Escalations merge two sources that are one thing to a human: a session on a `waiting_user` step, and a `qa_tasks` row the agent pushed back as `needs_input`.

## Notes for the reviewer

- **No new tables, no migration.** Everything is derived from `agent_sessions`, `qa_tasks` and the existing team run-usage counters.
- **Explorer is deliberately missing** from the roster here — `explorer_sessions` is the plugin's table and core cannot select from it. It keeps its own sidebar entry until the next PR in the stack.
- **The Pro gate moved onto `/agents`.** The console is the door to agent work, so it carries the entitlement check; `/qa-agent` keeps its own so direct navigation cannot bypass it. `QaAgentUpgradeGate` gained optional `title`/`icon`/`description` so the locked console heads with its own name — the run preview beneath is unchanged, since a QA run is what the plan unlocks.
- **`decryptAgentSessionRow` is now exported** from `queries/integrations.ts` so the new cross-kind selects apply the same decrypt-on-read as every other reader.
- **No live pool-service call** on page render. The console reports browsers held *by this repo's agents*; it does not fetch the fleet-wide cap, because that is a network hop to another process on every navigation.

## Not in scope

The design also had a per-agent policy strip (scope, time budget, guardrails). That needs a fleet-policy model that does not exist yet — building the strip now would mean showing invented numbers, so it is deferred rather than faked.

## Verification

- `pnpm exec vitest run` — 128 files, 1921 passing
- `pnpm exec tsc --noEmit` — clean
- `pnpm build` — compiled successfully, `/agents` present in the route table
- 12 new unit tests over the derivation rules (state split, browser accounting, narration, ordering, escalation merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
