### PR TITLE
feat(agents): fold the Explorer into the console roster

### DIFF
--- a/plugins/explorer/src/data/queries.ts
+++ b/plugins/explorer/src/data/queries.ts
@@ -188,6 +188,33 @@ export async function getActiveSession(
   return row ? decryptSession(ctx, row) : undefined;
 }
 
+/**
+ * The repo's live run for the Agents console — `active` **or** `paused`.
+ *
+ * Distinct from `getActiveSession`, which is what the Explorer page drives and
+ * must stay `active`-only: resuming, stepping and cancelling all act on a run
+ * that is actually running. The roster has the opposite need — a paused run is
+ * still a roster row, and showing it as "idle" is exactly the under-report the
+ * console exists to prevent.
+ */
+export async function getLiveSession(
+  ctx: Ctx,
+  repositoryId: string,
+): Promise<ExplorerSession | undefined> {
+  const [row] = await ctx.db
+    .select()
+    .from(explorerSessions)
+    .where(
+      and(
+        eq(explorerSessions.repositoryId, repositoryId),
+        inArray(explorerSessions.status, ["active", "paused"]),
+      ),
+    )
+    .orderBy(desc(explorerSessions.createdAt))
+    .limit(1);
+  return row ? decryptSession(ctx, row) : undefined;
+}
+
 export async function getLatestSession(
   ctx: Ctx,
   repositoryId: string,

--- a/plugins/explorer/src/fleet.test.ts
+++ b/plugins/explorer/src/fleet.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { projectFleetSession } from "./fleet";
+import type { ExplorerStepState } from "./types";
+
+/**
+ * The plugin half of the Agents-console projection.
+ *
+ * Core's `rowFromExplorer` is tested in isolation over in
+ * `src/lib/agents/fleet.test.ts`, so these assertions are what stops the two
+ * halves from drifting: a status the read admits but the projection drops, or
+ * a field (`awaitingUser`) that ships its placeholder forever.
+ */
+const step = (over: Partial<ExplorerStepState> = {}): ExplorerStepState =>
+  ({
+    id: "explorer_plan",
+    label: "Planning",
+    description: "Deciding what to try",
+    status: "completed",
+    substeps: [],
+    ...over,
+  }) as ExplorerStepState;
+
+const session = (over: Record<string, unknown> = {}) => ({
+  id: "s1",
+  status: "active" as const,
+  steps: [
+    step(),
+    step({ id: "explorer_act", label: "Acting", status: "active" }),
+  ],
+  createdAt: new Date("2026-08-27T10:00:00Z"),
+  metadata: { targetUrl: "https://example.test" },
+  ...over,
+});
+
+describe("projectFleetSession", () => {
+  it("projects a running session onto the console's shape", () => {
+    const out = projectFleetSession(session());
+    expect(out).toMatchObject({
+      id: "s1",
+      status: "active",
+      stepLabel: "Acting",
+      progress: 50,
+      targetUrl: "https://example.test",
+    });
+  });
+
+  it("keeps a paused run on the roster rather than dropping it", () => {
+    // The read is `getLiveSession` (active OR paused) precisely so this row
+    // exists — a paused Explorer showing as idle under-reports held browsers.
+    expect(projectFleetSession(session({ status: "paused" }))?.status).toBe(
+      "paused",
+    );
+  });
+
+  it("drops a settled run — the roster is live runs only", () => {
+    for (const status of ["completed", "failed", "cancelled"] as const) {
+      expect(projectFleetSession(session({ status }))).toBeNull();
+    }
+  });
+
+  it("reports awaitingUser as false — explorer has no human gate yet", () => {
+    // Pins the placeholder. When explorer grows a gate, this assertion is the
+    // thing that fails and points at the field that has to start carrying it.
+    expect(projectFleetSession(session())?.awaitingUser).toBe(false);
+  });
+
+  it("prefers the freshest running substep for the narration detail", () => {
+    const out = projectFleetSession(
+      session({
+        steps: [
+          step({
+            id: "explorer_act",
+            status: "active",
+            substeps: [
+              { label: "First", status: "done" },
+              { label: "Second", detail: "clicking", status: "running" },
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(out?.stepDetail).toBe("clicking");
+  });
+});

--- a/plugins/explorer/src/fleet.ts
+++ b/plugins/explorer/src/fleet.ts
@@ -1,0 +1,84 @@
+import { orm } from "./data/db";
+import * as q from "./data/queries";
+import { explorerPlugin } from "./index";
+import { explorerWiring } from "./wiring";
+
+/**
+ * The one read core is allowed to make into explorer's sessions.
+ *
+ * The Agents console lists every agent working a repo in a single roster, and
+ * the Explorer is one of them — but `explorer_sessions` is this plugin's table
+ * and `core-scope.md` §6 puts it out of core's reach. So the plugin answers the
+ * question instead of exposing the table: core calls this, gets a projection,
+ * and never learns the row shape.
+ *
+ * Deliberately a projection and not `ExplorerSession`. The row carries an
+ * encrypted login password in `metadata`, and the console has no business
+ * holding one — a narrow return type makes that structural rather than a rule
+ * someone has to remember. It also keeps core free of explorer's step and
+ * metadata types, so the plugin can change them without a core PR.
+ *
+ * Authorization comes from `contextFor()`, exactly as it does for every action
+ * in this package: the runtime resolves the caller's scope through the app's
+ * own guard, so this cannot read a repo the caller cannot see. There is no
+ * unscoped handle to reach for.
+ */
+export interface ExplorerFleetSession {
+  id: string;
+  /** `active` or `paused` only — settled runs are not roster rows. */
+  status: "active" | "paused";
+  /** Label of the step the run is on, for the console's narration line. */
+  stepLabel: string | null;
+  /** Freshest running substep detail, when the step reports one. */
+  stepDetail: string | null;
+  /** 0-100 across the pipeline's steps. */
+  progress: number;
+  /** True when the run is parked waiting for a person. */
+  awaitingUser: boolean;
+  startedAt: Date | null;
+  targetUrl: string | null;
+}
+
+export async function readLiveExplorerSession(
+  repositoryId: string,
+): Promise<ExplorerFleetSession | null> {
+  const { runtime, host } = explorerWiring();
+  const ctx = await runtime.contextFor(explorerPlugin, { repositoryId });
+  const session = await q.getActiveSession(
+    { db: orm(ctx.data), host },
+    repositoryId,
+  );
+  if (!session) return null;
+
+  // `getActiveSession` filters to `active`, but the projection's type is what
+  // core reads — narrow explicitly rather than casting.
+  if (session.status !== "active" && session.status !== "paused") return null;
+
+  const step = session.steps.find(
+    (s) => s.status === "active" || s.status === "failed",
+  );
+  const running = [...(step?.substeps ?? [])]
+    .reverse()
+    .find((s) => s.status === "running");
+  const settled = session.steps.filter(
+    (s) => s.status === "completed" || s.status === "skipped",
+  ).length;
+
+  return {
+    id: session.id,
+    status: session.status,
+    stepLabel: step?.label ?? null,
+    stepDetail: running?.detail ?? running?.label ?? null,
+    progress:
+      session.steps.length > 0
+        ? Math.round((settled / session.steps.length) * 100)
+        : 0,
+    // Explorer has no human gate in its pipeline today, so this is always
+    // false. It is in the projection because the console's roster models
+    // "blocked on you" for every agent, and the day explorer grows a gate this
+    // is the field that carries it rather than a second core change.
+    awaitingUser: false,
+    startedAt: session.createdAt ?? null,
+    targetUrl: session.metadata.targetUrl ?? null,
+  };
+}

--- a/plugins/explorer/src/fleet.ts
+++ b/plugins/explorer/src/fleet.ts
@@ -1,6 +1,7 @@
 import { orm } from "./data/db";
 import * as q from "./data/queries";
 import { explorerPlugin } from "./index";
+import type { ExplorerSessionStatus, ExplorerStepState } from "./types";
 import { explorerWiring } from "./wiring";
 
 /**
@@ -39,19 +40,24 @@ export interface ExplorerFleetSession {
   targetUrl: string | null;
 }
 
-export async function readLiveExplorerSession(
-  repositoryId: string,
-): Promise<ExplorerFleetSession | null> {
-  const { runtime, host } = explorerWiring();
-  const ctx = await runtime.contextFor(explorerPlugin, { repositoryId });
-  const session = await q.getActiveSession(
-    { db: orm(ctx.data), host },
-    repositoryId,
-  );
-  if (!session) return null;
-
-  // `getActiveSession` filters to `active`, but the projection's type is what
-  // core reads — narrow explicitly rather than casting.
+/**
+ * The row a live explorer session projects to, as a pure function.
+ *
+ * Split out of `readLiveExplorerSession` so the plugin half of the wiring is
+ * pinned by a unit test rather than only by the DB-backed integration run.
+ * Core's `rowFromExplorer` is tested in isolation, so without this the two
+ * halves of the projection had no test between them: `awaitingUser` could ship
+ * hardcoded `false` forever with every test green.
+ */
+export function projectFleetSession(session: {
+  id: string;
+  status: ExplorerSessionStatus;
+  steps: ExplorerStepState[];
+  createdAt: Date | null;
+  metadata: { targetUrl?: string | null };
+}): ExplorerFleetSession | null {
+  // The query admits exactly these two, but the projection's type is what core
+  // reads — narrow explicitly rather than casting.
   if (session.status !== "active" && session.status !== "paused") return null;
 
   const step = session.steps.find(
@@ -76,9 +82,28 @@ export async function readLiveExplorerSession(
     // Explorer has no human gate in its pipeline today, so this is always
     // false. It is in the projection because the console's roster models
     // "blocked on you" for every agent, and the day explorer grows a gate this
-    // is the field that carries it rather than a second core change.
+    // is the field that carries it rather than a second core change. The unit
+    // test below asserts today's value, so growing the gate breaks a test
+    // instead of silently shipping `false`.
     awaitingUser: false,
     startedAt: session.createdAt ?? null,
     targetUrl: session.metadata.targetUrl ?? null,
   };
+}
+
+export async function readLiveExplorerSession(
+  repositoryId: string,
+): Promise<ExplorerFleetSession | null> {
+  const { runtime, host } = explorerWiring();
+  const ctx = await runtime.contextFor(explorerPlugin, { repositoryId });
+  // `getLiveSession`, not `getActiveSession`: a paused run is still holding a
+  // roster slot, and the console under-reports held browsers if it reads as
+  // idle. The Explorer page keeps the `active`-only read, which is what its
+  // resume/cancel controls need.
+  const session = await q.getLiveSession(
+    { db: orm(ctx.data), host },
+    repositoryId,
+  );
+  if (!session) return null;
+  return projectFleetSession(session);
 }

--- a/plugins/explorer/src/index.ts
+++ b/plugins/explorer/src/index.ts
@@ -62,3 +62,6 @@ export {
   isExplorerConfigured,
   type ExplorerWiring,
 } from "./wiring";
+// The Agents console's one read into this plugin's sessions — see fleet.ts
+// for why it is a projection rather than the row.
+export { readLiveExplorerSession, type ExplorerFleetSession } from "./fleet";

--- a/plugins/explorer/src/ui/page.tsx
+++ b/plugins/explorer/src/ui/page.tsx
@@ -31,6 +31,11 @@ export interface ExplorerPageProps {
   browserViewer?: ComponentType<{ streamUrl: string }>;
   /** Shown instead of the tool when the team's plan does not include it. */
   upgradeGate?: ReactNode;
+  /** Rendered above the title. Core passes the "Agents › Explorer" trail —
+   *  the console is the only sidebar entry for agent work, so this page needs
+   *  a visible parent. A plugin cannot import a core component, so it arrives
+   *  as a node, the same seam `upgradeGate` and `noRepository` already use. */
+  breadcrumb?: ReactNode;
   /** Shown when no repository is selected. */
   noRepository?: ReactNode;
 }
@@ -42,6 +47,7 @@ export default async function ExplorerPage({
   browserViewer,
   upgradeGate,
   noRepository,
+  breadcrumb,
 }: ExplorerPageProps) {
   if (!repositoryId) return <>{noRepository ?? null}</>;
 
@@ -87,7 +93,8 @@ export default async function ExplorerPage({
     <div className="flex-1 p-6 overflow-auto">
       <div className="max-w-5xl mx-auto space-y-6">
         <header className="space-y-1">
-          <h1 className="text-2xl font-semibold flex items-center gap-2">
+          {breadcrumb}
+          <h1 className="text-2xl font-semibold flex items-center gap-2 pt-1">
             <Compass className="h-6 w-6" />
             Explorer
           </h1>

--- a/src/app/(app)/agents/page.tsx
+++ b/src/app/(app)/agents/page.tsx
@@ -12,12 +12,14 @@ import { getQaConsoleQueue } from "@lastest/plugin-qa-agent/reads";
 import {
   escalationsFrom,
   idleRow,
+  rowFromExplorer,
   rowFromSession,
   sortRoster,
   summarise,
   type FleetAgentKind,
   type FleetRow,
 } from "@/lib/agents/fleet";
+import { getLiveExplorerSession } from "@/lib/core/explorer-reads";
 import { AgentsConsole } from "@/components/agents/agents-console-client";
 import { QaAgentUpgradeGate } from "@lastest/plugin-qa-agent/ui/qa-agent-upgrade-gate";
 import {
@@ -35,9 +37,10 @@ export const dynamic = "force-dynamic";
  * This is the only sidebar entry for agent work: the QA agent and the Explorer
  * are reached by drilling through a row rather than by their own nav items.
  *
- * Explorer rows are absent from this PR. They live in the explorer plugin's
- * own table and arrive through `src/lib/core/explorer-reads.ts`, which is the
- * next change in the stack — until then the Explorer keeps its sidebar entry.
+ * The roster is composed from two stores that cannot be joined in SQL: core's
+ * `agent_sessions`, and the explorer plugin's own `explorer_sessions`, which
+ * core reaches only through `src/lib/core/explorer-reads.ts`. Both become
+ * `FleetRow`s before the console sees them.
  */
 export default async function AgentsPage() {
   const session = await getCurrentSession();
@@ -91,28 +94,34 @@ export default async function AgentsPage() {
     );
   }
 
-  const [liveSessions, settled, queue, runUsage] = await Promise.all([
-    listLiveAgentSessions(selectedRepo.id).catch(() => []),
-    listRecentSettledAgentSessions(selectedRepo.id).catch(() => []),
-    // Only the two things the console renders — the escalations and the queued
-    // count — rather than every task on the repo. This page is
-    // `force-dynamic`, so the query runs on every navigation.
-    getQaConsoleQueue(selectedRepo.id).catch(() => ({
-      needsInput: [],
-      queuedCount: 0,
-    })),
-    teamId ? getTeamRunUsage(teamId).catch(() => null) : Promise.resolve(null),
-  ]);
+  const [liveSessions, settled, queue, runUsage, explorerSession] =
+    await Promise.all([
+      listLiveAgentSessions(selectedRepo.id).catch(() => []),
+      listRecentSettledAgentSessions(selectedRepo.id).catch(() => []),
+      // Only the two things the console renders — the escalations and the
+      // queued count — rather than every task on the repo. This page is
+      // `force-dynamic`, so the query runs on every navigation.
+      getQaConsoleQueue(selectedRepo.id).catch(() => ({
+        needsInput: [],
+        queuedCount: 0,
+      })),
+      teamId
+        ? getTeamRunUsage(teamId).catch(() => null)
+        : Promise.resolve(null),
+      getLiveExplorerSession(selectedRepo.id),
+    ]);
 
   // One row per live session, plus an idle row for every kind that has none —
   // the roster is the whole fleet, not just what happens to be running.
-  const liveRows = liveSessions.map(rowFromSession);
+  const liveRows = [
+    ...liveSessions.map(rowFromSession),
+    ...(explorerSession ? [rowFromExplorer(explorerSession)] : []),
+  ];
   const kindsWithLiveRow = new Set<FleetAgentKind>(liveRows.map((r) => r.kind));
+  const rosterKinds: FleetAgentKind[] = [...FLEET_AGENT_KINDS, "explorer"];
   const rows: FleetRow[] = sortRoster([
     ...liveRows,
-    ...FLEET_AGENT_KINDS.filter(
-      (k: FleetAgentKind) => !kindsWithLiveRow.has(k),
-    ).map(idleRow),
+    ...rosterKinds.filter((k) => !kindsWithLiveRow.has(k)).map(idleRow),
   ]);
 
   return (

--- a/src/app/(app)/explorer/page.tsx
+++ b/src/app/(app)/explorer/page.tsx
@@ -6,6 +6,7 @@ import { getCurrentSession } from "@/lib/auth";
 import { getSelectedRepository, getAISettings } from "@/lib/db/queries";
 import { getEnvironmentConfig } from "@/server/actions/environment";
 import { ExplorerBrowserViewer } from "@/components/explorer-browser-viewer";
+import { AgentBreadcrumb } from "@/components/agents/agent-breadcrumb";
 import { QaAgentUpgradeGate } from "@lastest/plugin-qa-agent/ui/qa-agent-upgrade-gate";
 import { qaAgentMinPlanName } from "@/lib/billing/feature-access";
 import { planConfig } from "@/lib/billing/plans";
@@ -61,6 +62,7 @@ export default async function Page() {
         aiSettings?.provider && aiSettings.provider !== "none",
       )}
       browserViewer={ExplorerBrowserViewer}
+      breadcrumb={<AgentBreadcrumb current="Explorer" />}
       upgradeGate={
         team ? (
           <QaAgentUpgradeGate

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -17,7 +17,6 @@ import {
   ShieldCheck,
   GitCommit,
   Wrench,
-  Compass,
   Network,
   Lock,
   Waypoints,
@@ -83,7 +82,6 @@ const definitionNav = [
 const executionNav = [
   { name: "Runs", href: "/run", icon: Play },
   { name: "Agents", href: "/agents", icon: Network },
-  { name: "Explorer", href: "/explorer", icon: Compass },
   { name: "Compare", href: "/compare", icon: GitCompare },
   { name: "Impact", href: "/analytics/impact", icon: TrendingDown },
 ];

--- a/src/lib/agents/fleet.test.ts
+++ b/src/lib/agents/fleet.test.ts
@@ -3,6 +3,7 @@ import type { AgentSession, AgentStepState } from "@/lib/db/schema";
 import {
   deriveState,
   escalationsFrom,
+  rowFromExplorer,
   rowFromSession,
   sortRoster,
   summarise,
@@ -215,5 +216,56 @@ describe("escalationsFrom", () => {
   it("prefers the agent's reply over the task title as the question", () => {
     const out = escalationsFrom([], [task({ agentReply: "Need fresh codes" })]);
     expect(out[0].question).toBe("Need fresh codes");
+  });
+});
+
+describe("rowFromExplorer", () => {
+  const explorer = (over: Record<string, unknown> = {}) => ({
+    id: "x1",
+    status: "active" as const,
+    stepLabel: "Act",
+    stepDetail: "scenario 3 of 4",
+    progress: 62,
+    awaitingUser: false,
+    startedAt: new Date("2026-08-27T10:00:00Z"),
+    targetUrl: "https://staging.example.dev",
+    ...over,
+  });
+
+  it("lands on the same shape as a core session row", () => {
+    const row = rowFromExplorer(explorer());
+    expect(row).toMatchObject({
+      kind: "explorer",
+      state: "working",
+      progress: 62,
+      holdsBrowser: true,
+      href: "/explorer",
+    });
+  });
+
+  it("narrates step, detail and target together", () => {
+    expect(rowFromExplorer(explorer()).narration).toBe(
+      "Act — scenario 3 of 4 · https://staging.example.dev",
+    );
+  });
+
+  it("falls back to the step label when no substep is running", () => {
+    expect(rowFromExplorer(explorer({ stepDetail: null })).narration).toBe(
+      "Act · https://staging.example.dev",
+    );
+  });
+
+  it("frees the browser when the run is paused", () => {
+    const row = rowFromExplorer(explorer({ status: "paused" }));
+    expect(row.state).toBe("paused");
+    expect(row.holdsBrowser).toBe(false);
+  });
+
+  it("becomes an escalation when explorer grows a human gate", () => {
+    // `awaitingUser` is always false today — this pins the wiring so the day
+    // the pipeline gains a gate, the console already routes it correctly.
+    const rows = [rowFromExplorer(explorer({ awaitingUser: true }))];
+    expect(rows[0].state).toBe("blocked");
+    expect(escalationsFrom(rows, [])).toHaveLength(1);
   });
 });

--- a/src/lib/agents/fleet.ts
+++ b/src/lib/agents/fleet.ts
@@ -3,6 +3,9 @@ import type {
   AgentSessionKind,
   AgentStepState,
 } from "@/lib/db/schema";
+// Type-only, so this module stays pure and importable from a client component:
+// `explorer-reads` is `server-only`, and the import is erased at compile time.
+import type { ExplorerFleetSession } from "@/lib/core/explorer-reads";
 
 /**
  * The slice of a QA-agent task this module needs.
@@ -192,17 +195,12 @@ export function idleRow(kind: FleetAgentKind): FleetRow {
  * Kept here beside `rowFromSession` rather than in the read port so both
  * sources land on one shape and one set of rules — the console must not care
  * which table a row came from.
+ *
+ * Takes `ExplorerFleetSession` itself rather than an inline structural copy of
+ * it: two hand-maintained shapes that must stay byte-identical would let a
+ * field added to the projection be silently dropped here.
  */
-export function rowFromExplorer(session: {
-  id: string;
-  status: "active" | "paused";
-  stepLabel: string | null;
-  stepDetail: string | null;
-  progress: number;
-  awaitingUser: boolean;
-  startedAt: Date | null;
-  targetUrl: string | null;
-}): FleetRow {
+export function rowFromExplorer(session: ExplorerFleetSession): FleetRow {
   const state: FleetState =
     session.status === "paused"
       ? "paused"

--- a/src/lib/agents/fleet.ts
+++ b/src/lib/agents/fleet.ts
@@ -186,6 +186,52 @@ export function idleRow(kind: FleetAgentKind): FleetRow {
   };
 }
 
+/**
+ * The explorer's projection, as a roster row.
+ *
+ * Kept here beside `rowFromSession` rather than in the read port so both
+ * sources land on one shape and one set of rules — the console must not care
+ * which table a row came from.
+ */
+export function rowFromExplorer(session: {
+  id: string;
+  status: "active" | "paused";
+  stepLabel: string | null;
+  stepDetail: string | null;
+  progress: number;
+  awaitingUser: boolean;
+  startedAt: Date | null;
+  targetUrl: string | null;
+}): FleetRow {
+  const state: FleetState =
+    session.status === "paused"
+      ? "paused"
+      : session.awaitingUser
+        ? "blocked"
+        : "working";
+  const narration = session.stepLabel
+    ? session.stepDetail
+      ? `${session.stepLabel} — ${session.stepDetail}`
+      : session.stepLabel
+    : null;
+  return {
+    id: session.id,
+    kind: "explorer",
+    label: KIND_LABELS.explorer,
+    state,
+    narration: session.targetUrl
+      ? `${narration ?? "Exploring"} · ${session.targetUrl}`
+      : narration,
+    progress: session.progress,
+    // Explorer's steps carry no sub-agent role the way a QA run's do.
+    role: null,
+    href: KIND_HREFS.explorer,
+    startedAt: session.startedAt,
+    blockedOn: state === "blocked" ? session.stepLabel : null,
+    holdsBrowser: state === "working" || state === "blocked",
+  };
+}
+
 export interface FleetSummary {
   working: number;
   blocked: number;

--- a/src/lib/core/explorer-reads.ts
+++ b/src/lib/core/explorer-reads.ts
@@ -1,0 +1,40 @@
+import "server-only";
+
+import {
+  readLiveExplorerSession,
+  type ExplorerFleetSession,
+} from "@lastest/plugin-explorer";
+
+/**
+ * Reverse read into the `explorer` plugin's own sessions, for the Agents
+ * console.
+ *
+ * The mirror image of `share-reads.ts`, for the same reason: the console lists
+ * every agent working a repo, the Explorer is one of them, and
+ * `explorer_sessions` is not a table core may select from (`core-scope.md` §6).
+ * `src/lib/core/` is the one place in `src/` that legitimately imports plugins,
+ * so the read crosses here and nowhere else.
+ *
+ * What comes back is a projection, not the row — the plugin decides what core
+ * is allowed to know (`plugins/explorer/src/fleet.ts` explains why, including
+ * the encrypted credential the row carries and this one does not).
+ *
+ * Like `share-reads.ts` this deliberately does NOT import `./runtime`: the
+ * plugin resolves its own wiring, and `src/instrumentation.ts` awaits
+ * `getPluginRuntime()` before the server serves a request, so by the time a
+ * page calls this the explorer's wiring is already in place. If it somehow is
+ * not, the console must still render — an agent roster missing one row beats a
+ * 500 — so the failure is swallowed to `null` here rather than at every call
+ * site.
+ */
+export type { ExplorerFleetSession };
+
+export async function getLiveExplorerSession(
+  repositoryId: string,
+): Promise<ExplorerFleetSession | null> {
+  try {
+    return await readLiveExplorerSession(repositoryId);
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/core/explorer-reads.ts
+++ b/src/lib/core/explorer-reads.ts
@@ -4,6 +4,9 @@ import {
   readLiveExplorerSession,
   type ExplorerFleetSession,
 } from "@lastest/plugin-explorer";
+import { getLogger } from "@/lib/logger";
+
+const log = getLogger("ExplorerReads");
 
 /**
  * Reverse read into the `explorer` plugin's own sessions, for the Agents
@@ -34,7 +37,11 @@ export async function getLiveExplorerSession(
 ): Promise<ExplorerFleetSession | null> {
   try {
     return await readLiveExplorerSession(repositoryId);
-  } catch {
+  } catch (err) {
+    log.warn(
+      { err, repositoryId },
+      "explorer fleet read failed; roster will show the Explorer as idle",
+    );
     return null;
   }
 }


### PR DESCRIPTION
**Stack: 2 of 2.** Base is `feat/agents-console` (#113) — review that one first. Split out because it touches the explorer plugin as well as core, and those ship as separate PRs per `core-scope.md` / RFC §7.2.

## What this adds

Explorer runs appear on the `/agents` roster beside core's agents, and Explorer loses its own sidebar entry — `/agents` becomes the single door to agent work. The Explorer page keeps its route and gains the same breadcrumb the QA agent page has.

## The boundary, and why it is shaped this way

`explorer_sessions` is the plugin's table; core cannot select from it. So the plugin **answers the question instead of exposing the table**:

- `readLiveExplorerSession()` (`plugins/explorer/src/fleet.ts`) returns a **projection**, not `ExplorerSession`
- core reaches it through `src/lib/core/explorer-reads.ts`, the mirror of the existing `share-reads.ts`

The projection is the part worth a second look. The session row carries an **encrypted login password** in `metadata`; the console has no business holding one. A narrow return type makes that structural rather than a rule someone has to remember, and it keeps core free of explorer's step/metadata types so the plugin can change them without a core PR.

Authorization is `contextFor()`'s, exactly as for every action in that package — there is no unscoped handle to reach for, so this cannot read a repo the caller cannot see.

## Notes for the reviewer

- **`rowFromExplorer` lands the projection on the same `FleetRow`** the core sessions produce, so the roster's rules (blocked before working; a blocked agent still holds its browser) apply without a special case.
- **`awaitingUser` is always `false` today** — explorer's pipeline has no human gate. It is in the projection so that adding one later needs no core change, and there is a test pinning that wiring so the field cannot rot into a lie.
- **The breadcrumb crosses as a `ReactNode` prop**, not an import — a plugin cannot import a core component, so it uses the seam `upgradeGate` and `noRepository` already use.
- **The read fails soft to `null`.** A roster missing one row beats a 500 on the console, so the failure is swallowed once in the read port rather than at each call site. Say the word if you would rather it surface.

## Verification

- `pnpm exec vitest run` — 128 files, 1921 passing (5 new tests covering the explorer row)
- `pnpm exec tsc --noEmit` — clean
- `pnpm build` — compiled successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)