### PR TITLE
feat(qa-agent): rebuild the QA agent console on the new bento direction

### DIFF
--- a/plugins/qa-agent/src/actions.ts
+++ b/plugins/qa-agent/src/actions.ts
@@ -97,6 +97,7 @@ import {
 } from "./domain/task-triage";
 import type { QaActivityEvent, QaAgentHost, QaExistingAuthSetup } from "./host";
 import { qaAgentPlugin } from "./index";
+import { QA_PHASES } from "./phases";
 import type { QaAgentTask } from "./schema";
 import type {
   QaAgentRole,
@@ -156,58 +157,9 @@ import { qaAgentWiring } from "./wiring";
  *   `host.ts` for the full port and each group's honest future.
  */
 
-const QA_STEP_DEFINITIONS: Array<{
-  id: QaStepId;
-  label: string;
-  description: string;
-}> = [
-  {
-    id: "qa_setup",
-    label: "Preflight",
-    description: "Validate target URL, AI provider, and GitHub connection",
-  },
-  {
-    id: "qa_login",
-    label: "Login",
-    description:
-      "Resolve authentication — existing setup, provided credentials, or an agent-registered account",
-  },
-  {
-    id: "qa_discover",
-    label: "Discover",
-    description: "Scan source routes and crawl the live app for DOM/selectors",
-  },
-  {
-    id: "qa_plan",
-    label: "Plan",
-    description: "Design a risk-prioritized test plan from real discovery data",
-  },
-  {
-    id: "qa_plan_review",
-    label: "Review",
-    description: "Human review gate — approve or request plan changes",
-  },
-  {
-    id: "qa_generate",
-    label: "Generate",
-    description: "Generate tests per plan item with live selector verification",
-  },
-  {
-    id: "qa_execute",
-    label: "Execute",
-    description: "Run the generated suite against the target app",
-  },
-  {
-    id: "qa_heal",
-    label: "Heal",
-    description: "Fix failing tests and re-run them",
-  },
-  {
-    id: "qa_summary",
-    label: "Summary",
-    description: "Coverage matrix and journey traceability",
-  },
-];
+/** The pipeline shape lives in `@/lib/qa-agent/phases` so the screen can draw
+ *  it before a session exists. */
+const QA_STEP_DEFINITIONS = QA_PHASES;
 
 const EB_CLAIM_TIMEOUT_MS = 5 * 60 * 1000;
 const PLANNER_TIMEOUT_MS = 5 * 60 * 1000;

--- a/plugins/qa-agent/src/actions.ts
+++ b/plugins/qa-agent/src/actions.ts
@@ -157,8 +157,8 @@ import { qaAgentWiring } from "./wiring";
  *   `host.ts` for the full port and each group's honest future.
  */
 
-/** The pipeline shape lives in `@/lib/qa-agent/phases` so the screen can draw
- *  it before a session exists. */
+/** The pipeline shape lives in `./phases` so the screen can draw it before a
+ *  session exists. */
 const QA_STEP_DEFINITIONS = QA_PHASES;
 
 const EB_CLAIM_TIMEOUT_MS = 5 * 60 * 1000;

--- a/plugins/qa-agent/src/phases.ts
+++ b/plugins/qa-agent/src/phases.ts
@@ -7,11 +7,16 @@ import type { QaStepId } from "./types";
  * new session's `steps` from this list, and the QA agent screen renders the
  * pipeline strip from it (so the strip has a shape to draw before the repo has
  * ever run the agent).
+ *
+ * `readonly`, and that is load-bearing rather than stylistic: one of those two
+ * consumers is a client component, and an in-place `.sort()` or `.reverse()`
+ * there would silently reshape what every new session gets seeded with. The
+ * single-source-of-truth claim is structural this way instead of conventional.
  */
-export const QA_PHASES: Array<{
-  id: QaStepId;
-  label: string;
-  description: string;
+export const QA_PHASES: ReadonlyArray<{
+  readonly id: QaStepId;
+  readonly label: string;
+  readonly description: string;
 }> = [
   {
     id: "qa_setup",

--- a/plugins/qa-agent/src/phases.ts
+++ b/plugins/qa-agent/src/phases.ts
@@ -1,0 +1,62 @@
+import type { QaStepId } from "./types";
+
+/**
+ * The QA agent's nine-phase pipeline, in order.
+ *
+ * Single source of truth for both halves of the app: the server action seeds a
+ * new session's `steps` from this list, and the QA agent screen renders the
+ * pipeline strip from it (so the strip has a shape to draw before the repo has
+ * ever run the agent).
+ */
+export const QA_PHASES: Array<{
+  id: QaStepId;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: "qa_setup",
+    label: "Preflight",
+    description: "Validate target URL, AI provider, and GitHub connection",
+  },
+  {
+    id: "qa_login",
+    label: "Login",
+    description:
+      "Resolve authentication — existing setup, provided credentials, or an agent-registered account",
+  },
+  {
+    id: "qa_discover",
+    label: "Discover",
+    description: "Scan source routes and crawl the live app for DOM/selectors",
+  },
+  {
+    id: "qa_plan",
+    label: "Plan",
+    description: "Design a risk-prioritized test plan from real discovery data",
+  },
+  {
+    id: "qa_plan_review",
+    label: "Review",
+    description: "Human review gate — approve or request plan changes",
+  },
+  {
+    id: "qa_generate",
+    label: "Generate",
+    description: "Generate tests per plan item with live selector verification",
+  },
+  {
+    id: "qa_execute",
+    label: "Execute",
+    description: "Run the generated suite against the target app",
+  },
+  {
+    id: "qa_heal",
+    label: "Heal",
+    description: "Fix failing tests and re-run them",
+  },
+  {
+    id: "qa_summary",
+    label: "Summary",
+    description: "Coverage matrix and journey traceability",
+  },
+];

--- a/plugins/qa-agent/src/ui/qa-agent-client.tsx
+++ b/plugins/qa-agent/src/ui/qa-agent-client.tsx
@@ -15,14 +15,27 @@ import type {
   QaAgentTriggerRow as QaAgentTrigger,
 } from "../schema";
 import type { QaSessionRow as AgentSession } from "../types";
+import type { QaFeedEvent } from "./use-activity-events";
 import { QA_GROUPS } from "../domain/plan";
 import { useQaAgent } from "./use-qa-agent";
 import { useQaTasks } from "./use-qa-tasks";
 import { useActivityEvents } from "./use-activity-events";
 import { QaAgentHeader } from "./qa-agent-header";
 import { PhaseTimeline } from "./qa-phase-timeline";
+import { QaPipelineStrip } from "./qa-pipeline-strip";
 import { QaPlanReview } from "./qa-plan-review";
-import { QaGeneratedTestsPanel, QaSummaryPanel } from "./qa-results-panel";
+import {
+  QaCoverageMatrix,
+  QaGeneratedTestsPanel,
+  QaSummaryPanel,
+} from "./qa-results-panel";
+import {
+  CoverageTile,
+  DoingNowTile,
+  LiveActivityTile,
+  UpNextTile,
+  WatchingTile,
+} from "./qa-bento-tiles";
 import type { CoverageRequestHint } from "./qa-results-panel";
 import { QaTaskBoard } from "./qa-task-board";
 import { QaRunHistory } from "./qa-run-history";
@@ -48,6 +61,7 @@ import {
   Bot,
   FileText,
   Github,
+  Grid3x3,
   Loader2,
   Lock,
   MonitorPlay,
@@ -502,6 +516,7 @@ export function QaAgentClient({
   initialTasks,
   initialTriggerConfig,
   BrowserViewer,
+  initialActivity,
 }: {
   repositoryId: string;
   repositoryName: string;
@@ -531,6 +546,9 @@ export function QaAgentClient({
     hideToolbar?: boolean;
     className?: string;
   }>;
+  /** Recent activity for this repo, newest last — seeds the live feed tile,
+   *  which otherwise starts empty because SSE only carries new events. */
+  initialActivity: QaFeedEvent[];
 }) {
   const {
     session,
@@ -664,6 +682,16 @@ export function QaAgentClient({
   );
 
   const neverRan = historySessions.length === 0;
+  // The strip draws the live run when there is one, the newest settled run
+  // otherwise, and the bare pipeline shape before the repo has ever run it.
+  const pipelineSession = liveSession ?? historySessions[0] ?? null;
+  const coverageSummary = coverageSource?.metadata.qaSummary ?? null;
+  const queuedCount = tasks.filter((t) => t.status === "queued").length;
+  // Server-seeded history plus everything the SSE feed has delivered since.
+  const feedEvents = useMemo(() => {
+    const seen = new Set(events.map((e) => e.id));
+    return [...initialActivity.filter((e) => !seen.has(e.id)), ...events];
+  }, [initialActivity, events]);
   const showSetup = !liveSession && (setupOpen || neverRan);
 
   return (
@@ -678,12 +706,59 @@ export function QaAgentClient({
         loading={loading}
         setupOpen={showSetup}
         canStartRun={!neverRan}
-        triggerSummary={describeTriggers(triggerState)}
         onToggleSetup={() => setSetupOpen((v) => !v)}
         onPause={pause}
         onResume={resume}
         onCancel={cancel}
       />
+
+      {/* Bento console: the pipeline reads first, then the matrix and the
+          live quadrants, then the queue and the feed. */}
+      <QaPipelineStrip session={pipelineSession} />
+
+      <div className="grid grid-cols-1 gap-3 xl:grid-cols-4">
+        {coverageSummary ? (
+          <Card className="gap-0 overflow-x-auto p-4 xl:col-span-2 xl:row-span-2">
+            <QaCoverageMatrix
+              summary={coverageSummary}
+              onRequestCoverage={handleRequestCoverage}
+              requestPending={taskPending}
+            />
+          </Card>
+        ) : (
+          <Card className="gap-0 p-4 xl:col-span-2 xl:row-span-2">
+            <div className="mb-2.5 flex items-center gap-1.5 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+              <Grid3x3 className="h-3 w-3" />
+              Coverage matrix
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Business area × test group. The matrix appears once a run reaches
+              its summary phase.
+            </p>
+          </Card>
+        )}
+        <DoingNowTile session={liveSession} awaitingReview={awaitingReview} />
+        <CoverageTile
+          summary={coverageSummary}
+          updatedAt={coverageSource?.completedAt ?? coverageSource?.createdAt}
+        />
+        <UpNextTile trigger={triggerState} queuedCount={queuedCount} />
+        <WatchingTile
+          trigger={triggerState}
+          githubConnected={githubConnected}
+        />
+
+        <QaTaskBoard
+          className="xl:col-span-2"
+          tasks={tasks}
+          pending={taskPending}
+          error={taskError}
+          onAdd={addTask}
+          onRetry={retryTask}
+          onDrop={dropTask}
+        />
+        <LiveActivityTile events={feedEvents} className="xl:col-span-2" />
+      </div>
 
       {error && (
         <div className="flex items-start gap-1.5 text-sm text-destructive">
@@ -714,7 +789,7 @@ export function QaAgentClient({
       {/* Active run — collapses into history when it ends */}
       {liveSession && (
         <>
-          <PhaseTimeline session={liveSession} />
+          <PhaseTimeline session={liveSession} detailOnly />
           {/* Live browser while an agent holds an EB */}
           {(streamUrl || queuedForBrowser) && (
             <Card>
@@ -764,27 +839,19 @@ export function QaAgentClient({
         </>
       )}
 
-      {/* Persistent coverage dashboard — the agent's standing artifact */}
+      {/* Coverage detail — the headline counts and the matrix are bento tiles
+          above, so this card carries the branch, group and journey breakdowns */}
       {coverageSource?.metadata.qaSummary && (
         <QaSummaryPanel
           summary={coverageSource.metadata.qaSummary}
           plan={coverageSource.metadata.qaPlan}
           persistent
+          showOverview={false}
           updatedAt={coverageSource.completedAt ?? coverageSource.createdAt}
           onRequestCoverage={handleRequestCoverage}
           requestPending={taskPending}
         />
       )}
-
-      {/* Direction queue */}
-      <QaTaskBoard
-        tasks={tasks}
-        pending={taskPending}
-        error={taskError}
-        onAdd={addTask}
-        onRetry={retryTask}
-        onDrop={dropTask}
-      />
 
       {/* Automation triggers (cron + PR) */}
       <QaTriggerConfig

--- a/plugins/qa-agent/src/ui/qa-agent-client.tsx
+++ b/plugins/qa-agent/src/ui/qa-agent-client.tsx
@@ -651,10 +651,12 @@ export function QaAgentClient({
     for (let i = events.length - 1; i >= 0; i--) {
       const e = events[i];
       if (e.sourceType === "qa_agent") continue;
-      if (
-        new Date(e.createdAt as unknown as string).getTime() <
-        nowTick - EXTERNAL_ACTIVITY_WINDOW_MS
-      ) {
+      // `createdAt` is `string | Date | null` on the wire. An event with no
+      // timestamp cannot be placed in the window at all, so skip it rather
+      // than let `new Date(null)` read as epoch 0 and close the whole scan.
+      if (!e.createdAt) continue;
+      const at = new Date(e.createdAt).getTime();
+      if (Number.isNaN(at) || at < nowTick - EXTERNAL_ACTIVITY_WINDOW_MS) {
         return null;
       }
       return {

--- a/plugins/qa-agent/src/ui/qa-agent-header.tsx
+++ b/plugins/qa-agent/src/ui/qa-agent-header.tsx
@@ -93,7 +93,6 @@ export function QaAgentHeader({
   loading,
   setupOpen,
   canStartRun,
-  triggerSummary,
   onToggleSetup,
   onPause,
   onResume,
@@ -112,8 +111,6 @@ export function QaAgentHeader({
   loading: boolean;
   setupOpen: boolean;
   canStartRun: boolean;
-  /** From the automation config — e.g. "manual runs · task queue · on PR". */
-  triggerSummary: string;
   onToggleSetup: () => void;
   onPause: () => void;
   onResume: () => void;
@@ -137,115 +134,122 @@ export function QaAgentHeader({
     : "Ready — start a run, or drop a task in the queue below";
 
   return (
-    <Card>
-      <CardContent className="pt-4 space-y-3">
-        <div className="flex flex-wrap items-center gap-3">
-          <div className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 shrink-0">
-            <Bot className="h-5 w-5 text-primary" />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2 font-medium">
-              QA agent
-              <span
-                className={`flex items-center gap-1.5 text-xs font-medium ${meta.textClass}`}
-              >
-                <StatusDot state={state} />
-                {meta.label}
-              </span>
-              {session?.metadata.qaMode &&
-                session.metadata.qaMode !== "full" && (
-                  <Badge variant="outline" className="text-[10px] px-1.5">
-                    {session.metadata.qaMode === "refresh_spec"
-                      ? "spec refresh"
-                      : "fill gaps"}
-                  </Badge>
-                )}
-              {workingTask && (
-                <Badge
-                  variant="outline"
-                  className="text-[10px] px-1.5 gap-1 bg-primary/5 border-primary/30 max-w-56"
-                  title={workingTask.title}
-                >
-                  <ListTodo className="h-3 w-3 shrink-0" />
-                  <span className="truncate">{workingTask.title}</span>
-                </Badge>
-              )}
-            </div>
-            <div
-              className="text-xs text-muted-foreground truncate"
-              title={narration}
+    <Card className="gap-0 p-3.5">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-info/10">
+          <Bot className="h-5 w-5 text-info" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 text-sm font-semibold">
+            QA agent
+            <span
+              className={`flex items-center gap-1.5 text-xs font-medium ${meta.textClass}`}
             >
-              {narration}
-              {session?.metadata.qaTargetUrl && (
-                <span className="opacity-70">
-                  {" "}
-                  · {repositoryName} → {session.metadata.qaTargetUrl}
+              <StatusDot state={state} />
+              {meta.label}
+            </span>
+            {session?.metadata.qaMode && session.metadata.qaMode !== "full" && (
+              <Badge variant="outline" className="text-[10px] px-1.5">
+                {session.metadata.qaMode === "refresh_spec"
+                  ? "spec refresh"
+                  : "fill gaps"}
+              </Badge>
+            )}
+            {workingTask && (
+              <Badge
+                variant="outline"
+                className="text-[10px] px-1.5 gap-1 bg-primary/5 border-primary/30 max-w-56"
+                title={workingTask.title}
+              >
+                <ListTodo className="h-3 w-3 shrink-0" />
+                <span className="truncate">{workingTask.title}</span>
+              </Badge>
+            )}
+          </div>
+          <div
+            className="mt-0.5 truncate text-xs text-muted-foreground"
+            title={narration}
+          >
+            {narration}
+            {session?.metadata.qaTargetUrl && (
+              <span className="opacity-70">
+                {" "}
+                · {repositoryName} →{" "}
+                <span className="font-mono">
+                  {session.metadata.qaTargetUrl}
                 </span>
-              )}
+              </span>
+            )}
+          </div>
+          {externalActivity && (
+            <div className="mt-0.5 flex items-center gap-1 text-[11px] text-info truncate">
+              <Plug className="h-3 w-3 shrink-0" />
+              <span className="truncate">
+                {externalActivity.sourceLabel}: {externalActivity.summary}
+              </span>
             </div>
-            {externalActivity && (
-              <div className="mt-0.5 flex items-center gap-1 text-[11px] text-info truncate">
-                <Plug className="h-3 w-3 shrink-0" />
-                <span className="truncate">
-                  {externalActivity.sourceLabel}: {externalActivity.summary}
-                </span>
-              </div>
-            )}
-          </div>
-          <div className="flex items-center gap-2">
-            {isRunning && (
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={onPause}
-                disabled={loading}
-              >
-                <Pause className="h-3.5 w-3.5" />
-                Pause
-              </Button>
-            )}
-            {isPaused && !awaitingReview && (
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={onResume}
-                disabled={loading}
-              >
-                <Play className="h-3.5 w-3.5" />
-                Resume
-              </Button>
-            )}
-            {(isRunning || isPaused) && (
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={onCancel}
-                disabled={loading}
-              >
-                <Ban className="h-3.5 w-3.5" />
-                Cancel
-              </Button>
-            )}
-            {!session && canStartRun && (
-              <Button size="sm" variant="outline" onClick={onToggleSetup}>
-                {setupOpen ? (
-                  <ChevronUp className="h-3.5 w-3.5" />
-                ) : (
-                  <Plus className="h-3.5 w-3.5" />
-                )}
-                New run
-                {!setupOpen && <ChevronDown className="h-3.5 w-3.5" />}
-              </Button>
-            )}
-          </div>
+          )}
         </div>
+
         {(isRunning || isPaused) && (
-          <Progress value={progress} className="h-1.5" />
+          <div className="w-52 shrink-0">
+            <div className="mb-1 flex justify-between text-[11px]">
+              <span className="text-muted-foreground">Pipeline</span>
+              <span className="font-mono font-semibold text-info tabular-nums">
+                {Math.round(progress)}%
+              </span>
+            </div>
+            <Progress value={progress} className="h-1.5" />
+          </div>
         )}
-        <div className="text-[11px] text-muted-foreground">
-          Triggers: {triggerSummary} — configure below
+
+        <div className="flex items-center gap-2">
+          {isRunning && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onPause}
+              disabled={loading}
+            >
+              <Pause className="h-3.5 w-3.5" />
+              Pause
+            </Button>
+          )}
+          {isPaused && !awaitingReview && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onResume}
+              disabled={loading}
+            >
+              <Play className="h-3.5 w-3.5" />
+              Resume
+            </Button>
+          )}
+          {(isRunning || isPaused) && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onCancel}
+              disabled={loading}
+            >
+              <Ban className="h-3.5 w-3.5" />
+              Cancel
+            </Button>
+          )}
+          {!session && canStartRun && (
+            <Button size="sm" variant="outline" onClick={onToggleSetup}>
+              {setupOpen ? (
+                <ChevronUp className="h-3.5 w-3.5" />
+              ) : (
+                <Plus className="h-3.5 w-3.5" />
+              )}
+              New run
+              {!setupOpen && <ChevronDown className="h-3.5 w-3.5" />}
+            </Button>
+          )}
         </div>
-      </CardContent>
+      </div>
     </Card>
   );
 }

--- a/plugins/qa-agent/src/ui/qa-bento-tiles.tsx
+++ b/plugins/qa-agent/src/ui/qa-bento-tiles.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { QaSummaryData } from "@lastest/eb-protocol";
+import type { QaSessionRow as AgentSession } from "../types";
+// Activity rows arrive narrowed — `ActivityEvent` is core's row type and a
+// plugin may not import it (recipe §6.1); `QaFeedEvent` is the slice read here.
+import type { QaFeedEvent } from "./use-activity-events";
+import type { QaTriggerState } from "./qa-trigger-config";
+import { timeAgo } from "./format";
+import { Card } from "@lastest/ui";
+import {
+  Activity,
+  CalendarClock,
+  CheckCircle2,
+  Clock,
+  GitPullRequest,
+  Hand,
+  ListTodo,
+  Radar,
+  Rss,
+  ShieldCheck,
+  Wrench,
+  XCircle,
+} from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Bento tiles for the QA agent console — each one reads live session, coverage,
+// trigger or activity state. Every number here comes from the store; a tile
+// with nothing to say says so rather than inventing a figure.
+// ---------------------------------------------------------------------------
+
+export function Tile({
+  eyebrow,
+  icon: Icon,
+  className = "",
+  children,
+}: {
+  eyebrow: string;
+  icon: typeof Activity;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Card className={`gap-0 p-4 ${className}`}>
+      <div className="mb-2.5 flex items-center gap-1.5 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+        <Icon className="h-3 w-3" />
+        {eyebrow}
+      </div>
+      {children}
+    </Card>
+  );
+}
+
+/** Client-only clock. Null until mount, so anything derived from "now"
+ *  (countdowns, relative times) renders identically on the server. */
+function useNow(intervalMs: number): number | null {
+  const [now, setNow] = useState<number | null>(null);
+  useEffect(() => {
+    // Deliberate first paint from the server value, then the client clock.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
+  return now;
+}
+
+/** Elapsed clock for the running phase — ticks client-side from a timestamp. */
+function Elapsed({ since }: { since: string }) {
+  const now = useNow(1000);
+  const started = new Date(since).getTime();
+  if (now === null || !Number.isFinite(started)) return null;
+  const secs = Math.max(0, Math.floor((now - started) / 1000));
+  const mm = String(Math.floor(secs / 60)).padStart(2, "0");
+  const ss = String(secs % 60).padStart(2, "0");
+  return (
+    <span className="font-mono tabular-nums">
+      {mm}:{ss}
+    </span>
+  );
+}
+
+export function DoingNowTile({
+  session,
+  awaitingReview,
+}: {
+  /** The live (active/paused) session, or null when the agent is idle. */
+  session: AgentSession | null;
+  awaitingReview: boolean;
+}) {
+  const step = session?.steps.find(
+    (s) => s.status === "active" || s.status === "waiting_user",
+  );
+  const substep = step
+    ? [...(step.substeps ?? [])].reverse().find((s) => s.status === "running")
+    : undefined;
+
+  return (
+    <Tile eyebrow="Doing now" icon={Activity}>
+      {step ? (
+        <>
+          <div
+            className={`text-sm font-semibold ${
+              awaitingReview ? "text-warning" : "text-info"
+            }`}
+          >
+            {step.label}
+          </div>
+          <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
+            {substep?.detail ?? substep?.label ?? step.description}
+          </p>
+          {step.startedAt && (
+            <div className="mt-auto pt-2 text-[11px] text-muted-foreground">
+              running <Elapsed since={step.startedAt} />
+            </div>
+          )}
+        </>
+      ) : (
+        <>
+          <div className="text-sm font-semibold text-muted-foreground">
+            Idle
+          </div>
+          <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
+            Nothing running. Start a run, or drop a task in the direction queue
+            — the agent picks it up on its own.
+          </p>
+        </>
+      )}
+    </Tile>
+  );
+}
+
+export function CoverageTile({
+  summary,
+  updatedAt,
+}: {
+  summary: QaSummaryData | null;
+  updatedAt?: Date | string | null;
+}) {
+  // Hydration guard: timeAgo() drifts between server render and client mount.
+  const mounted = useNow(60_000) !== null;
+
+  if (!summary) {
+    return (
+      <Tile eyebrow="Coverage" icon={ShieldCheck}>
+        <div className="text-sm font-semibold text-muted-foreground">
+          No plan yet
+        </div>
+        <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
+          Coverage appears after the first run produces a plan and a summary.
+        </p>
+      </Tile>
+    );
+  }
+
+  const covered = summary.covered ?? 0;
+  const done = covered + summary.generated;
+  const gaps = Math.max(0, summary.planned - done);
+  const pct =
+    summary.planned > 0 ? Math.round((done / summary.planned) * 100) : 0;
+
+  return (
+    <Tile eyebrow="Coverage" icon={ShieldCheck}>
+      <div className="flex items-baseline gap-1.5">
+        <span className="text-3xl font-bold tracking-tight tabular-nums text-success">
+          {pct}%
+        </span>
+        <span className="text-xs text-muted-foreground">covered</span>
+      </div>
+      <div className="mt-2.5 flex h-2 w-full overflow-hidden rounded-full bg-muted">
+        <span className="h-full bg-success" style={{ width: `${pct}%` }} />
+      </div>
+      <div className="mt-2 text-[11px] leading-relaxed text-muted-foreground">
+        {done} / {summary.planned} planned · {covered} existing ·{" "}
+        {summary.generated} generated · {summary.passed} passing · {gaps} gap
+        {gaps === 1 ? "" : "s"}
+      </div>
+      {updatedAt && mounted && (
+        <div className="mt-auto pt-2 text-[10px] text-muted-foreground">
+          updated {timeAgo(new Date(updatedAt))}
+        </div>
+      )}
+    </Tile>
+  );
+}
+
+/** Countdown to the next automated run, or the queue depth when the only
+ *  thing due is user-queued work. */
+export function UpNextTile({
+  trigger,
+  queuedCount,
+}: {
+  trigger: QaTriggerState;
+  queuedCount: number;
+}) {
+  const now = useNow(30_000);
+
+  const nextRun =
+    trigger.scheduleEnabled && trigger.nextRunAt
+      ? new Date(trigger.nextRunAt)
+      : null;
+  const modeLabel =
+    trigger.scheduleMode === "fill_gaps"
+      ? "fill coverage gaps"
+      : trigger.scheduleMode === "refresh_spec"
+        ? "refresh the specification"
+        : "full run";
+
+  return (
+    <Tile eyebrow="Up next" icon={Clock}>
+      {nextRun && now !== null ? (
+        <>
+          <div className="text-xl font-bold tracking-tight text-info">
+            {nextRun.getTime() > now
+              ? `in ${formatUntil(nextRun, now)}`
+              : "due now"}
+          </div>
+          <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
+            Scheduled run — <span className="text-foreground">{modeLabel}</span>{" "}
+            · <span className="font-mono">{trigger.cronExpression}</span>
+          </p>
+        </>
+      ) : queuedCount > 0 ? (
+        <>
+          <div className="text-xl font-bold tracking-tight text-info tabular-nums">
+            {queuedCount} queued
+          </div>
+          <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
+            The agent works the direction queue as soon as it is free.
+          </p>
+        </>
+      ) : (
+        <>
+          <div className="text-sm font-semibold text-muted-foreground">
+            Nothing scheduled
+          </div>
+          <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
+            Turn on a schedule or PR trigger below to let the agent run itself.
+          </p>
+        </>
+      )}
+    </Tile>
+  );
+}
+
+function formatUntil(when: Date, now: number): string {
+  const mins = Math.max(0, Math.round((when.getTime() - now) / 60000));
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ${mins % 60}m`;
+  return `${Math.floor(hours / 24)}d ${hours % 24}h`;
+}
+
+export function WatchingTile({
+  trigger,
+  githubConnected,
+}: {
+  trigger: QaTriggerState;
+  githubConnected: boolean;
+}) {
+  const chips: Array<{ icon: typeof Radar; label: string }> = [];
+  if (trigger.prEnabled) chips.push({ icon: GitPullRequest, label: "on PR" });
+  if (trigger.scheduleEnabled)
+    chips.push({ icon: CalendarClock, label: trigger.cronExpression });
+  chips.push({ icon: Hand, label: "manual runs" });
+  chips.push({ icon: ListTodo, label: "task queue" });
+
+  return (
+    <Tile eyebrow="Watching" icon={Radar}>
+      <div className="mb-2 flex flex-wrap gap-1.5">
+        {chips.map((chip) => (
+          <span
+            key={chip.label}
+            className="inline-flex items-center gap-1 rounded-full bg-info/10 px-2 py-0.5 text-[11px] font-medium text-info"
+          >
+            <chip.icon className="h-3 w-3" />
+            {chip.label}
+          </span>
+        ))}
+      </div>
+      <p className="text-xs leading-relaxed text-muted-foreground">
+        {trigger.prEnabled
+          ? "Re-discovers changed routes on every pull request."
+          : githubConnected
+            ? "Connect a PR trigger below to re-check coverage on every pull request."
+            : "Connect GitHub to let the agent react to pull requests."}
+      </p>
+    </Tile>
+  );
+}
+
+const SOURCE_LABELS: Record<string, string> = {
+  play_agent: "Play agent",
+  mcp_server: "MCP agent",
+  generate_agent: "Generator",
+  heal_agent: "Healer",
+  qa_agent: "QA agent",
+  explorer_agent: "Explorer",
+};
+
+/** Icon + tone per event family — keyed on the event type's verb. */
+function eventTone(event: QaFeedEvent): {
+  icon: typeof CheckCircle2;
+  className: string;
+} {
+  const type = event.eventType;
+  if (type.endsWith(":error") || type.endsWith(":failed")) {
+    return { icon: XCircle, className: "bg-destructive/10 text-destructive" };
+  }
+  if (type.startsWith("heal") || type.includes("fix")) {
+    return { icon: Wrench, className: "bg-warning/15 text-warning" };
+  }
+  if (type.endsWith(":complete") || type.includes("pass")) {
+    return { icon: CheckCircle2, className: "bg-success/15 text-success" };
+  }
+  return { icon: Activity, className: "bg-info/10 text-info" };
+}
+
+export function LiveActivityTile({
+  events,
+  className = "",
+}: {
+  /** Newest last — seeded server-side, extended live over SSE. */
+  events: QaFeedEvent[];
+  className?: string;
+}) {
+  // Hydration guard for the relative timestamps.
+  const mounted = useNow(60_000) !== null;
+  const recent = [...events].reverse().slice(0, 8);
+
+  return (
+    <Tile eyebrow="Live activity" icon={Rss} className={className}>
+      {recent.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          No agent activity on this repo yet.
+        </p>
+      ) : (
+        <div className="divide-y divide-border">
+          {recent.map((event) => {
+            const tone = eventTone(event);
+            const Icon = tone.icon;
+            return (
+              <div key={event.id} className="flex gap-2.5 py-2">
+                <span
+                  className={`flex h-5.5 w-5.5 shrink-0 items-center justify-center rounded-md ${tone.className}`}
+                >
+                  <Icon className="h-3 w-3" />
+                </span>
+                <div className="min-w-0">
+                  <div className="text-xs leading-snug text-muted-foreground">
+                    <span className="font-semibold text-foreground">
+                      {SOURCE_LABELS[event.sourceType] ?? event.sourceType}
+                    </span>{" "}
+                    {event.summary}
+                  </div>
+                  {event.createdAt && mounted && (
+                    <div className="mt-0.5 font-mono text-[9.5px] uppercase text-muted-foreground/70">
+                      {timeAgo(new Date(event.createdAt))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </Tile>
+  );
+}

--- a/plugins/qa-agent/src/ui/qa-phase-timeline.tsx
+++ b/plugins/qa-agent/src/ui/qa-phase-timeline.tsx
@@ -93,10 +93,14 @@ function SubstepRow({
 export function PhaseTimeline({
   session,
   bare = false,
+  detailOnly = false,
 }: {
   session: AgentSession;
   /** Render without the Card wrapper (inside an expanded history row). */
   bare?: boolean;
+  /** Drop the phase row and show only the active-step detail — the console
+   *  already draws the phases as its own pipeline strip. */
+  detailOnly?: boolean;
 }) {
   const activeStep = session.steps.find(
     (s) =>
@@ -106,37 +110,39 @@ export function PhaseTimeline({
   );
   const body = (
     <>
-      <div className="flex items-start gap-0 overflow-x-auto pb-1">
-        {session.steps.map((step, i) => (
-          <div key={step.id} className="flex items-start min-w-0">
-            {i > 0 && (
+      {!detailOnly && (
+        <div className="flex items-start gap-0 overflow-x-auto pb-1">
+          {session.steps.map((step, i) => (
+            <div key={step.id} className="flex items-start min-w-0">
+              {i > 0 && (
+                <div
+                  className={`h-px w-5 sm:w-8 mt-2 shrink-0 ${
+                    step.status === "pending" ? "bg-border" : "bg-success/50"
+                  }`}
+                />
+              )}
               <div
-                className={`h-px w-5 sm:w-8 mt-2 shrink-0 ${
-                  step.status === "pending" ? "bg-border" : "bg-success/50"
-                }`}
-              />
-            )}
-            <div
-              className="flex flex-col items-center gap-1 px-1 min-w-14"
-              title={step.description}
-            >
-              <StepDot step={step} />
-              <span
-                className={`text-[11px] leading-tight text-center ${
-                  step.status === "active" || step.status === "waiting_user"
-                    ? "text-foreground font-medium"
-                    : "text-muted-foreground"
-                }`}
+                className="flex flex-col items-center gap-1 px-1 min-w-14"
+                title={step.description}
               >
-                {step.id === "qa_login" && (
-                  <Lock className="inline h-3 w-3 mr-0.5 align-[-1px]" />
-                )}
-                {step.label}
-              </span>
+                <StepDot step={step} />
+                <span
+                  className={`text-[11px] leading-tight text-center ${
+                    step.status === "active" || step.status === "waiting_user"
+                      ? "text-foreground font-medium"
+                      : "text-muted-foreground"
+                  }`}
+                >
+                  {step.id === "qa_login" && (
+                    <Lock className="inline h-3 w-3 mr-0.5 align-[-1px]" />
+                  )}
+                  {step.label}
+                </span>
+              </div>
             </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      )}
 
       {activeStep && (
         <div className="rounded-md border bg-muted/30 p-3 space-y-1">

--- a/plugins/qa-agent/src/ui/qa-pipeline-strip.tsx
+++ b/plugins/qa-agent/src/ui/qa-pipeline-strip.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import type {
+  QaSessionRow as AgentSession,
+  QaStepId as AgentStepId,
+  QaStepState as AgentStepState,
+} from "../types";
+import { QA_PHASES } from "../phases";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronRight,
+  FileCheck2,
+  Loader2,
+  Lock,
+  Map as MapIcon,
+  Play,
+  Search,
+  ShieldCheck,
+  Sparkles,
+  UserRound,
+  Wrench,
+} from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Pipeline strip — the run's phases as one connected track across the top of
+// the console. Reads a live session when there is one, the newest settled run
+// otherwise, and falls back to the (dimmed) pipeline shape before a repo has
+// ever run the agent.
+// ---------------------------------------------------------------------------
+
+const PHASE_ICONS: Record<string, typeof Search> = {
+  qa_setup: ShieldCheck,
+  qa_login: Lock,
+  qa_discover: Search,
+  qa_plan: MapIcon,
+  qa_plan_review: CheckCircle2,
+  qa_generate: Sparkles,
+  qa_execute: Play,
+  qa_heal: Wrench,
+  qa_summary: FileCheck2,
+};
+
+/** Short per-phase result line, read from the payload the step itself wrote
+ *  (`setStepCompleted` in the QA server action). Absent until it exists — the
+ *  strip never guesses a count. */
+function phaseDetail(step: AgentStepState): string | null {
+  const result = step.result ?? {};
+  const num = (key: string): number | null =>
+    typeof result[key] === "number" ? (result[key] as number) : null;
+  const str = (key: string): string | null =>
+    typeof result[key] === "string" ? (result[key] as string) : null;
+
+  switch (step.id) {
+    case "qa_login":
+      return str("strategy");
+    case "qa_discover": {
+      const routes = num("staticRoutes");
+      const pages = num("pagesCrawled");
+      if (routes !== null) return `${routes} routes`;
+      return pages === null ? null : `${pages} pages`;
+    }
+    case "qa_plan": {
+      const items = num("items");
+      return items === null ? null : `${items} items`;
+    }
+    case "qa_plan_review":
+      if (step.status === "waiting_user") return "needs you";
+      return step.status === "completed"
+        ? (step.userAction ?? "approved")
+        : null;
+    case "qa_generate": {
+      const generated = num("generated");
+      return generated === null ? null : `${generated} specs`;
+    }
+    case "qa_execute": {
+      const passed = num("passed");
+      const total = num("total");
+      if (passed === null) return null;
+      return total === null ? `${passed} passing` : `${passed} / ${total} pass`;
+    }
+    case "qa_heal": {
+      const healed = num("healed");
+      return healed === null ? null : `${healed} healed`;
+    }
+    case "qa_summary": {
+      const passed = num("passed");
+      return passed === null ? null : `${passed} passing`;
+    }
+    default:
+      return null;
+  }
+}
+
+type NodeTone =
+  | "done"
+  | "active"
+  | "waiting"
+  | "failed"
+  | "skipped"
+  | "pending";
+
+function toneOf(status: AgentStepState["status"]): NodeTone {
+  switch (status) {
+    case "completed":
+      return "done";
+    case "active":
+      return "active";
+    case "waiting_user":
+      return "waiting";
+    case "failed":
+      return "failed";
+    case "skipped":
+      return "skipped";
+    default:
+      return "pending";
+  }
+}
+
+const NODE_TONE: Record<
+  NodeTone,
+  { cell: string; icon: string; label: string }
+> = {
+  done: {
+    cell: "bg-success/5",
+    icon: "bg-success/15 text-success",
+    label: "text-foreground",
+  },
+  active: {
+    cell: "bg-info/5 ring-1 ring-inset ring-info/25 border-info/40",
+    icon: "bg-info/15 text-info",
+    label: "text-info",
+  },
+  waiting: {
+    cell: "bg-warning/5 ring-1 ring-inset ring-warning/25 border-warning/40",
+    icon: "bg-warning/15 text-warning",
+    label: "text-warning",
+  },
+  failed: {
+    cell: "bg-destructive/5 border-destructive/40",
+    icon: "bg-destructive/15 text-destructive",
+    label: "text-destructive",
+  },
+  skipped: {
+    cell: "",
+    icon: "bg-muted text-muted-foreground/60",
+    label: "text-muted-foreground/60",
+  },
+  pending: {
+    cell: "",
+    icon: "bg-muted text-muted-foreground/60",
+    label: "text-muted-foreground/60",
+  },
+};
+
+/** The pipeline shape with nothing run yet — every phase pending. */
+function skeletonSteps(): AgentStepState[] {
+  return QA_PHASES.map((phase) => ({
+    id: phase.id,
+    status: "pending" as const,
+    label: phase.label,
+    description: phase.description,
+  }));
+}
+
+export function QaPipelineStrip({
+  session,
+  className = "",
+}: {
+  /** Live session, else the newest settled run, else null (never ran). */
+  session: AgentSession | null;
+  className?: string;
+}) {
+  const steps = session?.steps?.length ? session.steps : skeletonSteps();
+
+  return (
+    <div className={`flex items-stretch overflow-x-auto ${className}`}>
+      {steps.map((step, i) => {
+        const tone = NODE_TONE[toneOf(step.status)];
+        const Icon = PHASE_ICONS[step.id as AgentStepId] ?? ShieldCheck;
+        const detail = phaseDetail(step);
+        const first = i === 0;
+        const last = i === steps.length - 1;
+        return (
+          <div
+            key={step.id}
+            title={step.description}
+            className={`relative flex min-w-28 flex-1 flex-col gap-1.5 border border-border p-3 ${
+              last ? "" : "border-r-0"
+            } ${first ? "rounded-l-md" : ""} ${last ? "rounded-r-md" : ""} ${tone.cell}`}
+          >
+            <span
+              className={`flex h-6 w-6 items-center justify-center rounded-md ${tone.icon}`}
+            >
+              {step.status === "active" ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : step.status === "waiting_user" ? (
+                <UserRound className="h-3.5 w-3.5" />
+              ) : step.status === "failed" ? (
+                <AlertTriangle className="h-3.5 w-3.5" />
+              ) : (
+                <Icon className="h-3.5 w-3.5" />
+              )}
+            </span>
+            <span className={`text-xs font-semibold ${tone.label}`}>
+              {step.label}
+            </span>
+            <span className="min-h-4 truncate text-[10px] text-muted-foreground">
+              {detail ?? " "}
+            </span>
+            {!last && (
+              <span className="absolute -right-2.5 top-1/2 z-10 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-full border border-border bg-card">
+                <ChevronRight className="h-3 w-3 text-muted-foreground" />
+              </span>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/plugins/qa-agent/src/ui/qa-results-panel.tsx
+++ b/plugins/qa-agent/src/ui/qa-results-panel.tsx
@@ -273,6 +273,113 @@ function QaPrCoverageSection({
   );
 }
 
+/**
+ * Coverage matrix — business area × test group. Extracted so the QA console can
+ * render it as its own bento tile while the coverage-detail card keeps the same
+ * table for the by-group and journey sections around it.
+ */
+export function QaCoverageMatrix({
+  summary,
+  onRequestCoverage,
+  requestPending = false,
+}: {
+  summary: QaSummaryData;
+  onRequestCoverage?: (hint: CoverageRequestHint) => void;
+  requestPending?: boolean;
+}) {
+  if (!summary.matrix || Object.keys(summary.matrix).length === 0) return null;
+  return (
+    <div className="space-y-1">
+      <h4 className="text-sm font-medium">
+        Coverage matrix{" "}
+        <span className="text-xs font-normal text-muted-foreground">
+          — business area × test group (covered+generated / planned, ✓ passing
+          this run; a multi-group test counts in every column it covers)
+        </span>
+      </h4>
+      <div className="rounded-md border overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b bg-muted/40">
+              <th className="w-full text-left px-3 py-1.5 font-medium">
+                Business area
+              </th>
+              {QA_GROUPS.filter((g) =>
+                Object.values(summary.matrix!).some((row) => row[g.id]),
+              ).map((g) => (
+                <th
+                  key={g.id}
+                  className="w-14 text-center px-1.5 py-1.5 font-medium text-xs whitespace-nowrap"
+                  title={`${g.label} — ${g.description}`}
+                >
+                  {g.short}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {Object.entries(summary.matrix).map(([area, row]) => (
+              <tr key={area}>
+                <td className="px-3 py-1.5 font-medium whitespace-nowrap">
+                  {area}
+                </td>
+                {QA_GROUPS.filter((g) =>
+                  Object.values(summary.matrix!).some((r) => r[g.id]),
+                ).map((g) => {
+                  const cell = row[g.id];
+                  if (!cell || cell.planned === 0) {
+                    return (
+                      <td
+                        key={g.id}
+                        className="text-center px-2 py-1.5 text-muted-foreground/40"
+                      >
+                        —
+                      </td>
+                    );
+                  }
+                  const done = cell.covered + cell.generated;
+                  const complete = cell.covered + cell.passed === cell.planned;
+                  const hasGap = done < cell.planned;
+                  return (
+                    <td
+                      key={g.id}
+                      className={`text-center px-2 py-1.5 whitespace-nowrap ${
+                        complete ? "text-success" : hasGap ? "text-warning" : ""
+                      }`}
+                      title={`planned ${cell.planned} · covered ${cell.covered} · generated ${cell.generated} · passing ${cell.passed}`}
+                    >
+                      {done}/{cell.planned}
+                      {cell.passed > 0 && (
+                        <span className="text-xs text-success">
+                          {" "}
+                          {cell.passed}✓
+                        </span>
+                      )}
+                      {hasGap && onRequestCoverage && (
+                        <button
+                          type="button"
+                          className="ml-1 inline-flex align-[-2px] rounded border border-warning/40 text-warning hover:bg-warning/10 disabled:opacity-50"
+                          title={`Ask the agent to cover the ${area} × ${g.label} gap`}
+                          disabled={requestPending}
+                          onClick={() =>
+                            onRequestCoverage({ area, group: g.id })
+                          }
+                        >
+                          <Plus className="h-3 w-3" />
+                        </button>
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
 export function QaSummaryPanel({
   summary,
   plan,
@@ -280,6 +387,7 @@ export function QaSummaryPanel({
   updatedAt,
   onRequestCoverage,
   requestPending = false,
+  showOverview = true,
 }: {
   summary: QaSummaryData;
   plan: QaTestPlan | undefined;
@@ -291,6 +399,9 @@ export function QaSummaryPanel({
    *  per-gap-cell CTAs render only when provided. */
   onRequestCoverage?: (hint: CoverageRequestHint) => void;
   requestPending?: boolean;
+  /** Headline counts + matrix. Off when the console already renders them as
+   *  their own bento tiles and this card is only the detail below them. */
+  showOverview?: boolean;
 }) {
   const [mounted, setMounted] = useState(false);
   useEffect(() => {
@@ -339,126 +450,44 @@ export function QaSummaryPanel({
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
-          {[
-            { label: "Planned", value: summary.planned },
-            { label: "Covered", value: summary.covered ?? 0 },
-            { label: "Generated", value: summary.generated },
-            { label: "Passing", value: summary.passed },
-            {
-              label: "Gaps",
-              value: Math.max(
-                0,
-                summary.planned - (summary.covered ?? 0) - summary.generated,
-              ),
-            },
-          ].map((stat) => (
-            <div key={stat.label} className="rounded-md border p-3 text-center">
-              <div className="text-2xl font-semibold">{stat.value}</div>
-              <div className="text-xs text-muted-foreground">{stat.label}</div>
-            </div>
-          ))}
-        </div>
+        {showOverview && (
+          <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
+            {[
+              { label: "Planned", value: summary.planned },
+              { label: "Covered", value: summary.covered ?? 0 },
+              { label: "Generated", value: summary.generated },
+              { label: "Passing", value: summary.passed },
+              {
+                label: "Gaps",
+                value: Math.max(
+                  0,
+                  summary.planned - (summary.covered ?? 0) - summary.generated,
+                ),
+              },
+            ].map((stat) => (
+              <div
+                key={stat.label}
+                className="rounded-md border p-3 text-center"
+              >
+                <div className="text-2xl font-semibold">{stat.value}</div>
+                <div className="text-xs text-muted-foreground">
+                  {stat.label}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
 
         {summary.prCoverage && (
           <QaPrCoverageSection prCoverage={summary.prCoverage} />
         )}
 
-        {summary.matrix && Object.keys(summary.matrix).length > 0 && (
-          <div className="space-y-1">
-            <h4 className="text-sm font-medium">
-              Coverage matrix{" "}
-              <span className="text-xs font-normal text-muted-foreground">
-                — business area × test group (covered+generated / planned, ✓
-                passing this run; a multi-group test counts in every column it
-                covers)
-              </span>
-            </h4>
-            <div className="rounded-md border overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b bg-muted/40">
-                    <th className="w-full text-left px-3 py-1.5 font-medium">
-                      Business area
-                    </th>
-                    {QA_GROUPS.filter((g) =>
-                      Object.values(summary.matrix!).some((row) => row[g.id]),
-                    ).map((g) => (
-                      <th
-                        key={g.id}
-                        className="w-14 text-center px-1.5 py-1.5 font-medium text-xs whitespace-nowrap"
-                        title={`${g.label} — ${g.description}`}
-                      >
-                        {g.short}
-                      </th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody className="divide-y">
-                  {Object.entries(summary.matrix).map(([area, row]) => (
-                    <tr key={area}>
-                      <td className="px-3 py-1.5 font-medium whitespace-nowrap">
-                        {area}
-                      </td>
-                      {QA_GROUPS.filter((g) =>
-                        Object.values(summary.matrix!).some((r) => r[g.id]),
-                      ).map((g) => {
-                        const cell = row[g.id];
-                        if (!cell || cell.planned === 0) {
-                          return (
-                            <td
-                              key={g.id}
-                              className="text-center px-2 py-1.5 text-muted-foreground/40"
-                            >
-                              —
-                            </td>
-                          );
-                        }
-                        const done = cell.covered + cell.generated;
-                        const complete =
-                          cell.covered + cell.passed === cell.planned;
-                        const hasGap = done < cell.planned;
-                        return (
-                          <td
-                            key={g.id}
-                            className={`text-center px-2 py-1.5 whitespace-nowrap ${
-                              complete
-                                ? "text-success"
-                                : hasGap
-                                  ? "text-warning"
-                                  : ""
-                            }`}
-                            title={`planned ${cell.planned} · covered ${cell.covered} · generated ${cell.generated} · passing ${cell.passed}`}
-                          >
-                            {done}/{cell.planned}
-                            {cell.passed > 0 && (
-                              <span className="text-xs text-success">
-                                {" "}
-                                {cell.passed}✓
-                              </span>
-                            )}
-                            {hasGap && onRequestCoverage && (
-                              <button
-                                type="button"
-                                className="ml-1 inline-flex align-[-2px] rounded border border-warning/40 text-warning hover:bg-warning/10 disabled:opacity-50"
-                                title={`Ask the agent to cover the ${area} × ${g.label} gap`}
-                                disabled={requestPending}
-                                onClick={() =>
-                                  onRequestCoverage({ area, group: g.id })
-                                }
-                              >
-                                <Plus className="h-3 w-3" />
-                              </button>
-                            )}
-                          </td>
-                        );
-                      })}
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
+        {showOverview && (
+          <QaCoverageMatrix
+            summary={summary}
+            onRequestCoverage={onRequestCoverage}
+            requestPending={requestPending}
+          />
         )}
 
         {groupRows.length > 0 && (

--- a/plugins/qa-agent/src/ui/qa-task-board.tsx
+++ b/plugins/qa-agent/src/ui/qa-task-board.tsx
@@ -144,6 +144,8 @@ function TaskCard({
   pending: boolean;
   onRetry: (id: string) => void;
   onDrop: (id: string) => void;
+  /** Grid placement when the console renders the board as a bento tile. */
+  className?: string;
 }) {
   const cancelled = task.status === "cancelled";
   return (
@@ -227,6 +229,7 @@ export function QaTaskBoard({
   onAdd,
   onRetry,
   onDrop,
+  className = "",
 }: {
   tasks: QaTask[];
   pending: boolean;
@@ -237,6 +240,8 @@ export function QaTaskBoard({
   ) => Promise<boolean>;
   onRetry: (id: string) => void;
   onDrop: (id: string) => void;
+  /** Grid placement when the console renders the board as a bento tile. */
+  className?: string;
 }) {
   const [draft, setDraft] = useState("");
 
@@ -247,7 +252,7 @@ export function QaTaskBoard({
   };
 
   return (
-    <Card>
+    <Card className={className}>
       <CardHeader className="pb-3">
         <CardTitle className="flex items-center gap-2 text-base">
           <ListTodo className="h-4 w-4" />
@@ -288,7 +293,7 @@ export function QaTaskBoard({
           </div>
         )}
 
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
           {COLUMNS.map((col) => {
             const Icon = col.icon;
             const items = tasks.filter((t) => col.statuses.includes(t.status));

--- a/plugins/qa-agent/src/ui/use-activity-events.ts
+++ b/plugins/qa-agent/src/ui/use-activity-events.ts
@@ -12,7 +12,7 @@ export interface QaFeedEvent {
   eventType: string;
   summary: string;
   sourceType: string;
-  createdAt: string | Date;
+  createdAt: string | Date | null;
 }
 
 const MAX_EVENTS = 500;

--- a/src/app/(app)/qa-agent/page.tsx
+++ b/src/app/(app)/qa-agent/page.tsx
@@ -8,6 +8,7 @@ import {
   getAISettings,
   getDefaultSetupSteps,
   getStorageStates,
+  getRecentActivityEvents,
 } from "@/lib/db/queries";
 // The plugin's own tables (tasks, triggers) are read through its reads
 // module; this page's repo selection is the authorization, same as before.
@@ -84,6 +85,7 @@ export default async function QaAgentPage() {
     recentSessions,
     qaTasks,
     qaTriggerConfig,
+    recentActivity,
     ghAccount,
     envConfig,
     aiSettings,
@@ -96,6 +98,12 @@ export default async function QaAgentPage() {
     getQaAgentTrigger(selectedRepo.id)
       .then((t) => t ?? null)
       .catch(() => null),
+    teamId
+      ? getRecentActivityEvents(teamId, {
+          repositoryId: selectedRepo.id,
+          limit: 20,
+        }).catch(() => [])
+      : [],
     teamId ? getGithubAccountByTeam(teamId).catch(() => null) : null,
     getEnvironmentConfig(selectedRepo.id).catch(() => null),
     getAISettings(selectedRepo.id).catch(() => null),
@@ -147,7 +155,7 @@ export default async function QaAgentPage() {
 
   return (
     <div className="flex-1 p-6 overflow-auto">
-      <div className="max-w-5xl mx-auto space-y-6">
+      <div className="max-w-[1600px] mx-auto space-y-6">
         <header className="space-y-1">
           <AgentBreadcrumb current="QA agent" />
           <h1 className="text-2xl font-semibold flex items-center gap-2 pt-1">
@@ -179,6 +187,7 @@ export default async function QaAgentPage() {
           // thing placed). A component reference, not a render function, so
           // it can cross the RSC boundary.
           BrowserViewer={BrowserViewer}
+          initialActivity={[...recentActivity].reverse()}
         />
       </div>
     </div>

--- a/src/lib/db/queries/activity-events.ts
+++ b/src/lib/db/queries/activity-events.ts
@@ -47,11 +47,22 @@ export async function getActivityEventsBySession(
  */
 export async function getRecentActivityEvents(
   teamId: string,
-  opts: { limit?: number; cursor?: string; sourceType?: string } = {},
+  opts: {
+    limit?: number;
+    cursor?: string;
+    sourceType?: string;
+    /** Narrow to one repo — the per-repo consoles (QA agent) seed their feed
+     *  with this, since the SSE stream only carries events from now on. */
+    repositoryId?: string;
+  } = {},
 ): Promise<ActivityEvent[]> {
-  const { limit = 50, cursor, sourceType } = opts;
+  const { limit = 50, cursor, sourceType, repositoryId } = opts;
 
   const conditions = [eq(activityEvents.teamId, teamId)];
+
+  if (repositoryId) {
+    conditions.push(eq(activityEvents.repositoryId, repositoryId));
+  }
 
   if (sourceType) {
     conditions.push(


### PR DESCRIPTION
Stacked on #120 (`feat/triage-agent`) — review that one first.

## What

The QA agent screen (`/qa-agent`, reached from Agents) was a vertical stack of cards. This reshapes it into the balanced-quad bento from the Claude Design direction (`QA Agent - Ongoing Mode.dc.html`):

- **status strip** — identity, state, narration, pipeline %
- **pipeline strip** — Preflight → … → Summary, full width
- **coverage matrix** beside four live quadrants: Doing now · Coverage · Up next · Watching
- **direction queue** beside **live activity**

Setup form, plan review, coverage detail, triggers and run history keep their place below the bento.

The design system colours were already in `globals.css`, so this is a layout/composition change, not a token change.

## Real data, no mock tiles

- `QaPipelineStrip` reads `session.steps` — live run, else newest settled run, else the pipeline shape with all phases pending. Per-phase detail lines are read from the payload each step wrote in `setStepCompleted`; a phase that reported no count renders none.
- Phase definitions moved to `src/lib/qa-agent/phases.ts` so the server action and the screen share one list.
- **Up next** counts down to `qa_agent_triggers.nextRunAt`, falling back to queue depth. **Watching** renders the configured triggers (this replaces the header's `triggerSummary` line).
- **Live activity** is seeded server-side — `getRecentActivityEvents` gained a `repositoryId` filter, since the SSE feed only carries events from connect time and the tile would otherwise always open empty.

## Refactors rather than duplicates

- `QaCoverageMatrix` extracted from `QaSummaryPanel`; the panel takes `showOverview={false}` and keeps the branch/group/journey detail.
- `PhaseTimeline` gains `detailOnly` so the active-step detail renders under the strip without repeating the phases (run history still uses the full form).

## Verification

`tsc --noEmit`, `eslint`, `pnpm build`, and `vitest run src/lib/qa-agent src/server/actions/qa-agent.integration.test.ts` (78 passing) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)