### PR TITLE
feat(pharma): segment fork in onboarding + the regulated profile

### DIFF
--- a/packages/db/src/schema/identity.ts
+++ b/packages/db/src/schema/identity.ts
@@ -86,6 +86,21 @@ export const teams = pgTable("teams", {
   /** Verify phase (v1.14+) — when true, /verify is the primary surface and
    *  appears as the first sidebar entry. /run and /review are demoted. */
   verifyPhaseEnabled: boolean("verify_phase_enabled").default(true),
+  /**
+   * Regulated (pharma / life-sciences) segment profile — set by the Pharma
+   * onboarding fork, and the single flag every restriction in
+   * `src/lib/segment/regulated.ts` reads.
+   *
+   * It encodes three rules: nothing probabilistic produces a verdict, nothing
+   * leaves the tenant without an authenticated identity attached, and nothing
+   * on screen suggests the tool is a game. See
+   * `docs/pharma-restricted-scope.md` §3.
+   *
+   * Deliberately a *team* flag rather than a per-repo one: it governs
+   * tenant-wide surfaces (public share links, the leaderboard, billing) that
+   * have no repository in scope to key off.
+   */
+  regulatedMode: boolean("regulated_mode").default(false),
   storageQuotaBytes: bigint("storage_quota_bytes", { mode: "number" }).default(
     10737418240,
   ), // 10 GB

--- a/plugins/share/src/actions.ts
+++ b/plugins/share/src/actions.ts
@@ -58,7 +58,7 @@ export async function publishBuildShare(
   // validated GxP system, so hiding the button that mints one is not a
   // control — this is. See `docs/pharma-restricted-scope.md` §3.3.
   const ownerFlags = await host.getOwnerTeamFlags(info.repositoryId);
-  if (ownerFlags?.regulatedMode) {
+  if (ownerFlags && !ownerFlags.sharingPermitted) {
     throw new Error(
       "Public share links are disabled for this team. Regulated mode is on, and a public link would serve run screenshots to anyone holding the URL.",
     );

--- a/plugins/share/src/actions.ts
+++ b/plugins/share/src/actions.ts
@@ -53,6 +53,17 @@ export async function publishBuildShare(
   });
   const actor = requireActor(ctx);
 
+  // Regulated (pharma) profile: refuse outright. A `/r/<slug>` link is an
+  // anonymous, unauthenticated URL serving screenshots of what may be a
+  // validated GxP system, so hiding the button that mints one is not a
+  // control — this is. See `docs/pharma-restricted-scope.md` §3.3.
+  const ownerFlags = await host.getOwnerTeamFlags(info.repositoryId);
+  if (ownerFlags?.regulatedMode) {
+    throw new Error(
+      "Public share links are disabled for this team. Regulated mode is on, and a public link would serve run screenshots to anyone holding the URL.",
+    );
+  }
+
   const kind: PublicShareKind = options.kind ?? "regression";
 
   // Reuse an existing live share instead of minting a new URL on every

--- a/plugins/share/src/data/queries.ts
+++ b/plugins/share/src/data/queries.ts
@@ -145,6 +145,30 @@ export async function revokePublicShareById(id: string): Promise<void> {
     .where(eq(sharePublicShares.id, id));
 }
 
+/**
+ * Revoke every live share owned by a team, returning how many were revoked.
+ *
+ * Exists for the regulated-mode switch: turning the profile on refuses to mint
+ * new links, but the links already out there are the actual exposure, and the
+ * toast says they are gone. This is what makes that true. Idempotent — a
+ * second call revokes nothing.
+ */
+export async function revokePublicSharesForTeam(
+  teamId: string,
+): Promise<number> {
+  const rows = await db()
+    .update(sharePublicShares)
+    .set({ status: "revoked", revokedAt: new Date() })
+    .where(
+      and(
+        eq(sharePublicShares.ownerTeamId, teamId),
+        eq(sharePublicShares.status, "public"),
+      ),
+    )
+    .returning({ id: sharePublicShares.id });
+  return rows.length;
+}
+
 export async function markPublicShareClaimed(
   slug: string,
   claimedByTeamId: string,

--- a/plugins/share/src/host.ts
+++ b/plugins/share/src/host.ts
@@ -247,14 +247,22 @@ export interface ShareHost {
    *  page has no session, so it reads the OWNER's flags, not the anonymous
    *  visitor's.
    *
-   *  `regulatedMode` is the one flag here that is a *control* rather than a
-   *  presentation hint: a team on the regulated (pharma) profile may not mint
-   *  public share links at all, because an anonymous URL serving screenshots
-   *  of a validated system is a data-protection problem. `publishBuildShare`
-   *  refuses on it. */
-  getOwnerTeamFlags(
-    repositoryId: string | null,
-  ): Promise<{ earlyAdopterMode: boolean; regulatedMode: boolean } | null>;
+   *  `sharingPermitted` is the one field here that is a *control* rather than
+   *  a presentation hint: a team on the regulated (pharma) profile may not
+   *  mint public share links at all, because an anonymous URL serving
+   *  screenshots of a validated system is a data-protection problem. The
+   *  decision is core's — `isSharingPermitted()` in
+   *  `src/lib/segment/regulated.ts` — and arrives already made, so this plugin
+   *  does not re-implement the predicate from `regulatedMode`.
+   *
+   *  Two callers, and both are needed: `publishBuildShare` refuses to mint,
+   *  and the public page refuses to *serve*. Minting is not the only way a
+   *  link exists — a team that flips regulated mode already has live ones. */
+  getOwnerTeamFlags(repositoryId: string | null): Promise<{
+    earlyAdopterMode: boolean;
+    regulatedMode: boolean;
+    sharingPermitted: boolean;
+  } | null>;
 
   /** Platform-wide "test runs completed" count for the social-proof strip.
    *  Deliberately not scoped to this share — see the query's own comment in

--- a/plugins/share/src/host.ts
+++ b/plugins/share/src/host.ts
@@ -245,10 +245,16 @@ export interface ShareHost {
 
   /** Feature flags of the team that owns a share's repository. The share
    *  page has no session, so it reads the OWNER's flags, not the anonymous
-   *  visitor's. */
+   *  visitor's.
+   *
+   *  `regulatedMode` is the one flag here that is a *control* rather than a
+   *  presentation hint: a team on the regulated (pharma) profile may not mint
+   *  public share links at all, because an anonymous URL serving screenshots
+   *  of a validated system is a data-protection problem. `publishBuildShare`
+   *  refuses on it. */
   getOwnerTeamFlags(
     repositoryId: string | null,
-  ): Promise<{ earlyAdopterMode: boolean } | null>;
+  ): Promise<{ earlyAdopterMode: boolean; regulatedMode: boolean } | null>;
 
   /** Platform-wide "test runs completed" count for the social-proof strip.
    *  Deliberately not scoped to this share — see the query's own comment in

--- a/plugins/share/src/index.ts
+++ b/plugins/share/src/index.ts
@@ -85,6 +85,7 @@ export {
   listPublicSharesForRepositories,
   listIndexablePublicShares,
   revokePublicShareById,
+  revokePublicSharesForTeam,
 } from "./data/queries";
 
 export { generateShareSlug, isValidShareSlug, buildShareUrl } from "./slug";

--- a/plugins/share/src/ui/page.tsx
+++ b/plugins/share/src/ui/page.tsx
@@ -76,6 +76,11 @@ export async function generateMetadata({
   const share = await queries.getPublicShareBySlug(slug);
   if (!share || share.status !== "public") return { title: "Share removed" };
   const { host } = shareWiring();
+  // Same refusal as the page below — the card must not leak a title or an
+  // og:image for a share the owner's segment no longer permits.
+  const ownerFlags = await host.getOwnerTeamFlags(share.repositoryId);
+  if (ownerFlags && !ownerFlags.sharingPermitted)
+    return { title: "Share removed" };
   const rendered = await host.getBuildRenderContext({
     buildId: share.buildId,
     testId: share.testId,
@@ -238,6 +243,15 @@ export default async function PublicSharePage({
 
   const share = await queries.getPublicShareBySlug(slug);
   if (!share || share.status !== "public") notFound();
+
+  // Refusing to *mint* a link is not the whole control: a team that flips into
+  // the regulated profile already has live ones, and every one of them keeps
+  // serving run screenshots to anyone holding the URL. `toggleRegulatedMode`
+  // revokes them, and this is the backstop for anything that revocation misses
+  // — a partial revoke, a share minted in a race, a row restored from a
+  // backup. Cheap: one flag read before the expensive render context.
+  const ownerFlags = await host.getOwnerTeamFlags(share.repositoryId);
+  if (ownerFlags && !ownerFlags.sharingPermitted) notFound();
 
   const rendered = await host.getBuildRenderContext({
     buildId: share.buildId,
@@ -435,7 +449,11 @@ export default async function PublicSharePage({
   // follow) is Early Adopter only. Viewers here are anonymous, so the gate
   // reads the flag of the team that published the share.
   const interactivePlayback = isInteractivePlaybackEnabled(
-    await host.getOwnerTeamFlags(repoIdForNotes),
+    // Already read above for the sharing refusal when the share carries a
+    // repository; only re-read for the (legacy) rows that do not.
+    share.repositoryId === repoIdForNotes
+      ? ownerFlags
+      : await host.getOwnerTeamFlags(repoIdForNotes),
   );
 
   // Platform-wide activity numbers for the social-proof strip near the claim

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -9,7 +9,11 @@ import { Badge } from "@/components/ui/badge";
 import * as queries from "@/lib/db/queries";
 import * as gamification from "@lastest/plugin-gamification/reads";
 import { getCurrentSession } from "@/lib/auth";
-import { isRegulatedTeam } from "@/lib/segment/regulated";
+import {
+  isRegulatedTeam,
+  isSettingHidden,
+  lockedPolicyFor,
+} from "@/lib/segment/regulated";
 import { RegulatedModeToggle } from "@/components/settings/regulated-mode-toggle";
 import { Github, Check, X, Users, Bot, Mail, Terminal } from "lucide-react";
 
@@ -213,6 +217,15 @@ export default async function SettingsPage({
   // Regulated (pharma) profile — see `src/lib/segment/regulated.ts` §3.3 for
   // why each of these cards goes away for this segment.
   const regulated = isRegulatedTeam(session?.team);
+  // Every card that disappears for this segment goes through
+  // REGULATED_HIDDEN_SETTINGS, so adding an id to that set is the whole change
+  // — the page must not re-decide it with a bare `!regulated &&`.
+  const hidden = (id: string) => isSettingHidden(id, session?.team);
+  // Settings the profile forces rather than defaults. Rendered as
+  // visible-but-disabled: a customer who can see auto-approval is off trusts it
+  // more than one who cannot find the switch. The server actions enforce the
+  // same table — see `isLockedSettingAllowed`.
+  const locked = lockedPolicyFor(session?.team);
   const banAiMode = session?.team?.banAiMode ?? false;
   const builtInAiEnabled = session?.team?.builtInAiEnabled ?? false;
 
@@ -254,6 +267,11 @@ export default async function SettingsPage({
               repositoryId={selectedRepo.id}
               enabled={selectedRepo.autoApproveDefaultBranch ?? false}
               defaultBranch={selectedRepo.defaultBranch || "main"}
+              lockedReason={
+                locked?.autoApprove === false
+                  ? "Locked off by regulated mode — an approval must be an attributable human act."
+                  : undefined
+              }
             />
           )}
         </CardContent>
@@ -266,23 +284,23 @@ export default async function SettingsPage({
           <CardDescription>Toggle experimental features</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          {!regulated && (
-            <>
-              <EarlyAdopterToggle
-                enabled={session?.team?.earlyAdopterMode ?? false}
-              />
-              {earlyAdopterMode && (
-                <QuickstartEmailTemplateInput
-                  initial={
-                    session?.team?.quickstartEmailTemplate ??
-                    "viktor+{slug}{stamp}@lastest.cloud"
-                  }
-                />
-              )}
-              <GamificationToggle
-                enabled={session?.team?.gamificationEnabled ?? false}
-              />
-            </>
+          {!hidden("features-early-adopter") && (
+            <EarlyAdopterToggle
+              enabled={session?.team?.earlyAdopterMode ?? false}
+            />
+          )}
+          {earlyAdopterMode && !hidden("features-quickstart-email") && (
+            <QuickstartEmailTemplateInput
+              initial={
+                session?.team?.quickstartEmailTemplate ??
+                "viktor+{slug}{stamp}@lastest.cloud"
+              }
+            />
+          )}
+          {!hidden("features-gamification") && (
+            <GamificationToggle
+              enabled={session?.team?.gamificationEnabled ?? false}
+            />
           )}
           <RegulatedModeToggle enabled={regulated} />
           <VerifyPhaseToggle
@@ -292,7 +310,7 @@ export default async function SettingsPage({
       </Card>
 
       {/* Gamification admin controls (admin-only) */}
-      {isAdmin && !regulated && (
+      {isAdmin && !hidden("gamification-admin") && (
         <GamificationAdminCard
           enabled={session?.team?.gamificationEnabled ?? false}
           activeSeasonName={activeGamificationSeason?.name ?? null}
@@ -385,7 +403,7 @@ export default async function SettingsPage({
       )}
 
       {/* GitHub Integration */}
-      {!regulated && (
+      {!hidden("github") && (
         <Card id="github">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
@@ -432,7 +450,7 @@ export default async function SettingsPage({
       )}
 
       {/* GitLab Integration */}
-      {!regulated && (
+      {!hidden("gitlab") && (
         <Card id="gitlab">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
@@ -510,7 +528,7 @@ export default async function SettingsPage({
           props because the plugin may not import app components — the OAuth
           connect flow is core's (it holds the credential) and DiagramThumbnail
           is built on next/image. Recipe §6. */}
-      {!regulated && (
+      {!hidden("github-actions") && (
         <div id="github-actions">
           <GithubActionsCard
             configs={githubActionConfigs}
@@ -531,7 +549,7 @@ export default async function SettingsPage({
         </div>
       )}
 
-      {!regulated && (
+      {!hidden("gitlab-pipelines") && (
         <div id="gitlab-pipelines">
           <GitlabPipelinesCard
             configs={gitlabPipelineConfigs}
@@ -621,7 +639,14 @@ export default async function SettingsPage({
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
-              <AiModeToggle enabled={builtInAiEnabled} />
+              <AiModeToggle
+                enabled={builtInAiEnabled}
+                lockedReason={
+                  locked?.builtInAi === false
+                    ? "Locked off by regulated mode — AI stays outside the evidence path, driven from your own agent over MCP."
+                    : undefined
+                }
+              />
               {builtInAiEnabled && !byokConfigured && (
                 <p className="text-xs text-amber-600 dark:text-amber-500">
                   Built-in AI is on, but no AI provider is configured. Set one
@@ -678,6 +703,11 @@ export default async function SettingsPage({
                 repositoryId={selectedRepo?.id}
                 claudeCliAvailable={!hostClaudeCliUnavailable()}
                 agentSdkAvailable={agentSdkReadiness().runnable}
+                aiDiffingLockedReason={
+                  locked?.aiDiffing === false
+                    ? "Locked off by regulated mode — a probabilistic verdict cannot be evidence."
+                    : undefined
+                }
               />
             </div>
           </AiAdvancedSettings>
@@ -751,7 +781,7 @@ export default async function SettingsPage({
       {/* Billing — plan + checkout + cancel (admin-only) */}
       {/* Enterprise procurement is not a Stripe portal — the regulated profile
           bills by invoice, so the self-serve plan picker goes away. */}
-      {isAdmin && teamBilling && !regulated && (
+      {isAdmin && teamBilling && !hidden("billing") && (
         <div id="billing" className="space-y-2">
           {params.checkout === "success" && (
             <div className="rounded-md border border-green-500/40 bg-green-500/5 p-4 text-sm">

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -9,6 +9,8 @@ import { Badge } from "@/components/ui/badge";
 import * as queries from "@/lib/db/queries";
 import * as gamification from "@lastest/plugin-gamification/reads";
 import { getCurrentSession } from "@/lib/auth";
+import { isRegulatedTeam } from "@/lib/segment/regulated";
+import { RegulatedModeToggle } from "@/components/settings/regulated-mode-toggle";
 import { Github, Check, X, Users, Bot, Mail, Terminal } from "lucide-react";
 
 // GitLab icon SVG component
@@ -208,6 +210,9 @@ export default async function SettingsPage({
 
   const serverUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
   const earlyAdopterMode = session?.team?.earlyAdopterMode ?? false;
+  // Regulated (pharma) profile — see `src/lib/segment/regulated.ts` §3.3 for
+  // why each of these cards goes away for this segment.
+  const regulated = isRegulatedTeam(session?.team);
   const banAiMode = session?.team?.banAiMode ?? false;
   const builtInAiEnabled = session?.team?.builtInAiEnabled ?? false;
 
@@ -261,20 +266,25 @@ export default async function SettingsPage({
           <CardDescription>Toggle experimental features</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <EarlyAdopterToggle
-            enabled={session?.team?.earlyAdopterMode ?? false}
-          />
-          {earlyAdopterMode && (
-            <QuickstartEmailTemplateInput
-              initial={
-                session?.team?.quickstartEmailTemplate ??
-                "viktor+{slug}{stamp}@lastest.cloud"
-              }
-            />
+          {!regulated && (
+            <>
+              <EarlyAdopterToggle
+                enabled={session?.team?.earlyAdopterMode ?? false}
+              />
+              {earlyAdopterMode && (
+                <QuickstartEmailTemplateInput
+                  initial={
+                    session?.team?.quickstartEmailTemplate ??
+                    "viktor+{slug}{stamp}@lastest.cloud"
+                  }
+                />
+              )}
+              <GamificationToggle
+                enabled={session?.team?.gamificationEnabled ?? false}
+              />
+            </>
           )}
-          <GamificationToggle
-            enabled={session?.team?.gamificationEnabled ?? false}
-          />
+          <RegulatedModeToggle enabled={regulated} />
           <VerifyPhaseToggle
             enabled={session?.team?.verifyPhaseEnabled ?? false}
           />
@@ -282,7 +292,7 @@ export default async function SettingsPage({
       </Card>
 
       {/* Gamification admin controls (admin-only) */}
-      {isAdmin && (
+      {isAdmin && !regulated && (
         <GamificationAdminCard
           enabled={session?.team?.gamificationEnabled ?? false}
           activeSeasonName={activeGamificationSeason?.name ?? null}
@@ -375,104 +385,109 @@ export default async function SettingsPage({
       )}
 
       {/* GitHub Integration */}
-      <Card id="github">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Github className="w-5 h-5" />
-            GitHub Integration
-          </CardTitle>
-          <CardDescription>
-            Connect GitHub for PR linking and automatic triggers
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {githubAccount ? (
-            <>
-              <div className="flex items-center justify-between p-4 bg-muted rounded-lg">
-                <div className="flex items-center gap-3">
-                  <div className="w-10 h-10 rounded-full bg-secondary flex items-center justify-center">
-                    <Github className="w-6 h-6" />
-                  </div>
-                  <div>
-                    <div className="font-medium">
-                      @{githubAccount.githubUsername}
+      {!regulated && (
+        <Card id="github">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Github className="w-5 h-5" />
+              GitHub Integration
+            </CardTitle>
+            <CardDescription>
+              Connect GitHub for PR linking and automatic triggers
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {githubAccount ? (
+              <>
+                <div className="flex items-center justify-between p-4 bg-muted rounded-lg">
+                  <div className="flex items-center gap-3">
+                    <div className="w-10 h-10 rounded-full bg-secondary flex items-center justify-center">
+                      <Github className="w-6 h-6" />
                     </div>
-                    <div className="text-sm text-muted-foreground">
-                      Connected
+                    <div>
+                      <div className="font-medium">
+                        @{githubAccount.githubUsername}
+                      </div>
+                      <div className="text-sm text-muted-foreground">
+                        Connected
+                      </div>
                     </div>
                   </div>
+                  <ReconnectGithubLink />
                 </div>
-                <ReconnectGithubLink />
-              </div>
-              <p className="text-sm text-muted-foreground">
-                Builds will automatically link to open PRs by branch name.
-              </p>
-            </>
-          ) : (
-            <>
-              <p className="text-muted-foreground">
-                Connect your GitHub account to link builds with pull requests.
-              </p>
-              <ConnectGithubButton />
-            </>
-          )}
-        </CardContent>
-      </Card>
+                <p className="text-sm text-muted-foreground">
+                  Builds will automatically link to open PRs by branch name.
+                </p>
+              </>
+            ) : (
+              <>
+                <p className="text-muted-foreground">
+                  Connect your GitHub account to link builds with pull requests.
+                </p>
+                <ConnectGithubButton />
+              </>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
       {/* GitLab Integration */}
-      <Card id="gitlab">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <GitLabIcon className="w-5 h-5" />
-            GitLab Integration
-          </CardTitle>
-          <CardDescription>
-            Connect GitLab for MR linking and automatic triggers
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {gitlabAccount ? (
-            <>
-              <div className="flex items-center justify-between p-4 bg-muted rounded-lg">
-                <div className="flex items-center gap-3">
-                  <div className="w-10 h-10 rounded-full bg-secondary flex items-center justify-center">
-                    <GitLabIcon className="w-6 h-6" />
-                  </div>
-                  <div>
-                    <div className="font-medium">
-                      @{gitlabAccount.gitlabUsername}
+      {!regulated && (
+        <Card id="gitlab">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <GitLabIcon className="w-5 h-5" />
+              GitLab Integration
+            </CardTitle>
+            <CardDescription>
+              Connect GitLab for MR linking and automatic triggers
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {gitlabAccount ? (
+              <>
+                <div className="flex items-center justify-between p-4 bg-muted rounded-lg">
+                  <div className="flex items-center gap-3">
+                    <div className="w-10 h-10 rounded-full bg-secondary flex items-center justify-center">
+                      <GitLabIcon className="w-6 h-6" />
                     </div>
-                    <div className="text-sm text-muted-foreground">
-                      {gitlabAccount.instanceUrl === "https://gitlab.com"
-                        ? "Connected"
-                        : gitlabAccount.instanceUrl}
+                    <div>
+                      <div className="font-medium">
+                        @{gitlabAccount.gitlabUsername}
+                      </div>
+                      <div className="text-sm text-muted-foreground">
+                        {gitlabAccount.instanceUrl === "https://gitlab.com"
+                          ? "Connected"
+                          : gitlabAccount.instanceUrl}
+                      </div>
                     </div>
                   </div>
+                  <a
+                    href="/api/connect/gitlab"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-primary hover:underline"
+                  >
+                    Reconnect
+                  </a>
                 </div>
-                <a
-                  href="/api/connect/gitlab"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm text-primary hover:underline"
-                >
-                  Reconnect
-                </a>
-              </div>
-              <p className="text-sm text-muted-foreground">
-                Builds will automatically link to open MRs by branch name.
-              </p>
-            </>
-          ) : (
-            <>
-              <p className="text-muted-foreground">
-                Connect your GitLab account to link builds with merge requests.
-                Self-hosted instances supported via PAT or per-account OAuth.
-              </p>
-              <ConnectGitlabButton />
-            </>
-          )}
-        </CardContent>
-      </Card>
+                <p className="text-sm text-muted-foreground">
+                  Builds will automatically link to open MRs by branch name.
+                </p>
+              </>
+            ) : (
+              <>
+                <p className="text-muted-foreground">
+                  Connect your GitLab account to link builds with merge
+                  requests. Self-hosted instances supported via PAT or
+                  per-account OAuth.
+                </p>
+                <ConnectGitlabButton />
+              </>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
       {/* Google Sheets Test Data */}
       <div id="google-sheets">
@@ -495,34 +510,38 @@ export default async function SettingsPage({
           props because the plugin may not import app components — the OAuth
           connect flow is core's (it holds the credential) and DiagramThumbnail
           is built on next/image. Recipe §6. */}
-      <div id="github-actions">
-        <GithubActionsCard
-          configs={githubActionConfigs}
-          runners={runners}
-          repos={teamRepos}
-          hasGithubAccount={!!githubAccount}
-          githubUsername={githubAccount?.githubUsername ?? null}
-          connectAccountButton={<ConnectGithubButton />}
-          flowDiagram={
-            <DiagramThumbnail
-              src="/docs/development-flow.png"
-              alt="Development & Review Flow — from code push to production with visual validation"
-              width={480}
-              height={120}
-            />
-          }
-        />
-      </div>
+      {!regulated && (
+        <div id="github-actions">
+          <GithubActionsCard
+            configs={githubActionConfigs}
+            runners={runners}
+            repos={teamRepos}
+            hasGithubAccount={!!githubAccount}
+            githubUsername={githubAccount?.githubUsername ?? null}
+            connectAccountButton={<ConnectGithubButton />}
+            flowDiagram={
+              <DiagramThumbnail
+                src="/docs/development-flow.png"
+                alt="Development & Review Flow — from code push to production with visual validation"
+                width={480}
+                height={120}
+              />
+            }
+          />
+        </div>
+      )}
 
-      <div id="gitlab-pipelines">
-        <GitlabPipelinesCard
-          configs={gitlabPipelineConfigs}
-          runners={runners}
-          repos={teamRepos}
-          hasGitlabAccount={!!gitlabAccount}
-          connectAccountButton={<ConnectGitlabButton />}
-        />
-      </div>
+      {!regulated && (
+        <div id="gitlab-pipelines">
+          <GitlabPipelinesCard
+            configs={gitlabPipelineConfigs}
+            runners={runners}
+            repos={teamRepos}
+            hasGitlabAccount={!!gitlabAccount}
+            connectAccountButton={<ConnectGitlabButton />}
+          />
+        </div>
+      )}
     </>
   );
 
@@ -730,7 +749,9 @@ export default async function SettingsPage({
       )}
 
       {/* Billing — plan + checkout + cancel (admin-only) */}
-      {isAdmin && teamBilling && (
+      {/* Enterprise procurement is not a Stripe portal — the regulated profile
+          bills by invoice, so the self-serve plan picker goes away. */}
+      {isAdmin && teamBilling && !regulated && (
         <div id="billing" className="space-y-2">
           {params.checkout === "success" && (
             <div className="rounded-md border border-green-500/40 bg-green-500/5 p-4 text-sm">

--- a/src/app/(onboarding)/onboarding/onboarding-client.tsx
+++ b/src/app/(onboarding)/onboarding/onboarding-client.tsx
@@ -16,11 +16,13 @@ import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import {
   Check,
+  ChevronLeft,
   ChevronRight,
   Github,
   Hand,
   Loader2,
   Rocket,
+  ShieldCheck,
   Sparkles,
   ArrowRight,
   X,
@@ -36,7 +38,9 @@ import {
   setBaseUrl,
   completeOnboarding,
   kickoffPlayAgent,
+  startPharmaOnboarding,
 } from "@/server/actions/onboarding";
+import type { OnboardingSegment } from "@/lib/segment/regulated";
 import {
   selectRepo,
   createLocalRepo,
@@ -59,6 +63,9 @@ type AccountLite = { username: string };
 interface OnboardingClientProps {
   initialStep: number;
   initialPath: OnboardingPath | null;
+  /** `"pharma"` when the team is already in the regulated profile (a return
+   *  visit), otherwise null so the fork is asked. */
+  initialSegment: OnboardingSegment | null;
   userName: string;
   serverUrl: string;
   githubAccount: AccountLite | null;
@@ -106,6 +113,7 @@ const PATHS: Array<{
 export function OnboardingClient({
   initialStep,
   initialPath,
+  initialSegment,
   userName,
   serverUrl,
   githubAccount,
@@ -117,16 +125,29 @@ export function OnboardingClient({
   const router = useRouter();
   const [step, setStep] = useState(initialStep);
   const [path, setPath] = useState<OnboardingPath | null>(initialPath ?? "mcp");
+  const [segment, setSegment] = useState<OnboardingSegment | null>(
+    initialSegment,
+  );
   const [pending, startTransition] = useTransition();
   // Captured from createLocalRepo when the sandbox flow picks a known template
   // so Step 5 can deep-link to the seeded test instead of /tests/new?ai=true.
   const [seededTestId, setSeededTestId] = useState<string | null>(null);
 
-  // For manual path, step 4 (AI) is skipped entirely.
+  // Step 0 is the segment fork and step 6 is the pharma setup; both sit
+  // *outside* the original 1–5 numbering rather than renumbering it, so the
+  // `?step=` deep links, the Esc-to-skip range and every existing step body
+  // keep meaning exactly what they did before.
+  //
+  // For the manual path, step 4 (AI) is skipped entirely.
   const visibleSteps = useMemo(() => {
-    if (path === "manual") return [1, 2, 3, 5];
-    return [1, 2, 3, 4, 5];
-  }, [path]);
+    // Before the fork is answered we don't know the length of the path yet.
+    // Project the custom one rather than `[0]`, which would render the very
+    // first screen as "Step 1 of 1" at 100% complete.
+    if (segment === null) return [0, 1, 2, 3, 4, 5];
+    if (segment === "pharma") return [0, 6];
+    if (path === "manual") return [0, 1, 2, 3, 5];
+    return [0, 1, 2, 3, 4, 5];
+  }, [path, segment]);
 
   const next = useCallback(() => {
     setStep((s) => {
@@ -202,6 +223,48 @@ export function OnboardingClient({
 
       {/* Step body */}
       <div className="flex-1">
+        {step === 0 && (
+          <Step0Segment
+            userName={userName}
+            selected={segment}
+            onSelect={setSegment}
+            pending={pending}
+            onNext={() => {
+              if (!segment) return;
+              setStep(segment === "pharma" ? 6 : 1);
+            }}
+          />
+        )}
+
+        {step === 6 && (
+          <StepPharma
+            pending={pending}
+            onBack={() => {
+              setSegment(null);
+              setStep(0);
+            }}
+            onStart={(projectName) =>
+              startTransition(async () => {
+                try {
+                  const created = await startPharmaOnboarding(projectName);
+                  track(Events.repo_linked, { source: "pharma" });
+                  await finish(
+                    created.seededTestId
+                      ? `/tests?test=${encodeURIComponent(created.seededTestId)}`
+                      : "/tests",
+                  );
+                } catch (err) {
+                  toast.error(
+                    err instanceof Error
+                      ? err.message
+                      : "Could not set up the Vault workspace",
+                  );
+                }
+              })
+            }
+          />
+        )}
+
         {step === 1 && (
           <Step1Fork
             userName={userName}
@@ -390,6 +453,218 @@ export function OnboardingClient({
           <DiscordIcon className="h-3 w-3" />
           Need help? Join Discord
         </a>
+      </div>
+    </div>
+  );
+}
+
+// ─── Step 0: Segment fork ────────────────────────────────────────────────────
+
+const SEGMENTS: Array<{
+  id: OnboardingSegment;
+  name: string;
+  tagline: string;
+  bullets: string[];
+  bestFor: string;
+  Icon: typeof Hand;
+}> = [
+  {
+    id: "pharma",
+    name: "Pharma & life sciences",
+    tagline: "Veeva Vault and Salesforce release regression.",
+    bullets: [
+      "Vault + Salesforce suites ready on arrival",
+      "Check layers tuned for a validated system",
+      "Leaderboards, public links and AI verdicts off",
+    ],
+    bestFor: "Validation leads · Veeva consultants",
+    Icon: ShieldCheck,
+  },
+  {
+    id: "custom",
+    name: "Custom app testing",
+    tagline: "Your own web app, your own suite.",
+    bullets: [
+      "Connect a repo or start from a URL",
+      "Record, generate or write tests",
+      "The full product surface",
+    ],
+    bestFor: "Product & QA teams",
+    Icon: Rocket,
+  },
+];
+
+function Step0Segment({
+  userName,
+  selected,
+  onSelect,
+  onNext,
+  pending,
+}: {
+  userName: string;
+  selected: OnboardingSegment | null;
+  onSelect: (s: OnboardingSegment) => void;
+  onNext: () => void;
+  pending: boolean;
+}) {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">
+          Hi {userName}, what are you testing?
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          This picks your starting suite and how much of the product you see.
+          You can change it later in Settings.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {SEGMENTS.map((s) => {
+          const active = selected === s.id;
+          return (
+            <button
+              key={s.id}
+              type="button"
+              onClick={() => onSelect(s.id)}
+              className={`relative rounded-lg border-2 p-4 text-left transition-all ${
+                active
+                  ? "border-primary bg-primary/5 shadow-sm"
+                  : "border-border bg-card hover:border-muted-foreground/40"
+              }`}
+            >
+              <div className="flex items-center gap-2">
+                <s.Icon className="h-5 w-5 text-primary" />
+                <h2 className="text-base font-semibold">{s.name}</h2>
+              </div>
+              <p className="mt-1 text-sm text-muted-foreground">{s.tagline}</p>
+              <ul className="mt-3 space-y-1 text-xs text-muted-foreground">
+                {s.bullets.map((b) => (
+                  <li key={b} className="flex items-start gap-1.5">
+                    <Check className="mt-0.5 h-3 w-3 shrink-0 text-primary" />
+                    <span>{b}</span>
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-3 border-t pt-2 text-[11px] uppercase tracking-wide text-muted-foreground">
+                Best for: {s.bestFor}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex justify-end">
+        <Button onClick={onNext} disabled={!selected || pending} size="lg">
+          Continue
+          <ChevronRight className="ml-1 h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Step 6: Pharma setup (terminal step of the pharma fork) ─────────────────
+
+function StepPharma({
+  onStart,
+  onBack,
+  pending,
+}: {
+  onStart: (projectName: string) => void;
+  onBack: () => void;
+  pending: boolean;
+}) {
+  const [projectName, setProjectName] = useState("Vault + Salesforce");
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">
+          Your Vault workspace
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          We&apos;ll create a project with both release-regression suites
+          already in it, and set the check layers for a validated system.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="pharma-project">Project name</Label>
+        <Input
+          id="pharma-project"
+          value={projectName}
+          onChange={(e) => setProjectName(e.target.value)}
+          placeholder="Vault + Salesforce"
+        />
+      </div>
+
+      <Card>
+        <CardContent className="space-y-3 py-4 text-sm">
+          <div className="font-medium">What you get</div>
+          <ul className="space-y-2 text-muted-foreground">
+            <li className="flex items-start gap-2">
+              <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
+              <span>
+                <span className="font-medium text-foreground">
+                  Vault release regression
+                </span>{" "}
+                — lifecycle actions by role, the 21 CFR Part 11 §11.50 signature
+                manifestation, a retrievable audit trail, and visual baselines
+                of your configured surfaces.
+              </span>
+            </li>
+            <li className="flex items-start gap-2">
+              <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
+              <span>
+                <span className="font-medium text-foreground">
+                  Salesforce release regression
+                </span>{" "}
+                — Lightning page layouts, LWC rendering, declarative validation
+                rules, and visual baselines of home, list and report surfaces.
+              </span>
+            </li>
+            <li className="flex items-start gap-2">
+              <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
+              <span>
+                Text and DOM checks raised to{" "}
+                <span className="font-medium text-foreground">enforce</span>;
+                performance, storage, accessibility and design-token checks off.
+                Auto-approval and AI verdicts are locked off — an approval stays
+                an attributable human act.
+              </span>
+            </li>
+          </ul>
+        </CardContent>
+      </Card>
+
+      {/* Say the blocking part out loud here rather than letting them discover
+          it on a red first build. */}
+      <Card className="border-amber-500/40 bg-amber-500/5">
+        <CardContent className="py-3 text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">
+            Both tests arrive quarantined.
+          </span>{" "}
+          They need a sandbox URL — never production — and a service account
+          with a fixed role before they can run. Quarantined tests never block a
+          build, so your first run stays green while you wire that up.
+        </CardContent>
+      </Card>
+
+      <div className="flex items-center justify-between">
+        <Button variant="ghost" onClick={onBack} disabled={pending}>
+          <ChevronLeft className="mr-1 h-4 w-4" />
+          Back
+        </Button>
+        <Button
+          size="lg"
+          onClick={() => onStart(projectName)}
+          disabled={pending}
+        >
+          {pending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+          Create my workspace
+          <ChevronRight className="ml-1 h-4 w-4" />
+        </Button>
       </div>
     </div>
   );

--- a/src/app/(onboarding)/onboarding/page.tsx
+++ b/src/app/(onboarding)/onboarding/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { getCurrentSession } from "@/lib/auth";
 import * as queries from "@/lib/db/queries";
+import type { OnboardingSegment } from "@/lib/segment/regulated";
 import { OnboardingClient } from "./onboarding-client";
 
 export default async function OnboardingPage({
@@ -28,11 +29,24 @@ export default async function OnboardingPage({
     ],
   );
 
-  const initialStep = (() => {
-    const raw = parseInt(params.step ?? "", 10);
-    if (Number.isNaN(raw) || raw < 1 || raw > 5) return 1;
-    return raw;
-  })();
+  // 0 is the segment fork and 6 the pharma setup; 1-5 are the original custom
+  // path, unchanged. A deep link into 1-5 (`connectGithub("/onboarding?step=2")`
+  // is one) can only have come from the custom path, so it implies the segment
+  // rather than re-asking it and dropping the user's OAuth round-trip.
+  const rawStep = parseInt(params.step ?? "", 10);
+  const deepLinkedStep =
+    !Number.isNaN(rawStep) && rawStep >= 0 && rawStep <= 6 ? rawStep : null;
+
+  const initialSegment: OnboardingSegment | null =
+    // The team is regulated only if it came through the pharma fork, so that
+    // flag is what a return visit resumes from.
+    session.team?.regulatedMode
+      ? "pharma"
+      : deepLinkedStep !== null && deepLinkedStep >= 1 && deepLinkedStep <= 5
+        ? "custom"
+        : null;
+
+  const initialStep = deepLinkedStep ?? (initialSegment === "pharma" ? 6 : 0);
 
   const serverUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
 
@@ -40,6 +54,7 @@ export default async function OnboardingPage({
     <OnboardingClient
       initialStep={initialStep}
       initialPath={session.user.onboardingPath ?? null}
+      initialSegment={initialSegment}
       userName={session.user.name ?? session.user.email.split("@")[0]}
       serverUrl={serverUrl}
       githubAccount={

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -33,6 +33,7 @@ import { UserMenu } from "@/components/auth/user-menu";
 import { InlineScore } from "@lastest/plugin-gamification/ui/score-chip";
 import { SidebarQuickActions } from "./sidebar-quick-actions";
 import { hasQaAgentAccess } from "@/lib/billing/feature-access";
+import { isRegulatedTeam, REGULATED_HIDDEN_NAV } from "@/lib/segment/regulated";
 import type { Repository, User, Team, EmbeddedSession } from "@/lib/db/schema";
 
 interface SidebarProps {
@@ -115,7 +116,16 @@ export function Sidebar({
     (searchParams.get("success") === "github_connected" ||
       searchParams.get("success") === "gitlab_connected");
   const earlyAdopter = team?.earlyAdopterMode ?? false;
-  const gamificationEnabled = team?.gamificationEnabled ?? false;
+  // Regulated (pharma) profile — see `src/lib/segment/regulated.ts`. Nav
+  // filtering here is merchandising, not access control: the destinations stay
+  // reachable by URL, and the one restriction that is a real control (public
+  // sharing) is refused server-side instead.
+  const regulated = isRegulatedTeam(team);
+  // Gamification is force-off under the regulated profile rather than merely
+  // filtered out of the nav list: it also drives the score chip and the
+  // Leaderboard group, which render outside `filteredDefinitionNav`.
+  const gamificationEnabled =
+    (team?.gamificationEnabled ?? false) && !regulated;
   const verifyPhaseEnabled = team?.verifyPhaseEnabled ?? false;
   // Agents is a Pro-tier feature — surface a lock on the nav item so the
   // gated destination doesn't look identical to unlocked pages.
@@ -123,9 +133,16 @@ export function Sidebar({
     ? !hasQaAgentAccess(team.plan, billingEnabled)
     : false;
 
-  const filteredDefinitionNav = earlyAdopter
-    ? definitionNav
-    : definitionNav.filter((item) => !EARLY_ADOPTER_ITEMS.has(item.name));
+  const hideForSegment = (items: typeof definitionNav) =>
+    regulated
+      ? items.filter((item) => !REGULATED_HIDDEN_NAV.has(item.name))
+      : items;
+
+  const filteredDefinitionNav = hideForSegment(
+    earlyAdopter
+      ? definitionNav
+      : definitionNav.filter((item) => !EARLY_ADOPTER_ITEMS.has(item.name)),
+  );
 
   // Verify lives in the Execution section. When the flag is on it sits at
   // the top of that group; legacy /run, /review etc remain accessible so
@@ -135,9 +152,11 @@ export function Sidebar({
     href: "/verify",
     icon: ShieldCheck,
   } as const;
-  const filteredExecutionNav = earlyAdopter
-    ? executionNav
-    : executionNav.filter((item) => !EARLY_ADOPTER_ITEMS.has(item.name));
+  const filteredExecutionNav = hideForSegment(
+    earlyAdopter
+      ? executionNav
+      : executionNav.filter((item) => !EARLY_ADOPTER_ITEMS.has(item.name)),
+  );
   const finalExecutionNav = verifyPhaseEnabled
     ? [verifyEntry, ...filteredExecutionNav]
     : filteredExecutionNav;

--- a/src/components/settings/ai-mode-toggle.tsx
+++ b/src/components/settings/ai-mode-toggle.tsx
@@ -7,6 +7,9 @@ import { updateBuiltInAiEnabled } from "@/server/actions/settings";
 
 interface AiModeToggleProps {
   enabled: boolean;
+  /** Set when `REGULATED_LOCKED_POLICY` forces this off — rendered
+   *  visible-but-disabled, with the server action refusing independently. */
+  lockedReason?: string;
 }
 
 /**
@@ -14,7 +17,7 @@ interface AiModeToggleProps {
  * is the dedicated gate for in-product AI + background AI — it no longer infers
  * availability from whether an AI key/provider is configured.
  */
-export function AiModeToggle({ enabled }: AiModeToggleProps) {
+export function AiModeToggle({ enabled, lockedReason }: AiModeToggleProps) {
   const [isPending, startTransition] = useTransition();
   const [optimisticEnabled, setOptimisticEnabled] = useOptimistic(enabled);
 
@@ -35,15 +38,16 @@ export function AiModeToggle({ enabled }: AiModeToggleProps) {
       <div className="space-y-0.5">
         <span className="text-sm font-medium">Built-in AI</span>
         <p className="text-xs text-muted-foreground/70">
-          {optimisticEnabled
-            ? "Lastest runs AI server-side for fixes, triage, and diff review."
-            : "MCP mode (default) — drive Lastest's AI from your own agent over MCP."}
+          {lockedReason ??
+            (optimisticEnabled
+              ? "Lastest runs AI server-side for fixes, triage, and diff review."
+              : "MCP mode (default) — drive Lastest's AI from your own agent over MCP.")}
         </p>
       </div>
       <Switch
-        checked={optimisticEnabled}
+        checked={lockedReason ? false : optimisticEnabled}
         onCheckedChange={handleToggle}
-        disabled={isPending}
+        disabled={isPending || !!lockedReason}
       />
     </div>
   );

--- a/src/components/settings/ai-settings-card.tsx
+++ b/src/components/settings/ai-settings-card.tsx
@@ -61,6 +61,10 @@ interface AISettingsCardProps {
    *  the claude-agent-sdk provider is not offered. Server env is not visible
    *  here, so both flags are resolved server-side and passed in. */
   agentSdkAvailable?: boolean;
+  /** Set when `REGULATED_LOCKED_POLICY.aiDiffing` forces AI diffing off. The
+   *  switch stays visible and disabled — `saveAISettings` refuses the value
+   *  independently, so this is presentation, not the control. */
+  aiDiffingLockedReason?: string;
 }
 
 const OPENROUTER_MODELS = [
@@ -87,6 +91,7 @@ export function AISettingsCard({
   repositoryId,
   claudeCliAvailable,
   agentSdkAvailable,
+  aiDiffingLockedReason,
 }: AISettingsCardProps) {
   const [isPending, startTransition] = useTransition();
   const [isTesting, setIsTesting] = useState(false);
@@ -909,11 +914,17 @@ export function AISettingsCard({
           {/* Enable Toggle */}
           <div className="flex items-center gap-3 mb-4">
             <Switch
-              checked={aiDiffingEnabled}
+              checked={aiDiffingLockedReason ? false : aiDiffingEnabled}
               onCheckedChange={setAiDiffingEnabled}
+              disabled={!!aiDiffingLockedReason}
             />
             <Label>Enable AI Diff Analysis</Label>
           </div>
+          {aiDiffingLockedReason && (
+            <p className="text-xs text-muted-foreground mb-4">
+              {aiDiffingLockedReason}
+            </p>
+          )}
 
           {aiDiffingEnabled && (
             <div className="space-y-4 pl-2 border-l-2 border-border ml-2">

--- a/src/components/settings/auto-approve-toggle.tsx
+++ b/src/components/settings/auto-approve-toggle.tsx
@@ -9,12 +9,18 @@ interface AutoApproveToggleProps {
   repositoryId: string;
   enabled: boolean;
   defaultBranch: string;
+  /** Set when `REGULATED_LOCKED_POLICY` forces this off. The switch is
+   *  rendered visible-but-disabled rather than hidden — a customer who can see
+   *  auto-approval is off trusts it more than one who cannot find the switch.
+   *  The server action refuses independently; this is presentation. */
+  lockedReason?: string;
 }
 
 export function AutoApproveToggle({
   repositoryId,
   enabled,
   defaultBranch,
+  lockedReason,
 }: AutoApproveToggleProps) {
   const [isPending, startTransition] = useTransition();
   const [optimisticEnabled, setOptimisticEnabled] = useOptimistic(enabled);
@@ -43,11 +49,14 @@ export function AutoApproveToggle({
           Automatically approve builds on <code>{defaultBranch}</code> and set
           screenshots as baselines
         </p>
+        {lockedReason && (
+          <p className="text-xs text-muted-foreground/70">{lockedReason}</p>
+        )}
       </div>
       <Switch
-        checked={optimisticEnabled}
+        checked={lockedReason ? false : optimisticEnabled}
         onCheckedChange={handleToggle}
-        disabled={isPending}
+        disabled={isPending || !!lockedReason}
       />
     </div>
   );

--- a/src/components/settings/regulated-mode-toggle.tsx
+++ b/src/components/settings/regulated-mode-toggle.tsx
@@ -17,10 +17,17 @@ export function RegulatedModeToggle({ enabled }: RegulatedModeToggleProps) {
     startTransition(async () => {
       setOptimisticEnabled(checked);
       try {
-        await toggleRegulatedMode(checked);
+        const res = await toggleRegulatedMode(checked);
         toast.success(
           checked
-            ? "Regulated mode on — public share links are now refused."
+            ? // Say what actually happened to the links that already exist:
+              // the action revokes them, and the old copy ("are now refused")
+              // read as "they are gone" without being true of them.
+              res.revokedShares > 0
+              ? `Regulated mode on — ${res.revokedShares} live share link${
+                  res.revokedShares === 1 ? "" : "s"
+                } revoked, and new ones are refused.`
+              : "Regulated mode on — public share links are refused."
             : "Regulated mode off",
         );
       } catch {

--- a/src/components/settings/regulated-mode-toggle.tsx
+++ b/src/components/settings/regulated-mode-toggle.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useOptimistic, useTransition } from "react";
+import { Switch } from "@/components/ui/switch";
+import { toast } from "sonner";
+import { toggleRegulatedMode } from "@/server/actions/regulated-mode";
+
+interface RegulatedModeToggleProps {
+  enabled: boolean;
+}
+
+export function RegulatedModeToggle({ enabled }: RegulatedModeToggleProps) {
+  const [isPending, startTransition] = useTransition();
+  const [optimisticEnabled, setOptimisticEnabled] = useOptimistic(enabled);
+
+  function handleToggle(checked: boolean) {
+    startTransition(async () => {
+      setOptimisticEnabled(checked);
+      try {
+        await toggleRegulatedMode(checked);
+        toast.success(
+          checked
+            ? "Regulated mode on — public share links are now refused."
+            : "Regulated mode off",
+        );
+      } catch {
+        toast.error("Failed to update setting");
+      }
+    });
+  }
+
+  return (
+    <div className="flex items-center justify-between">
+      <div className="space-y-0.5">
+        <span className="text-sm font-medium">Regulated mode</span>
+        <p className="text-xs text-muted-foreground/70">
+          For validated systems. Hides the leaderboard, agents and repo
+          integrations, and refuses public share links. Turning it on does not
+          re-tune check layers on projects that already exist.
+        </p>
+      </div>
+      <Switch
+        checked={optimisticEnabled}
+        onCheckedChange={handleToggle}
+        disabled={isPending}
+      />
+    </div>
+  );
+}

--- a/src/lib/core/share-host.ts
+++ b/src/lib/core/share-host.ts
@@ -15,6 +15,7 @@ import { getRepoAward as awardsGetRepoAward } from "@lastest/plugin-awards/reads
 import type { Build } from "@/lib/db/schema";
 import * as queries from "@/lib/db/queries";
 import { sendDiscordShareNotification } from "@/lib/integrations/discord";
+import { isSharingPermitted } from "@/lib/segment/regulated";
 
 /**
  * The app's fill for `ShareHost`. See `plugins/share/src/host.ts` for why
@@ -297,15 +298,22 @@ export const appShareHost: ShareHost = {
     };
   },
 
-  async getOwnerTeamFlags(
-    repositoryId: string | null,
-  ): Promise<{ earlyAdopterMode: boolean; regulatedMode: boolean } | null> {
+  async getOwnerTeamFlags(repositoryId: string | null): Promise<{
+    earlyAdopterMode: boolean;
+    regulatedMode: boolean;
+    sharingPermitted: boolean;
+  } | null> {
     if (!repositoryId) return null;
     const row = await queries.getRepositoryOwnerTeamFlags(repositoryId);
     return row
       ? {
           earlyAdopterMode: row.earlyAdopterMode ?? false,
           regulatedMode: row.regulatedMode ?? false,
+          // The decision, not the flag it is derived from. `isSharingPermitted`
+          // is the segment module's intended control point, and this is its
+          // production caller — the plugin used to re-derive it from
+          // `regulatedMode`, which left the real predicate tested but unused.
+          sharingPermitted: isSharingPermitted(row),
         }
       : null;
   },

--- a/src/lib/core/share-host.ts
+++ b/src/lib/core/share-host.ts
@@ -299,10 +299,15 @@ export const appShareHost: ShareHost = {
 
   async getOwnerTeamFlags(
     repositoryId: string | null,
-  ): Promise<{ earlyAdopterMode: boolean } | null> {
+  ): Promise<{ earlyAdopterMode: boolean; regulatedMode: boolean } | null> {
     if (!repositoryId) return null;
     const row = await queries.getRepositoryOwnerTeamFlags(repositoryId);
-    return row ? { earlyAdopterMode: row.earlyAdopterMode ?? false } : null;
+    return row
+      ? {
+          earlyAdopterMode: row.earlyAdopterMode ?? false,
+          regulatedMode: row.regulatedMode ?? false,
+        }
+      : null;
   },
 
   async getPlatformStats(): Promise<{ testRunsCompleted: number }> {

--- a/src/lib/core/share-reads.ts
+++ b/src/lib/core/share-reads.ts
@@ -3,6 +3,7 @@ import "server-only";
 import {
   getPublicShareBySlug,
   listPublicSharesForRepositories,
+  revokePublicSharesForTeam,
 } from "@lastest/plugin-share";
 
 /**
@@ -57,4 +58,21 @@ export async function listLatestPublicSharesForRepositories(
   Array<{ repositoryId: string | null; slug: string; createdAt: Date | null }>
 > {
   return listPublicSharesForRepositories(repositoryIds);
+}
+
+/**
+ * Revoke every live `/r/<slug>` a team holds.
+ *
+ * The one write in this file, and it crosses here for the same reason the
+ * reads do: `share_public_shares` is the share plugin's table, and
+ * `src/lib/core/` is the only place in `src/` that may reach a plugin.
+ *
+ * Called by `toggleRegulatedMode`. Turning the regulated profile on refuses to
+ * mint new links, but the ones already minted are the actual exposure — an
+ * anonymous URL serving screenshots of a validated system — and the switch's
+ * toast tells the user they are gone. Returns the count so the caller can say
+ * how many.
+ */
+export async function revokeTeamPublicShares(teamId: string): Promise<number> {
+  return revokePublicSharesForTeam(teamId);
 }

--- a/src/lib/db/queries/repositories.ts
+++ b/src/lib/db/queries/repositories.ts
@@ -410,7 +410,10 @@ export async function deleteRepository(id: string) {
  */
 export async function getRepositoryOwnerTeamFlags(repositoryId: string) {
   const [row] = await db
-    .select({ earlyAdopterMode: teams.earlyAdopterMode })
+    .select({
+      earlyAdopterMode: teams.earlyAdopterMode,
+      regulatedMode: teams.regulatedMode,
+    })
     .from(repositories)
     .innerJoin(teams, eq(repositories.teamId, teams.id))
     .where(eq(repositories.id, repositoryId))

--- a/src/lib/demo/pharma-seed.integration.test.ts
+++ b/src/lib/demo/pharma-seed.integration.test.ts
@@ -1,0 +1,145 @@
+/**
+ * The pharma seed's insert path, against a real database.
+ *
+ * `startPharmaOnboarding` itself can't be called here — like every
+ * `"use server"` action behind `requireCapability()`, it throws outside a real
+ * Next request scope (`next/headers()`). What it reduces to is
+ * `seedPharmaSuite`, which is where every claim the onboarding screen makes
+ * about the resulting repo actually has to hold.
+ *
+ * Run with `pnpm test:integration`.
+ */
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+
+import { db } from "@/lib/db";
+import {
+  functionalAreas,
+  playwrightSettings,
+  repositories,
+  teams,
+  tests,
+  testVersions,
+} from "@/lib/db/schema";
+import { seedPharmaSuite } from "@/lib/demo/pharma-seed";
+import { REGULATED_CHECK_MODES } from "@/lib/segment/regulated";
+
+let teamId: string;
+let repositoryId: string;
+
+beforeAll(async () => {
+  teamId = randomUUID();
+  repositoryId = randomUUID();
+  await db.insert(teams).values({
+    id: teamId,
+    name: `pharma-seed-${teamId}`,
+    slug: `pharma-seed-${teamId}`,
+    regulatedMode: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  await db.insert(repositories).values({
+    id: repositoryId,
+    teamId,
+    provider: "local",
+    owner: "local",
+    name: "Vault + Salesforce",
+    fullName: "Vault + Salesforce",
+  });
+});
+
+afterAll(async () => {
+  const seeded = await db
+    .select({ id: tests.id })
+    .from(tests)
+    .where(eq(tests.repositoryId, repositoryId));
+  for (const t of seeded) {
+    await db.delete(testVersions).where(eq(testVersions.testId, t.id));
+  }
+  await db.delete(tests).where(eq(tests.repositoryId, repositoryId));
+  await db
+    .delete(functionalAreas)
+    .where(eq(functionalAreas.repositoryId, repositoryId));
+  await db
+    .delete(playwrightSettings)
+    .where(eq(playwrightSettings.repositoryId, repositoryId));
+  await db.delete(repositories).where(eq(repositories.id, repositoryId));
+  await db.delete(teams).where(eq(teams.id, teamId));
+});
+
+describe("seedPharmaSuite", () => {
+  it("lands the repo with both suites in place", async () => {
+    const firstTestId = await seedPharmaSuite(repositoryId);
+    expect(firstTestId).toBeTruthy();
+
+    const seeded = await db
+      .select()
+      .from(tests)
+      .where(eq(tests.repositoryId, repositoryId));
+    expect(seeded).toHaveLength(2);
+    expect(seeded.map((t) => t.name).sort()).toEqual([
+      "Salesforce release regression",
+      "Vault release regression",
+    ]);
+
+    const areas = await db
+      .select()
+      .from(functionalAreas)
+      .where(eq(functionalAreas.repositoryId, repositoryId));
+    expect(areas).toHaveLength(2);
+  });
+
+  it("quarantines both, so the first build cannot go red on missing credentials", async () => {
+    const seeded = await db
+      .select()
+      .from(tests)
+      .where(eq(tests.repositoryId, repositoryId));
+    for (const t of seeded) {
+      expect(t.quarantined, t.name).toBe(true);
+      expect(t.isPlaceholder, t.name).toBe(true);
+    }
+  });
+
+  it("writes a version row per test, so the code has history from the start", async () => {
+    const seeded = await db
+      .select({ id: tests.id })
+      .from(tests)
+      .where(eq(tests.repositoryId, repositoryId));
+    for (const t of seeded) {
+      const versions = await db
+        .select()
+        .from(testVersions)
+        .where(eq(testVersions.testId, t.id));
+      expect(versions).toHaveLength(1);
+      expect(versions[0].version).toBe(1);
+    }
+  });
+
+  it("applies the regulated check-layer modes to the repo", async () => {
+    const [settings] = await db
+      .select()
+      .from(playwrightSettings)
+      .where(eq(playwrightSettings.repositoryId, repositoryId));
+    expect(settings).toBeDefined();
+    // Text is the one the segment is bought for — see the profile's comment.
+    expect(settings.textMode).toBe(REGULATED_CHECK_MODES.text);
+    expect(settings.visualMode).toBe(REGULATED_CHECK_MODES.visual);
+    expect(settings.domMode).toBe(REGULATED_CHECK_MODES.dom);
+    expect(settings.perfMode).toBe(REGULATED_CHECK_MODES.perf);
+    expect(settings.a11yMode).toBe(REGULATED_CHECK_MODES.a11y);
+  });
+
+  it("is idempotent — a second call adds nothing", async () => {
+    const before = await db
+      .select({ id: tests.id })
+      .from(tests)
+      .where(eq(tests.repositoryId, repositoryId));
+    await seedPharmaSuite(repositoryId);
+    const after = await db
+      .select({ id: tests.id })
+      .from(tests)
+      .where(eq(tests.repositoryId, repositoryId));
+    expect(after).toHaveLength(before.length);
+  });
+});

--- a/src/lib/demo/pharma-seed.test.ts
+++ b/src/lib/demo/pharma-seed.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { PHARMA_SEED_TESTS, PHARMA_SEED_CODES } from "@/lib/demo/pharma-seed";
+
+/**
+ * These guard the seed *content*, which is the part that ships to a customer's
+ * regulated tenant. The insert path itself needs a database and lives with the
+ * integration suite.
+ */
+describe("pharma seed", () => {
+  it("seeds both release-regression suites in their own areas", () => {
+    expect(PHARMA_SEED_TESTS).toHaveLength(2);
+    const areas = PHARMA_SEED_TESTS.map((t) => t.area.name);
+    expect(new Set(areas).size).toBe(2);
+    expect(areas.join(" ")).toMatch(/Vault/);
+    expect(areas.join(" ")).toMatch(/Salesforce/);
+  });
+
+  for (const seed of [...PHARMA_SEED_TESTS]) {
+    describe(seed.name, () => {
+      it("refuses to run without credentials", () => {
+        // The whole reason both tests ship quarantined. A seed that fell
+        // through to `page.goto` with an undefined user would hammer whatever
+        // the target URL happens to point at.
+        expect(seed.code).toMatch(/throw new Error\('Blocked:/);
+      });
+
+      it("carries no credential of its own", () => {
+        // A seeded literal password would land in `tests.code`, in
+        // `test_versions`, and in every export of either.
+        expect(seed.code).not.toMatch(
+          /(password|secret|token)\s*=\s*['"][^'"]+['"]/i,
+        );
+      });
+
+      it("points at a placeholder sandbox host, never a real tenant", () => {
+        expect(seed.targetUrl).toMatch(/^https:\/\/your-/);
+      });
+
+      it("cancels rather than commits every mutating dialog it opens", () => {
+        // A signature or a save in a validated system is an audit-trail entry
+        // that cannot be removed. Until the platform-level write-guard exists
+        // (docs/pharma-restricted-scope.md §2.2), this convention is all that
+        // stands between the seed and a write — so it is worth a test.
+        expect(seed.code).toMatch(/name: \/cancel\/i/);
+      });
+    });
+  }
+
+  it("exposes each seeded code for untouched-seed recognition", () => {
+    expect(PHARMA_SEED_CODES.size).toBe(PHARMA_SEED_TESTS.length);
+    for (const seed of PHARMA_SEED_TESTS) {
+      expect(PHARMA_SEED_CODES.has(seed.code)).toBe(true);
+    }
+  });
+});

--- a/src/lib/demo/pharma-seed.ts
+++ b/src/lib/demo/pharma-seed.ts
@@ -1,0 +1,322 @@
+/**
+ * Pharma / life-sciences onboarding seed.
+ *
+ * Creates the two suites a Veeva consultant actually came for — Vault release
+ * regression and Salesforce release regression — plus the regulated
+ * check-layer defaults, so the pharma fork of onboarding lands on a repo that
+ * already looks like their job rather than on an empty project.
+ *
+ * Both tests are seeded **quarantined**. They cannot run yet: there is no
+ * per-repo secret store, so `process.env.VAULT_USER` inside a test resolves
+ * against the embedded browser's own process environment (see
+ * `docs/pharma-restricted-scope.md` §2.1). Seeding them green-able would be a
+ * lie; seeding them quarantined, with the blocking reason in the first line of
+ * the failure, is the honest version — and it matches how the same two tests
+ * ship in the MuniConS bundle.
+ *
+ * Sibling of `sandbox-seeds.ts` and deliberately shaped like it: same
+ * area→test→version insert, same "no-op if the repo already has tests"
+ * idempotence.
+ */
+import { db } from "@/lib/db";
+import { tests, testVersions, functionalAreas } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import { randomUUID as uuid } from "crypto";
+import { upsertPlaywrightSettings } from "@/lib/db/queries/settings";
+import { REGULATED_CHECK_MODES } from "@/lib/segment/regulated";
+
+const VAULT_CODE = `export async function test(page, baseUrl, screenshotPath, stepLogger) {
+  // ───────────────────────────────────────────────────────────────────────────
+  // QUARANTINED — blocked on credentials, so it never reds your first build.
+  //
+  // Vault ships three general releases a year. Each lands in your sandbox
+  // weeks before production, and every validated configuration on top of it
+  // has to be re-checked. That re-check is a person with a script and a
+  // screenshot folder. This is that person's checklist, executed on every
+  // release and diffed against the last known-good run.
+  //
+  // To unblock:
+  //   1. Point this test's target URL at a Vault SANDBOX (never production).
+  //   2. Provide a service account with a fixed, known role — a permission
+  //      change should surface as a test failure, not as noise.
+  //   3. Seed a fixture document the account may move through the lifecycle.
+  // ───────────────────────────────────────────────────────────────────────────
+  const shot = (n, slug) => screenshotPath.replace('.png', \`-\${n}-\${slug}.png\`);
+  const VAULT_USER = process.env.VAULT_USER;
+  const VAULT_PASSWORD = process.env.VAULT_PASSWORD;
+  const DOC_ID = process.env.VAULT_DOC_ID; // seeded fixture document
+
+  if (!VAULT_USER || !VAULT_PASSWORD) {
+    throw new Error('Blocked: VAULT_USER / VAULT_PASSWORD are not available to this run, and this test targets a Vault sandbox. Lastest has no per-repo secret store yet — see docs/pharma-restricted-scope.md §2.1.');
+  }
+
+  // ── 1. Authentication ─────────────────────────────────────────────────────
+  stepLogger.log('Scenario 1: Vault login');
+  await page.goto(baseUrl, { waitUntil: 'domcontentloaded' });
+  await page.getByLabel(/user name|username/i).fill(VAULT_USER);
+  await page.getByLabel(/password/i).fill(VAULT_PASSWORD);
+  await page.getByRole('button', { name: /log ?in|sign in/i }).click();
+  await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+  await page.screenshot({ path: shot(1, 'vault-home') });
+
+  // ── 2. Document lifecycle state and available user actions ────────────────
+  // A release regression most often shows up as an action that quietly
+  // disappears from the lifecycle menu for a given role.
+  stepLogger.log('Scenario 2: document lifecycle actions');
+  await page.goto(new URL(\`/ui/#doc_info/\${DOC_ID}\`, baseUrl).toString(), { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('[class*="doc-info"], [data-testid="document-header"]', { timeout: 30000 });
+
+  const state = await page.locator('[class*="lifecycle-state"], [data-field="status__v"]').first().innerText();
+  stepLogger.log(\`lifecycle state: \${state}\`);
+
+  const actions = await page.locator('[class*="user-action"], [role="menuitem"]').allInnerTexts();
+  stepLogger.log(\`available user actions: \${actions.join(' | ')}\`);
+  await page.screenshot({ path: shot(2, 'doc-lifecycle-actions') });
+
+  // ── 3. 21 CFR Part 11 eSignature manifestation ────────────────────────────
+  // Part 11 §11.50 requires the signature manifestation to carry the signer's
+  // printed name, the date and time of signing, and the MEANING of the
+  // signature. Those three are asserted literally, because a template change
+  // that drops "Meaning" is a compliance finding, not a cosmetic one.
+  stepLogger.log('Scenario 3: eSignature manifestation (21 CFR Part 11 §11.50)');
+  await page.getByRole('button', { name: /approve|complete review/i }).click();
+  const signature = page.locator('[class*="esignature"], [role="dialog"]').first();
+  await signature.waitFor({ state: 'visible', timeout: 20000 });
+  await page.screenshot({ path: shot(3, 'esignature-dialog') });
+
+  const manifest = await signature.innerText();
+  const missing = ['name', 'date', 'meaning'].filter((token) => !new RegExp(token, 'i').test(manifest));
+  if (missing.length) throw new Error(\`eSignature manifestation is missing required Part 11 element(s): \${missing.join(', ')}\`);
+
+  // Cancel — do not actually sign. A signed record in a validated sandbox is
+  // an audit-trail entry that cannot be removed.
+  await page.getByRole('button', { name: /cancel/i }).click();
+
+  // ── 4. Audit trail ────────────────────────────────────────────────────────
+  stepLogger.log('Scenario 4: audit trail renders and is ordered');
+  await page.goto(new URL(\`/ui/#doc_info/\${DOC_ID}/audit_trail\`, baseUrl).toString(), { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('table, [role="grid"]', { timeout: 30000 });
+  const rows = await page.locator('table tbody tr, [role="row"]').count();
+  if (rows === 0) throw new Error('Audit trail rendered no entries — Part 11 §11.10(e) requires a retrievable audit trail.');
+  stepLogger.log(\`audit trail rows: \${rows}\`);
+  await page.screenshot({ path: shot(4, 'audit-trail') });
+
+  // ── 5. Visual baseline of the configured surfaces ─────────────────────────
+  // Everything above is a functional assertion. This is the part that catches
+  // what assertions never do: a Vault release restyling a custom layout,
+  // truncating a field label, or reflowing a section so it no longer prints.
+  stepLogger.log('Scenario 5: visual baselines for configured layouts');
+  for (const [n, [slug, hash]] of [['doc-viewer', \`#doc_info/\${DOC_ID}\`], ['library', '#library'], ['my-tasks', '#tasks']].entries()) {
+    await page.goto(new URL(\`/ui/\${hash}\`, baseUrl).toString(), { waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('networkidle', { timeout: 20000 }).catch(() => {});
+    await page.screenshot({ path: shot(5 + n, \`vault-\${slug}\`), fullPage: true });
+  }
+
+  await page.screenshot({ path: screenshotPath });
+  stepLogger.log('Vault release regression pass complete.');
+}
+`;
+
+const SALESFORCE_CODE = `export async function test(page, baseUrl, screenshotPath, stepLogger) {
+  // ───────────────────────────────────────────────────────────────────────────
+  // QUARANTINED — blocked on credentials, so it never reds your first build.
+  //
+  // Salesforce ships three seasonal releases a year (Spring, Summer, Winter)
+  // and pushes them to sandboxes on a published preview window. The regression
+  // surface that actually breaks is rarely Apex — it is Lightning page
+  // layouts, LWC rendering, validation rules and Flow screens, none of which
+  // unit tests see. This test walks those.
+  //
+  // To unblock: point the target URL at a Salesforce SANDBOX or Developer org
+  // and provide SF_USER / SF_PASSWORD.
+  // ───────────────────────────────────────────────────────────────────────────
+  const shot = (n, slug) => screenshotPath.replace('.png', \`-\${n}-\${slug}.png\`);
+  const SF_USER = process.env.SF_USER;
+  const SF_PASSWORD = process.env.SF_PASSWORD;
+
+  if (!SF_USER || !SF_PASSWORD) {
+    throw new Error('Blocked: SF_USER / SF_PASSWORD are not available to this run, and this test targets a Salesforce sandbox. Lastest has no per-repo secret store yet — see docs/pharma-restricted-scope.md §2.1.');
+  }
+
+  // ── 1. Login ──────────────────────────────────────────────────────────────
+  stepLogger.log('Scenario 1: Salesforce login');
+  await page.goto(baseUrl, { waitUntil: 'domcontentloaded' });
+  await page.locator('#username').fill(SF_USER);
+  await page.locator('#password').fill(SF_PASSWORD);
+  await page.locator('#Login').click();
+  await page.waitForLoadState('networkidle', { timeout: 40000 }).catch(() => {});
+  await page.screenshot({ path: shot(1, 'sf-home') });
+
+  // ── 2. Lightning record page renders its configured components ────────────
+  stepLogger.log('Scenario 2: Lightning record page layout');
+  await page.goto(new URL('/lightning/o/Account/list', baseUrl).toString(), { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('table[role="grid"], .slds-table', { timeout: 40000 });
+  await page.locator('table a[data-refid="recordId"]').first().click();
+  await page.waitForSelector('.slds-page-header, records-lwc-highlights-panel', { timeout: 40000 });
+
+  // A release regression here reads as "a component silently stopped rendering".
+  for (const region of ['records-lwc-highlights-panel', 'flexipage-component2', 'records-record-layout-section']) {
+    const count = await page.locator(region).count();
+    stepLogger.log(\`\${region}: \${count} instance(s)\`);
+    if (count === 0) throw new Error(\`Lightning record page rendered no <\${region}> — a configured component is missing after the release.\`);
+  }
+  await page.screenshot({ path: shot(2, 'sf-record-page'), fullPage: true });
+
+  // ── 3. Validation rules still fire ────────────────────────────────────────
+  // Assert the org's declarative guardrails survive the upgrade. Edit and
+  // cancel — never save.
+  stepLogger.log('Scenario 3: validation rules');
+  await page.getByRole('button', { name: /^edit$/i }).first().click();
+  const modal = page.locator('.slds-modal, [role="dialog"]').first();
+  await modal.waitFor({ state: 'visible', timeout: 20000 });
+  await modal.getByLabel(/account name/i).fill('');
+  await modal.getByRole('button', { name: /save/i }).click();
+  const error = modal.locator('.slds-form-element__help, [role="alert"]').first();
+  await error.waitFor({ state: 'visible', timeout: 15000 });
+  stepLogger.log(\`validation message: \${(await error.innerText()).slice(0, 120)}\`);
+  await page.screenshot({ path: shot(3, 'sf-validation') });
+  await modal.getByRole('button', { name: /cancel/i }).click();
+
+  // ── 4. Visual baselines for the configured surfaces ───────────────────────
+  stepLogger.log('Scenario 4: visual baselines');
+  for (const [n, [slug, path]] of [['home', '/lightning/page/home'], ['accounts', '/lightning/o/Account/list'], ['reports', '/lightning/o/Report/home']].entries()) {
+    await page.goto(new URL(path, baseUrl).toString(), { waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('networkidle', { timeout: 25000 }).catch(() => {});
+    await page.screenshot({ path: shot(4 + n, \`sf-\${slug}\`), fullPage: true });
+  }
+
+  await page.screenshot({ path: screenshotPath });
+  stepLogger.log('Salesforce release regression pass complete.');
+}
+`;
+
+interface PharmaSeedTest {
+  name: string;
+  code: string;
+  targetUrl: string;
+  area: { name: string; description: string };
+}
+
+export const PHARMA_SEED_TESTS: readonly PharmaSeedTest[] = [
+  {
+    name: "Vault release regression",
+    code: VAULT_CODE,
+    // Placeholder host: the test is quarantined, and pointing a seeded test at
+    // a real Vault would be pointing it at somebody else's tenant.
+    targetUrl: "https://your-vault-sandbox.veevavault.com",
+    area: {
+      name: "Veeva Vault Release Regression",
+      description:
+        "Re-checks the customer's validated Vault configuration against each general release: lifecycle actions by role, the 21 CFR Part 11 §11.50 signature manifestation, a retrievable audit trail (§11.10(e)), and visual baselines of the configured document, library and task surfaces.",
+    },
+  },
+  {
+    name: "Salesforce release regression",
+    code: SALESFORCE_CODE,
+    targetUrl: "https://your-sandbox.my.salesforce.com",
+    area: {
+      name: "Salesforce Release Regression",
+      description:
+        "Walks the seasonal-release surface that unit tests never see: Lightning page layouts, LWC rendering, declarative validation rules, and visual baselines of home, list and report surfaces.",
+    },
+  },
+];
+
+/** Codes this module seeds. Lets callers recognise an untouched seed. */
+export const PHARMA_SEED_CODES: ReadonlySet<string> = new Set([
+  VAULT_CODE,
+  SALESFORCE_CODE,
+]);
+
+/**
+ * Seed the Vault + Salesforce suites into a repo and apply the regulated
+ * check-layer defaults.
+ *
+ * Idempotent: a no-op returning the existing first test when the repo already
+ * has any test, matching `seedSandboxTemplate`.
+ */
+export async function seedPharmaSuite(
+  repositoryId: string,
+): Promise<string | null> {
+  const existing = await db
+    .select({ id: tests.id })
+    .from(tests)
+    .where(eq(tests.repositoryId, repositoryId))
+    .limit(1);
+  if (existing.length > 0) return existing[0].id;
+
+  const now = new Date();
+  let firstTestId: string | null = null;
+
+  for (const seed of PHARMA_SEED_TESTS) {
+    const faId = uuid();
+    await db.insert(functionalAreas).values({
+      id: faId,
+      repositoryId,
+      name: seed.area.name,
+      parentId: null,
+      agentPlan: seed.area.description,
+      planGeneratedAt: now,
+    });
+
+    const testId = uuid();
+    await db.insert(tests).values({
+      id: testId,
+      repositoryId,
+      functionalAreaId: faId,
+      name: seed.name,
+      code: seed.code,
+      targetUrl: seed.targetUrl,
+      executionMode: "procedural",
+      // Neither can run until a sandbox URL and a service account exist.
+      // Quarantined tests run but never block a build.
+      quarantined: true,
+      isPlaceholder: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await db.insert(testVersions).values({
+      id: uuid(),
+      testId,
+      version: 1,
+      code: seed.code,
+      name: seed.name,
+      targetUrl: seed.targetUrl,
+      changeReason: "manual_edit",
+      createdAt: now,
+    });
+
+    firstTestId ??= testId;
+  }
+
+  await applyRegulatedCheckModes(repositoryId);
+
+  return firstTestId;
+}
+
+/**
+ * Write `REGULATED_CHECK_MODES` onto the repo's Playwright settings row.
+ *
+ * Split out so the settings toggle can re-apply the profile to an existing
+ * repo without re-seeding tests. Uses `upsert` rather than
+ * `updatePlaywrightSettingsByRepo`, because a repo created seconds ago has no
+ * settings row yet and the modes are the entire point of the profile.
+ */
+export async function applyRegulatedCheckModes(
+  repositoryId: string,
+): Promise<void> {
+  await upsertPlaywrightSettings(repositoryId, {
+    visualMode: REGULATED_CHECK_MODES.visual,
+    textMode: REGULATED_CHECK_MODES.text,
+    domMode: REGULATED_CHECK_MODES.dom,
+    networkMode: REGULATED_CHECK_MODES.network,
+    consoleMode: REGULATED_CHECK_MODES.console,
+    perfMode: REGULATED_CHECK_MODES.perf,
+    urlMode: REGULATED_CHECK_MODES.url,
+    apiMode: REGULATED_CHECK_MODES.api,
+    storageMode: REGULATED_CHECK_MODES.storage,
+    a11yMode: REGULATED_CHECK_MODES.a11y,
+    designMode: REGULATED_CHECK_MODES.design,
+  });
+}

--- a/src/lib/segment/regulated.test.ts
+++ b/src/lib/segment/regulated.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import {
+  REGULATED_CHECK_MODES,
+  REGULATED_HIDDEN_NAV,
+  REGULATED_LOCKED_POLICY,
+  isOnboardingSegment,
+  isRegulatedTeam,
+  isSharingPermitted,
+} from "@/lib/segment/regulated";
+import { CHECK_LAYERS } from "@/lib/verify/check-layers";
+
+describe("regulated segment profile", () => {
+  describe("check modes", () => {
+    // The two tests that matter. A key that doesn't match a registered layer
+    // id silently does nothing — the repo just keeps the product default and
+    // nobody finds out until an auditor asks why perf evidence is in the
+    // record. A layer with no key does the same thing in reverse.
+    it("names only real check layers", () => {
+      const known = new Set(CHECK_LAYERS.map((l) => l.id));
+      for (const id of Object.keys(REGULATED_CHECK_MODES)) {
+        expect(known, `unknown check layer "${id}"`).toContain(id);
+      }
+    });
+
+    it("covers every registered check layer", () => {
+      for (const layer of CHECK_LAYERS) {
+        expect(
+          REGULATED_CHECK_MODES,
+          `check layer "${layer.id}" has no regulated default`,
+        ).toHaveProperty(layer.id);
+      }
+    });
+
+    it("enforces the layers a validated-system regression is bought for", () => {
+      // Text is the load-bearing one: a template change that drops "Meaning"
+      // from a 21 CFR Part 11 §11.50 manifestation is a compliance finding,
+      // and the product default (`log`) would let it pass green.
+      expect(REGULATED_CHECK_MODES.text).toBe("enforce");
+      expect(REGULATED_CHECK_MODES.visual).toBe("enforce");
+      expect(REGULATED_CHECK_MODES.dom).toBe("enforce");
+    });
+
+    it("uses only valid modes", () => {
+      for (const [id, mode] of Object.entries(REGULATED_CHECK_MODES)) {
+        expect(["enforce", "log", "disable"], `layer "${id}"`).toContain(mode);
+      }
+    });
+  });
+
+  describe("verdict policy", () => {
+    it("never lets anything settle a case without a human", () => {
+      expect(REGULATED_LOCKED_POLICY.autoApprove).toBe(false);
+      expect(REGULATED_LOCKED_POLICY.confirmOnGreen).toBe(false);
+      expect(REGULATED_LOCKED_POLICY.aiDiffing).toBe(false);
+      expect(REGULATED_LOCKED_POLICY.builtInAi).toBe(false);
+    });
+  });
+
+  describe("isRegulatedTeam", () => {
+    it("is false for every absent-flag shape", () => {
+      expect(isRegulatedTeam(null)).toBe(false);
+      expect(isRegulatedTeam(undefined)).toBe(false);
+      expect(isRegulatedTeam({})).toBe(false);
+      // The column is nullable, and `null` must not read as "regulated".
+      expect(isRegulatedTeam({ regulatedMode: null })).toBe(false);
+      expect(isRegulatedTeam({ regulatedMode: false })).toBe(false);
+    });
+
+    it("is true only for an explicit true", () => {
+      expect(isRegulatedTeam({ regulatedMode: true })).toBe(true);
+    });
+  });
+
+  describe("isSharingPermitted", () => {
+    it("refuses a regulated team and allows everyone else", () => {
+      expect(isSharingPermitted({ regulatedMode: true })).toBe(false);
+      expect(isSharingPermitted({ regulatedMode: false })).toBe(true);
+      expect(isSharingPermitted(null)).toBe(true);
+    });
+  });
+
+  describe("hidden nav", () => {
+    it("hides the surfaces that read as a toy or produce non-deterministic runs", () => {
+      expect(REGULATED_HIDDEN_NAV.has("Leaderboard")).toBe(true);
+      expect(REGULATED_HIDDEN_NAV.has("Agents")).toBe(true);
+    });
+
+    it("keeps the surfaces the segment is actually here for", () => {
+      // Verify is the review surface and Coverage is the PQ coverage matrix —
+      // hiding either would leave the profile with no product in it.
+      for (const kept of ["Verify", "Coverage", "Tests", "Runs", "Setup"]) {
+        expect(REGULATED_HIDDEN_NAV.has(kept), kept).toBe(false);
+      }
+    });
+  });
+
+  describe("isOnboardingSegment", () => {
+    it("accepts only the two forks", () => {
+      expect(isOnboardingSegment("pharma")).toBe(true);
+      expect(isOnboardingSegment("custom")).toBe(true);
+      expect(isOnboardingSegment("PHARMA")).toBe(false);
+      expect(isOnboardingSegment(null)).toBe(false);
+      expect(isOnboardingSegment(undefined)).toBe(false);
+    });
+  });
+});

--- a/src/lib/segment/regulated.test.ts
+++ b/src/lib/segment/regulated.test.ts
@@ -4,8 +4,12 @@ import {
   REGULATED_HIDDEN_NAV,
   REGULATED_LOCKED_POLICY,
   isOnboardingSegment,
+  isLockedSettingAllowed,
   isRegulatedTeam,
+  isSettingHidden,
   isSharingPermitted,
+  lockedPolicyFor,
+  REGULATED_HIDDEN_SETTINGS,
 } from "@/lib/segment/regulated";
 import { CHECK_LAYERS } from "@/lib/verify/check-layers";
 
@@ -53,6 +57,54 @@ describe("regulated segment profile", () => {
       expect(REGULATED_LOCKED_POLICY.confirmOnGreen).toBe(false);
       expect(REGULATED_LOCKED_POLICY.aiDiffing).toBe(false);
       expect(REGULATED_LOCKED_POLICY.builtInAi).toBe(false);
+    });
+  });
+
+  describe("lockedPolicyFor / isLockedSettingAllowed", () => {
+    const regulated = { regulatedMode: true };
+    const plain = { regulatedMode: false };
+
+    it("forces nothing on a team that is not regulated", () => {
+      expect(lockedPolicyFor(plain)).toBeNull();
+      expect(lockedPolicyFor(null)).toBeNull();
+      expect(isLockedSettingAllowed("autoApprove", true, plain)).toBe(true);
+      expect(isLockedSettingAllowed("builtInAi", true, null)).toBe(true);
+    });
+
+    it("refuses to turn a locked setting back on for a regulated team", () => {
+      // This is the half that makes the policy a control rather than a table:
+      // the settings UI disables the switch, but the action is still POSTable.
+      expect(isLockedSettingAllowed("autoApprove", true, regulated)).toBe(
+        false,
+      );
+      expect(isLockedSettingAllowed("aiDiffing", true, regulated)).toBe(false);
+      expect(isLockedSettingAllowed("builtInAi", true, regulated)).toBe(false);
+    });
+
+    it("still allows setting a locked setting to its forced value", () => {
+      expect(isLockedSettingAllowed("autoApprove", false, regulated)).toBe(
+        true,
+      );
+      expect(isLockedSettingAllowed("aiDiffing", false, regulated)).toBe(true);
+    });
+  });
+
+  describe("isSettingHidden", () => {
+    it("hides nothing for a team that is not regulated", () => {
+      for (const id of REGULATED_HIDDEN_SETTINGS) {
+        expect(isSettingHidden(id, { regulatedMode: false })).toBe(false);
+      }
+    });
+
+    it("hides exactly the ids in the set for a regulated team", () => {
+      const team = { regulatedMode: true };
+      for (const id of REGULATED_HIDDEN_SETTINGS) {
+        expect(isSettingHidden(id, team), id).toBe(true);
+      }
+      // The settings page must go through this, so an id NOT in the set stays
+      // visible — otherwise the set is documentation, not a mechanism.
+      expect(isSettingHidden("repository", team)).toBe(false);
+      expect(isSettingHidden("features", team)).toBe(false);
     });
   });
 

--- a/src/lib/segment/regulated.ts
+++ b/src/lib/segment/regulated.ts
@@ -1,0 +1,162 @@
+/**
+ * The regulated (pharma / life-sciences) segment profile.
+ *
+ * One team flag — `teams.regulatedMode` — and one module every restriction
+ * reads from, rather than a `team.regulatedMode &&` scattered across call
+ * sites. See `docs/pharma-restricted-scope.md` §3 for the reasoning behind
+ * each entry; this file is the executable form of those tables.
+ *
+ * Three rules it encodes:
+ *   1. Nothing probabilistic produces a verdict. AI may author; never adjudicate.
+ *   2. Nothing leaves the tenant without an authenticated identity attached.
+ *   3. Nothing on screen suggests the tool is a game.
+ *
+ * Client-safe: types + plain data only, no DB and no `server-only`, because
+ * the sidebar is a client component and has to filter itself.
+ */
+
+import type { CheckMode } from "@lastest/contracts";
+
+/** The subset of `Team` this module needs. Keeps the sidebar and the server
+ *  actions on the same predicate without either importing the other. */
+export interface RegulatedTeamLike {
+  regulatedMode?: boolean | null;
+}
+
+export function isRegulatedTeam(
+  team: RegulatedTeamLike | null | undefined,
+): boolean {
+  return team?.regulatedMode === true;
+}
+
+/**
+ * Check-layer modes seeded for a repo created under the regulated profile.
+ *
+ * These are *defaults*, not locks — the cogwheel dialog still lets a
+ * validation lead change them, and a profile that silently overrode a
+ * deliberate choice would be worse than one that never applied. The genuinely
+ * non-negotiable settings live in `REGULATED_LOCKED_POLICY` below.
+ *
+ * Keyed by check-layer id (`src/lib/verify/core-check-layers.ts` for the 9
+ * core layers, plus `a11y`/`design` contributed by their plugins).
+ */
+export const REGULATED_CHECK_MODES: Readonly<Record<string, CheckMode>> = {
+  /** A release restyling a validated layout is the headline finding. */
+  visual: "enforce",
+  /** Product default is `log`. A template change that drops "Meaning" from a
+   *  21 CFR Part 11 §11.50 signature manifestation is a compliance finding,
+   *  not a cosmetic one — this is the most important default change here. */
+  text: "enforce",
+  /** "A configured component silently stopped rendering" is what the seeded
+   *  Salesforce test hand-rolls against `records-lwc-highlights-panel`.
+   *  Making it a layer is what stops every future test re-implementing it. */
+  dom: "enforce",
+  /** Product default is `enforce`. Vault and Lightning poll noisily enough
+   *  that enforcing on day one buries the real findings under vendor traffic.
+   *  Ratchet to `enforce` after one clean cycle. The write-guard does not ride
+   *  on this mode — it gates regardless (see docs §2.2, not yet built). */
+  network: "log",
+  /** Same reason: vendor-owned console noise is not the customer's defect. */
+  console: "log",
+  /** Sandbox performance is non-deterministic and belongs to Veeva, not to
+   *  the customer's validated configuration. */
+  perf: "disable",
+  /** Vault hash routing — a route that no longer resolves is a real
+   *  regression, and a cheap one to catch. */
+  url: "enforce",
+  /** Nothing to assert against until the Vault REST/VQL connector exists
+   *  (gap analysis B3a). Flip to `enforce` with it, not before. */
+  api: "disable",
+  /** Browser cookies / localStorage are not a GxP artifact; capturing them
+   *  only adds review load to an execution cycle. */
+  storage: "disable",
+  /** A red a11y score on a vendor-owned UI is a finding against Veeva, not
+   *  against the customer's configuration. Available on request; off here. */
+  a11y: "disable",
+  /** Design tokens are meaningless against a vendor-styled UI. */
+  design: "disable",
+};
+
+/**
+ * Settings that are forced, not defaulted.
+ *
+ * Rendered as visible-but-disabled controls rather than hidden ones: a
+ * customer who can *see* that auto-approval is off trusts it more than one who
+ * simply cannot find the switch.
+ */
+export const REGULATED_LOCKED_POLICY = {
+  /** An approval is an attributable human act. */
+  autoApprove: false,
+  /** A case must not silently settle itself into the execution record. */
+  confirmOnGreen: false,
+  /** A probabilistic verdict cannot be evidence. */
+  aiDiffing: false,
+  /** AI runs in the consultant's own agent, over MCP, outside the evidence
+   *  path — not server-side against the tenant's data. */
+  builtInAi: false,
+} as const;
+
+/**
+ * Nav entries hidden under the regulated profile, keyed by the `name` used in
+ * `src/components/layout/sidebar.tsx`.
+ *
+ * `Agents` covers the QA-agent planner and the Explorer, which the agents
+ * console folded together: exploratory, non-deterministic run content cannot
+ * be an execution record. The features stay reachable by URL — this is a
+ * merchandising decision, not an access control. The one entry that is a real
+ * control (public sharing) is refused server-side instead; see
+ * `isSharingPermitted`.
+ */
+export const REGULATED_HIDDEN_NAV: ReadonlySet<string> = new Set([
+  "Leaderboard",
+  "Agents",
+]);
+
+/**
+ * Settings cards hidden under the regulated profile, keyed by the `id` on the
+ * `<Card>` (or the component name where the card has no id).
+ */
+export const REGULATED_HIDDEN_SETTINGS: ReadonlySet<string> = new Set([
+  // Reads as a hobbyist toy to a validation lead, and produces no pipeline.
+  "features-gamification",
+  "gamification-admin",
+  // Registers a demo user and sends mail from the product — unexplainable to
+  // this buyer.
+  "features-early-adopter",
+  "features-quickstart-email",
+  // A pharma QA lead has no repo. Same work as gap-analysis B1.
+  "github",
+  "gitlab",
+  "github-actions",
+  "gitlab-pipelines",
+  // Enterprise procurement is not a Stripe portal.
+  "billing",
+]);
+
+/**
+ * Public, unauthenticated share links (`/r/<slug>`) under the regulated
+ * profile.
+ *
+ * The single hard control in this module, and the reason it returns a boolean
+ * rather than appearing in `REGULATED_HIDDEN_NAV`: an anonymous URL serving
+ * screenshots of a validated system — potentially carrying HCP data — is a
+ * data-protection problem, and hiding the button that mints one is not a
+ * control. Callers must refuse server-side.
+ */
+export function isSharingPermitted(
+  team: RegulatedTeamLike | null | undefined,
+): boolean {
+  return !isRegulatedTeam(team);
+}
+
+/**
+ * Segment chosen at onboarding.
+ *
+ * `custom` is every existing user and the default; `pharma` is the fork that
+ * sets `regulatedMode` and seeds the Vault + Salesforce suite.
+ */
+export type OnboardingSegment = "pharma" | "custom";
+
+export function isOnboardingSegment(v: unknown): v is OnboardingSegment {
+  return v === "pharma" || v === "custom";
+}

--- a/src/lib/segment/regulated.ts
+++ b/src/lib/segment/regulated.ts
@@ -30,7 +30,9 @@ export function isRegulatedTeam(
 }
 
 /**
- * Check-layer modes seeded for a repo created under the regulated profile.
+ * Check-layer modes applied to every repo created while the team is on the
+ * regulated profile — the pharma onboarding fork AND `createLocalRepo` from
+ * `/tests`, which is the same decision reached by a different route.
  *
  * These are *defaults*, not locks — the cogwheel dialog still lets a
  * validation lead change them, and a profile that silently overrode a
@@ -83,11 +85,23 @@ export const REGULATED_CHECK_MODES: Readonly<Record<string, CheckMode>> = {
  * Rendered as visible-but-disabled controls rather than hidden ones: a
  * customer who can *see* that auto-approval is off trusts it more than one who
  * simply cannot find the switch.
+ *
+ * Applied through `lockedPolicyFor()` (the disabled controls) and
+ * `isLockedSettingAllowed()` (the server-side refusal in
+ * `updateAutoApproveDefaultBranch`, `updateBuiltInAiEnabled` and
+ * `saveAISettings`). Both halves are required: a disabled switch is not a lock
+ * on its own, since the action is still POST-able.
  */
 export const REGULATED_LOCKED_POLICY = {
   /** An approval is an attributable human act. */
   autoApprove: false,
-  /** A case must not silently settle itself into the execution record. */
+  /** A case must not silently settle itself into the execution record.
+   *
+   *  No product setting carries this yet — the Verify surface has no
+   *  confirm-on-green switch to lock. It is stated here so the profile is
+   *  complete and the day that switch ships it is already refused; unlike the
+   *  other three entries, nothing enforces it today because there is nothing
+   *  to enforce it against. */
   confirmOnGreen: false,
   /** A probabilistic verdict cannot be evidence. */
   aiDiffing: false,
@@ -115,6 +129,10 @@ export const REGULATED_HIDDEN_NAV: ReadonlySet<string> = new Set([
 /**
  * Settings cards hidden under the regulated profile, keyed by the `id` on the
  * `<Card>` (or the component name where the card has no id).
+ *
+ * Consulted through `isSettingHidden()` — `settings/page.tsx` must not
+ * hardcode `!regulated &&` around each card, or this set becomes documentation
+ * that looks like a mechanism and adding an id to it does nothing.
  */
 export const REGULATED_HIDDEN_SETTINGS: ReadonlySet<string> = new Set([
   // Reads as a hobbyist toy to a validation lead, and produces no pipeline.
@@ -132,6 +150,52 @@ export const REGULATED_HIDDEN_SETTINGS: ReadonlySet<string> = new Set([
   // Enterprise procurement is not a Stripe portal.
   "billing",
 ]);
+
+/**
+ * Whether a settings card is hidden for this team.
+ *
+ * The one way `REGULATED_HIDDEN_SETTINGS` is applied, so adding an id to that
+ * set is the whole change.
+ */
+export function isSettingHidden(
+  id: string,
+  team: RegulatedTeamLike | null | undefined,
+): boolean {
+  return isRegulatedTeam(team) && REGULATED_HIDDEN_SETTINGS.has(id);
+}
+
+/**
+ * The locked settings for a team, or `null` when nothing is forced.
+ *
+ * `REGULATED_LOCKED_POLICY` is a policy table, not a mechanism: this is what
+ * gives it a caller. Two consumers, and both are required for the guarantee to
+ * hold — the settings UI renders the affected switches as visible-but-disabled
+ * (so a customer can *see* auto-approval is off), and the server actions that
+ * write these fields refuse a value that contradicts the policy. UI alone is
+ * not a control; a POST would still flip the flag.
+ */
+export function lockedPolicyFor(
+  team: RegulatedTeamLike | null | undefined,
+): typeof REGULATED_LOCKED_POLICY | null {
+  return isRegulatedTeam(team) ? REGULATED_LOCKED_POLICY : null;
+}
+
+/**
+ * Whether a locked setting may be set to `value` for this team.
+ *
+ * Server-side half of `lockedPolicyFor`. Returns false only when the team is
+ * regulated AND the requested value contradicts the policy — turning a locked
+ * setting further *off* is always allowed.
+ */
+export function isLockedSettingAllowed(
+  key: keyof typeof REGULATED_LOCKED_POLICY,
+  value: boolean,
+  team: RegulatedTeamLike | null | undefined,
+): boolean {
+  const policy = lockedPolicyFor(team);
+  if (!policy) return true;
+  return value === policy[key];
+}
 
 /**
  * Public, unauthenticated share links (`/r/<slug>`) under the regulated

--- a/src/server/actions/ai-settings.ts
+++ b/src/server/actions/ai-settings.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/security/outbound-url";
 import type { AIProvider, AgentSdkPermissionMode } from "@/lib/db/schema";
 import { checkAiConfigReadiness } from "@/lib/ai/availability";
+import { isLockedSettingAllowed } from "@/lib/segment/regulated";
 import { revalidatePath } from "next/cache";
 import { exec } from "child_process";
 import { promisify } from "util";
@@ -79,9 +80,27 @@ export async function saveAISettings(data: {
   explorerStyleRotation?: string | null;
   explorerModel?: string | null;
 }) {
-  if (data.repositoryId) await requireRepoAccess(data.repositoryId);
-  else await requireTeamAccess();
+  const session = data.repositoryId
+    ? await requireRepoAccess(data.repositoryId)
+    : await requireTeamAccess();
   const { repositoryId, ...settingsData } = data;
+
+  // REGULATED_LOCKED_POLICY.aiDiffing: a probabilistic verdict cannot be
+  // evidence. The AI settings card renders the switch disabled for this
+  // segment; refusing here is what makes it a lock rather than a hidden
+  // control, since the form posts the whole settings object.
+  if (
+    settingsData.aiDiffingEnabled !== undefined &&
+    !isLockedSettingAllowed(
+      "aiDiffing",
+      settingsData.aiDiffingEnabled,
+      session.team,
+    )
+  ) {
+    throw new Error(
+      "AI diffing is locked off for this team. Regulated mode does not accept a probabilistic verdict as evidence.",
+    );
+  }
 
   // Don't overwrite real keys with masked placeholders
   if (isMaskedValue(settingsData.openrouterApiKey))

--- a/src/server/actions/onboarding.ts
+++ b/src/server/actions/onboarding.ts
@@ -32,6 +32,7 @@ export async function setOnboardingPath(path: OnboardingPath) {
  */
 export async function startPharmaOnboarding(projectName?: string) {
   const session = await requireCapability("repos:manage");
+  const previousPath = session.user.onboardingPath ?? null;
 
   // Flip the team into the regulated profile *before* creating the repo, so a
   // failure between the two leaves a restricted team with no project rather
@@ -39,10 +40,24 @@ export async function startPharmaOnboarding(projectName?: string) {
   await queries.updateTeam(session.team.id, { regulatedMode: true });
   await queries.updateUser(session.user.id, { onboardingPath: "manual" });
 
-  const repo = await createLocalRepo(
-    projectName?.trim() || "Vault + Salesforce",
-  );
-  const seededTestId = await seedPharmaSuite(repo.id);
+  let repo: Awaited<ReturnType<typeof createLocalRepo>>;
+  let seededTestId: string | null;
+  try {
+    repo = await createLocalRepo(projectName?.trim() || "Vault + Salesforce");
+    seededTestId = await seedPharmaSuite(repo.id);
+  } catch (err) {
+    // Compensation. `regulatedMode` deliberately stays ON — the ordering above
+    // exists so a half-finished fork never leaves an unrestricted team holding
+    // a Vault suite, and the settings toggle is the way back out of it. What
+    // must roll back is `onboardingPath`: rewritten to "manual" it drops the
+    // user outside the fork with no route back into it, having never reached
+    // the project the fork exists to create.
+    await queries
+      .updateUser(session.user.id, { onboardingPath: previousPath })
+      .catch(() => {});
+    revalidatePath("/onboarding");
+    throw err;
+  }
 
   revalidatePath("/");
   revalidatePath("/tests");

--- a/src/server/actions/onboarding.ts
+++ b/src/server/actions/onboarding.ts
@@ -3,15 +3,53 @@
 import { revalidatePath } from "next/cache";
 import * as queries from "@/lib/db/queries";
 import { requireAuth, requireTeamAccess } from "@/lib/auth";
+import { requireCapability } from "@/lib/auth/capabilities";
 import { assertHttpScheme } from "@/lib/security/url-validation";
 import type { OnboardingPath } from "@/lib/db/schema";
 import { startPlayAgent } from "./play-agent";
 import { repointSeededSampleToSmoke } from "@/lib/demo/sandbox-seeds";
+import { seedPharmaSuite } from "@/lib/demo/pharma-seed";
+import { createLocalRepo } from "./repos";
 
 export async function setOnboardingPath(path: OnboardingPath) {
   const session = await requireAuth();
   await queries.updateUser(session.user.id, { onboardingPath: path });
   revalidatePath("/onboarding");
+}
+
+/**
+ * The pharma fork of onboarding.
+ *
+ * Turns on the regulated segment profile for the team, creates a project, and
+ * seeds the Vault + Salesforce release-regression suites so the user lands on
+ * the two tests they came for rather than on an empty repo.
+ *
+ * No base URL is passed to `createLocalRepo` on purpose: a base URL there
+ * would trip the generic smoke-test seed, and each seeded test carries its own
+ * sandbox `targetUrl` for the user to re-point. Their real sandbox URL is
+ * something only they can supply, and guessing it would produce a test that
+ * runs against nothing.
+ */
+export async function startPharmaOnboarding(projectName?: string) {
+  const session = await requireCapability("repos:manage");
+
+  // Flip the team into the regulated profile *before* creating the repo, so a
+  // failure between the two leaves a restricted team with no project rather
+  // than an unrestricted team holding a Vault suite.
+  await queries.updateTeam(session.team.id, { regulatedMode: true });
+  await queries.updateUser(session.user.id, { onboardingPath: "manual" });
+
+  const repo = await createLocalRepo(
+    projectName?.trim() || "Vault + Salesforce",
+  );
+  const seededTestId = await seedPharmaSuite(repo.id);
+
+  revalidatePath("/");
+  revalidatePath("/tests");
+  revalidatePath("/settings");
+  revalidatePath("/onboarding");
+
+  return { repositoryId: repo.id, seededTestId };
 }
 
 export async function setBaseUrl(repositoryId: string, url: string) {

--- a/src/server/actions/regulated-mode.ts
+++ b/src/server/actions/regulated-mode.ts
@@ -1,0 +1,22 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import * as queries from "@/lib/db/queries";
+import { requireTeamAdmin } from "@/lib/auth";
+
+/**
+ * Toggle the regulated (pharma / life-sciences) segment profile for the team.
+ *
+ * Deliberately does *not* re-apply `REGULATED_CHECK_MODES` to existing
+ * projects. Those are per-repo defaults a validation lead may have already
+ * tuned, and silently rewriting them from a settings switch would overwrite a
+ * deliberate choice — the profile seeds them at project creation instead.
+ * Turning the flag off likewise leaves the modes where they are.
+ */
+export async function toggleRegulatedMode(enabled: boolean) {
+  const session = await requireTeamAdmin();
+  await queries.updateTeam(session.team.id, { regulatedMode: enabled });
+  revalidatePath("/", "layout");
+  revalidatePath("/settings");
+  return { enabled };
+}

--- a/src/server/actions/regulated-mode.ts
+++ b/src/server/actions/regulated-mode.ts
@@ -3,9 +3,13 @@
 import { revalidatePath } from "next/cache";
 import * as queries from "@/lib/db/queries";
 import { requireTeamAdmin } from "@/lib/auth";
+import { revokeTeamPublicShares } from "@/lib/core/share-reads";
 
 /**
  * Toggle the regulated (pharma / life-sciences) segment profile for the team.
+ *
+ * Turning it ON also revokes every live public share the team holds — see the
+ * comment on that branch for why refusing to mint new ones is not enough.
  *
  * Deliberately does *not* re-apply `REGULATED_CHECK_MODES` to existing
  * projects. Those are per-repo defaults a validation lead may have already
@@ -16,7 +20,24 @@ import { requireTeamAdmin } from "@/lib/auth";
 export async function toggleRegulatedMode(enabled: boolean) {
   const session = await requireTeamAdmin();
   await queries.updateTeam(session.team.id, { regulatedMode: enabled });
+
+  // Refusing to mint new share links is not the control on its own: every
+  // `/r/<slug>` minted before the switch keeps serving run screenshots to
+  // anyone holding the URL, which is exactly the exposure this profile exists
+  // to close. Revoke them, so the toast ("public share links are now refused")
+  // is true of the links that already exist and not only of future ones. The
+  // public page refuses independently on the owner's flags — see
+  // `plugins/share/src/ui/page.tsx` — so a failure here is not the only guard.
+  //
+  // Turning the profile OFF does not un-revoke: a revoked link is a decision,
+  // and silently reanimating public URLs is never the safe direction.
+  let revokedShares = 0;
+  if (enabled) {
+    revokedShares = await revokeTeamPublicShares(session.team.id);
+  }
+
   revalidatePath("/", "layout");
   revalidatePath("/settings");
-  return { enabled };
+  revalidatePath("/r", "layout");
+  return { enabled, revokedShares };
 }

--- a/src/server/actions/repos.ts
+++ b/src/server/actions/repos.ts
@@ -4,6 +4,11 @@ import { revalidatePath } from "next/cache";
 import * as queries from "@/lib/db/queries";
 import { planConfig } from "@/lib/billing/plans";
 import {
+  isLockedSettingAllowed,
+  isRegulatedTeam,
+} from "@/lib/segment/regulated";
+import { applyRegulatedCheckModes } from "@/lib/demo/pharma-seed";
+import {
   requireTeamAccess,
   requireRepoAccess,
   requireCapability,
@@ -279,6 +284,17 @@ export async function createLocalRepo(
     // the user's app rather than a third-party demo.
     seededTestId = await seedGenericSmokeTest(repo.id, baseUrl);
   }
+
+  // Regulated (pharma) profile: the check-mode table is a property of the
+  // segment, not of the onboarding fork that happens to be the usual way in.
+  // Without this, a repo created from /tests while the team is regulated gets
+  // product defaults — including `text: "log"`, the single most important
+  // change in that table (a 21 CFR Part 11 §11.50 signature manifestation
+  // losing "Meaning" is a compliance finding, not a cosmetic one).
+  if (isRegulatedTeam(session.team)) {
+    await applyRegulatedCheckModes(repo.id);
+  }
+
   revalidatePath("/");
   revalidatePath("/settings");
   return { ...repo, seededTestId };
@@ -330,6 +346,14 @@ export async function updateAutoApproveDefaultBranch(
   const session = await requireCapability("repos:settings");
   const repo = await queries.getRepository(repositoryId);
   if (!repo || repo.teamId !== session.team.id) return;
+  // REGULATED_LOCKED_POLICY.autoApprove: an approval is an attributable human
+  // act under the regulated profile. The settings UI renders the switch
+  // disabled; this is what makes it a control rather than a hidden button.
+  if (!isLockedSettingAllowed("autoApprove", enabled, session.team)) {
+    throw new Error(
+      "Auto-approval is locked off for this team. Regulated mode requires every approval to be an attributable human act.",
+    );
+  }
   await queries.updateRepository(repositoryId, {
     autoApproveDefaultBranch: enabled,
   });

--- a/src/server/actions/settings.ts
+++ b/src/server/actions/settings.ts
@@ -10,6 +10,7 @@ import type {
 } from "@/lib/db/schema";
 import type { CheckMode } from "@/lib/verify/check-modes";
 import { revalidatePath } from "next/cache";
+import { isLockedSettingAllowed } from "@/lib/segment/regulated";
 
 export async function getPlaywrightSettings(repositoryId?: string | null) {
   await requireTeamAccess();
@@ -279,6 +280,14 @@ export async function updateBanAiMode(enabled: boolean) {
 // AI mode: MCP (default, false) ↔ built-in AI (true)
 export async function updateBuiltInAiEnabled(enabled: boolean) {
   const session = await requireTeamAccess();
+  // REGULATED_LOCKED_POLICY.builtInAi: under the regulated profile AI runs in
+  // the consultant's own agent over MCP, outside the evidence path — never
+  // server-side against the tenant's data.
+  if (!isLockedSettingAllowed("builtInAi", enabled, session.team)) {
+    throw new Error(
+      "Built-in AI is locked off for this team. Regulated mode keeps AI outside the evidence path — use MCP from your own agent.",
+    );
+  }
   await queries.updateTeam(session.team.id, { builtInAiEnabled: enabled });
   revalidatePath("/settings");
   revalidatePath("/");


### PR DESCRIPTION
Last PR in the pharma stack (#97 → #113 → #114 → this).

Onboarding now opens on a segment question — **Pharma & life sciences** or
**Custom app testing** — instead of jumping straight to "how do you want to build
tests?". The custom path is unchanged. The pharma path creates a project with the
Veeva Vault and Salesforce release-regression suites already in it, turns on the
regulated profile for the team, and lands on `/tests`.

Companion to `docs/pharma-restricted-scope.md`, which this implements §3 of.

## The profile

`src/lib/segment/regulated.ts` is the single place every restriction reads from,
rather than a `team.regulatedMode &&` scattered across call sites. It encodes
three rules: nothing probabilistic produces a verdict, nothing leaves the tenant
without an authenticated identity attached, and nothing on screen suggests the
tool is a game.

**Eval defaults for a validated system.** `text` and `dom` are raised to
`enforce` — the load-bearing change, because a template change that drops
"Meaning" from a 21 CFR Part 11 §11.50 signature manifestation is a compliance
finding, and the product default (`log`) lets it pass green. `network` and
`console` drop to `log`, since Vault and Lightning poll noisily enough to bury
the real findings; ratchet after one clean cycle. `perf`, `storage`, `a11y` and
`design` go off.

**UI.** Leaderboard, Agents, gamification, early-adopter and repo/CI integration
cards are hidden. Public share links are refused server-side in
`publishBuildShare` — not merely hidden. An anonymous `/r/<slug>` URL serving
screenshots of a validated system is a data-protection problem, and hiding the
button that mints one is not a control. Everything else here is merchandising.

## Step numbering

Steps 0 (fork) and 6 (pharma setup) sit *outside* the original 1–5 numbering
rather than renumbering it, so `?step=` deep links
(`connectGithub("/onboarding?step=2")`), the Esc-to-skip range and every existing
step body keep meaning exactly what they did. A deep link into 1–5 implies the
custom segment rather than re-asking the fork and dropping the user's OAuth
round-trip.

## Verification

Against a running app with a real signed-up user, not only unit tests:

| | regulated OFF | ON |
|---|---|---|
| Leaderboard / Arcade / Agents | visible | hidden |
| Coverage / Verify / Tests / Runs / Setup | visible | visible |
| GitHub / GitLab / Gamification / Early-adopter cards | visible | hidden |
| Regulated-mode toggle | visible | visible |

Gamification was explicitly **on** at team level in that run, so it exercises the
override rather than a default. The seed's insert path is covered against a real
database (quarantine flags, version rows, check modes, idempotence). Full unit
suite 1942 passed, typecheck clean, `pnpm arch` 0 violations.

## Two things to look at

**Both seeded tests arrive quarantined, and the setup screen says so.** They
cannot run: there is no per-repo secret store, so `process.env.VAULT_USER`
resolves against the embedded browser's own environment
(`docs/pharma-restricted-scope.md` §2.1). Seeding them green-able would be a lie.

**`toggleRegulatedMode` does not re-apply check modes to existing projects.**
Those are per-repo defaults a validation lead may have tuned, and rewriting them
from a settings switch would overwrite a deliberate choice. The toggle's help
text says so. Turning it on for an existing team changes UI and sharing, not eval
defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
