### PR TITLE
feat(mcp): OAuth 2.1 on the remote MCP endpoint, and an access-level tool policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ Visual regression testing platform: Next.js 16 App Router, PostgreSQL (Drizzle O
 - `packages/pool-service/` — EB pool service (separate process, `pnpm dev:pool`): k8s/process provisioning, pool caps, warm pool, EB reapers; app consumes `@lastest/pool-service/client`
 - `packages/eb-protocol/` — canonical wire protocol app ↔ runners (`@lastest/eb-protocol`): command/response messages, stream messages, persisted jsonb payload shapes (schema.ts re-exports these)
 - `packages/runner/` — remote runner CLI (npm package via tsup)
-- `packages/mcp-server/` — MCP server for AI agent integration (`@lastest/mcp-server`)
+- `packages/mcp-server/` — MCP server for AI agent integration (`@lastest/mcp-server`). Three transports off one tool surface: the stdio CLI, a standalone Streamable HTTP server (`--transport http`), and the app's own `/api/mcp` route. `src/policy.ts` holds the read/write/full access-level table applied at tool-registration time — see `docs/architecture/remote-mcp-oauth.md` for the OAuth 2.1 story (`/api/mcp` is an OAuth-protected resource; `/.well-known/oauth-*` + `/oauth/mcp/authorize` + `/oauth/consent` are the discovery/consent chain). Both `/api/mcp` and `/.well-known/` must stay in `PUBLIC_PATHS` in `src/proxy.ts`
 - `packages/embedded-browser/` — containerized browser with CDP live streaming
 - `packages/ocr-service/` — Tesseract OCR container, the ONLY OCR backend (no in-process Tesseract in the app); app-side facade in `src/lib/ocr/` requires `OCR_SERVICE_URL` — unset means OCR features are disabled. The service wakes on demand and auto-sleeps after idle
 - `packages/vscode-extension/` — VS Code extension (esbuild)

--- a/docs/architecture/agentexchange-listing-plan.md
+++ b/docs/architecture/agentexchange-listing-plan.md
@@ -1,0 +1,134 @@
+# Salesforce AgentExchange listing plan (Lastest)
+
+Researched 2026-08-27. Sources at bottom.
+
+## Can we register today?
+
+No — not without a human doing the legal/corporate steps, and not with the MCP server as it exists.
+
+- Registration is `partnersignup.salesforce.com` → **AgentExchange ISV Program Track**. Corporate application approval takes 1–3 weeks and requires a signed Partner Distribution Agreement (a legal signature, not something I can do).
+- A Partner Business Org is provisioned after approval (1–3 business days, free for year 1).
+- ~~Our `@lastest/mcp-server` is stdio-only.~~ **Resolved** — `/api/mcp` now speaks Streamable HTTP with OAuth 2.1 and dynamic client registration, and the CLI has `--transport http`. See Phase 1 below and `remote-mcp-oauth.md`.
+
+## Listing surface options
+
+AgentExchange accepts: Actions (Apex / Flow / external API), Topics, Prompt Templates, **MCP Servers**, and Agent/Sub-Agent Templates.
+
+| Option | Build cost | Fit for Lastest |
+|---|---|---|
+| **A. Remote MCP server** | Low–medium | Best. We already have 50+ tools; needs an HTTP transport + OAuth. |
+| B. External Service / API action pack | Medium | Needs an OpenAPI spec + Named Credential setup guide; no Apex. |
+| C. 2GP managed package (Apex/Flow actions + topic) | High | Only if we want "Lastest QA" objects living inside Salesforce. Not our product. |
+
+Recommend **A, then B as a companion** so a listing can show both an MCP server and a couple of turnkey agent actions. Skip C.
+
+## Criteria we must satisfy
+
+- Active Salesforce Partner Network member, ISV track, approved business plan.
+- Solution must be **action-oriented and composable** — an agent triggers it; a passive UI does not qualify.
+- Pass AgentExchange Security Review (annual, not per-version):
+  - Static scan output (`sfdx-scanner` / Code Analyzer; Checkmarx report where external components exist).
+  - **DAST report** on our external endpoints — OWASP ZAP, Burp Suite, or Qualys. Chimera was retired 2025-06-16.
+  - Auth via Named Credentials / External Credentials — no secrets in config.
+  - Documented data flows, external endpoints, permission scoping, data handling.
+  - A test org with pre-loaded data and login steps, plus URLs+credentials for external components.
+- **Connected App / External Client App hardening** became mandatory 2026-05-11; non-compliance risks delisting.
+- Listing assets: title, tagline, description written for semantic/intent search, input/output schemas per tool, install guide, screenshots, <3-min demo video.
+
+## Costs
+
+- Partner Community signup + Partner Business Org: free.
+- Security review: **$999** one-time per paid listing, **~$150/yr** renewal.
+- Revenue share (ISVforce): **15%** of net subscription revenue, dropping to 10% past $20M cumulative. Free listings: no rev share.
+- Realistic timeline: ~5 months clean, ~7 months with one resubmission. ~50% of first submissions fail review.
+
+## Implementation plan
+
+### Phase 0 — Business gate (blocks everything, human-only)
+1. Sign up at partnersignup.salesforce.com under the AgentExchange ISV track; submit the business plan.
+2. Sign the Partner Distribution Agreement.
+3. Decide free vs paid listing (free avoids the $999 fee and the 15% rev share; paid gets Checkout billing). Recommend **listing free / bring-your-own Lastest account** for v1 — we bill outside Salesforce and dodge rev share on existing customers.
+4. Request the Partner Business Org.
+
+### Phase 1 — Remote MCP transport (`packages/mcp-server`) — **shipped**
+
+Built on `feat/mcp-oauth-remote`. Design notes: `remote-mcp-oauth.md`.
+
+1. ✅ Streamable HTTP alongside stdio. Two of them, in fact: `--transport http`
+   for a standalone process, and the app's own `/api/mcp` route (which already
+   existed, API-key only). Both share `createServer()`.
+2. ✅ Hosted as a route behind the front proxy. `/api/mcp` and `/.well-known/`
+   added to `PUBLIC_PATHS` — `/api/mcp` was missing, so bearer-only clients were
+   being 307'd to `/login` before ever seeing a 401.
+3. ✅ Accepts API keys *and* OAuth 2.1. better-auth's `mcp` plugin provides the
+   authorization server (RFC 8414 metadata, RFC 7591 dynamic client
+   registration, PKCE S256); `/.well-known/oauth-*` re-serve discovery at the
+   paths clients actually probe, and a 401 carries RFC 9728
+   `WWW-Authenticate`. Team scoping is unchanged — every tool still reaches
+   `/api/v1`, which runs `requireTeamAccess()` / `requireRepoAccess()` per
+   resource.
+4. ✅ Stateless: one MCP server + transport per request, no cross-tenant state.
+5. ❌ **Not done: per-connection rate limiting and audit logging.** The route
+   logs a debug line per authenticated request and nothing else. Needed before
+   submission — the MCP registry advertises per-server rate limits.
+
+### Phase 2 — Tool surface curation — **mostly shipped**
+
+1. ✅ Access levels (`read` / `write` / `full`) applied at registration:
+   16 / 27 / 29 tools. Destructive actions are not gated behind a confirm flag,
+   they are **absent** from an OAuth caller's schema — deletes, `share.revoke`,
+   `publish_share` and `quickstart` require the user's own API key. Table in
+   `packages/mcp-server/src/policy.ts`, drift-guarded by `policy.test.ts`.
+2. ❌ **Not done: rewriting tool descriptions for intent-based discovery.** The
+   existing descriptions are action-oriented and serviceable, but they were
+   written for a developer's coding agent, not for AgentExchange's semantic
+   search. This is listing-copy work and belongs with Phase 5.
+3. ✅ Read-only entry point: `lastest_insights { action: "qa" }` and
+   `lastest_status { action: "health" }` are both `read`-level and are what a
+   probing agent lands on first.
+4. ❌ **Not done: response redaction.** `redactSecrets()` covers inbound tool
+   *parameters* before they reach activity logs; tool *responses* are not
+   filtered. Worth an audit pass before customer data flows into a third-party
+   agent platform.
+
+### Phase 3 — Companion API actions (option B)
+1. Publish an OpenAPI 3.0 spec for the 5–8 highest-value endpoints (run tests, build status, failing tests, approve diff, share link).
+2. Ship a setup guide: External Credential (API key) → Named Credential → External Service registration → Agent Action.
+3. Package the guide + spec in the listing rather than as a managed package.
+
+### Phase 4 — Security review prep
+1. Run OWASP ZAP against the hosted MCP endpoint and the public API; fix and re-scan; keep the report.
+2. Run Code Analyzer if any Apex ships (none under options A/B — note that in the submission).
+3. Write the solution architecture doc: data flow Salesforce → Lastest → EB pods → screenshots, where customer data rests, retention, encryption (`ENCRYPTION_KEY`, per-repo credential store).
+4. Stand up a demo Lastest team + Salesforce test org with seeded builds/diffs and hand over login steps.
+5. Confirm Connected App / External Client App controls meet the 2026-05-11 baseline.
+
+### Phase 5 — Listing + launch
+1. Listing copy, logo, screenshots, <3-min demo video (reuse the existing `/r/` share flow for the demo).
+2. Submit for security review; budget 4–8 weeks first pass, 2–3 weeks per resubmission.
+3. Publish; plan the annual re-review.
+
+## Status
+
+Phases 1 and 2 are built and verified end to end against a local instance
+(discovery → dynamic client registration → forced consent → PKCE exchange →
+scope-limited tool list), with two gaps called out inline: no per-connection
+rate limiting, and no redaction of tool responses. Phase 0 is a legal/corporate
+gate no one has started, and Phases 3-5 are marketplace overhead waiting on the
+business decision below.
+
+## Go/no-go read
+
+Worth doing only if we expect Salesforce-resident buyers — the listing math works at >$25K ACV and enterprise procurement. Phases 1–2 are worth building regardless: a remote, OAuth'd MCP server is what every MCP registry (and our own customers) will want next, so that work is not Salesforce-specific sunk cost. Phases 0, 3–5 are pure marketplace overhead and should wait on a business decision.
+
+## Sources
+
+- https://developer.salesforce.com/docs/platform/isvforce/guide/security-review-how-it-works.html
+- https://developer.salesforce.com/docs/platform/isvforce/guide/security-review-required-materials.html
+- https://developer.salesforce.com/docs/platform/isvforce/guide/security-review-guidelines.html
+- https://www.salesforce.com/agentforce/agentexchange/
+- https://www.salesforce.com/agentforce/mcp-support/
+- https://agentexchange.salesforce.com/collections/agentforce-mcp
+- https://www.concret.io/blog/requirements-for-app-listing-on-salesforce-agentexchange
+- https://appnigma.ai/blogs/salesforce-appexchange-listing-guide-2026/
+- https://www.salesforce.com/partners/become-an-isv-partner/

--- a/docs/architecture/remote-mcp-oauth.md
+++ b/docs/architecture/remote-mcp-oauth.md
@@ -1,0 +1,142 @@
+# Remote MCP: Streamable HTTP + OAuth 2.1
+
+What this is: `/api/mcp` is a Streamable HTTP MCP endpoint that a third party
+can connect to knowing nothing but its URL. It exists so agent platforms —
+Salesforce Agentforce first, but the same machinery serves ChatGPT and Claude
+web — can use Lastest without a human generating and pasting an API key, and
+without those platforms getting the same privileges that key carries.
+
+It is Phases 1 and 2 of `agentexchange-listing-plan.md`.
+
+## The shape
+
+```
+agent platform                        Lastest
+     │
+     │ 1. POST /api/mcp  (no credential)
+     │──────────────────────────────────────▶  401
+     │◀──── WWW-Authenticate: Bearer resource_metadata="…"      (RFC 9728)
+     │
+     │ 2. GET /.well-known/oauth-protected-resource
+     │◀──── { resource: …/api/mcp, authorization_servers: [origin] }
+     │
+     │ 3. GET /.well-known/oauth-authorization-server            (RFC 8414)
+     │◀──── { authorization_endpoint: /oauth/mcp/authorize, … }
+     │
+     │ 4. POST /api/auth/mcp/register                            (RFC 7591)
+     │◀──── { client_id }
+     │
+     │ 5. browser → /oauth/mcp/authorize → /login → /oauth/consent
+     │◀──── code (PKCE S256)
+     │
+     │ 6. POST /api/auth/mcp/token
+     │◀──── { access_token, refresh_token, scope }
+     │
+     │ 7. POST /api/mcp  Authorization: Bearer <access_token>
+     │◀──── the tool subset that scope allows
+```
+
+Steps 4-6 are better-auth's `mcp` plugin (`src/lib/auth/auth.ts`), backed by
+three tables in `packages/db/src/schema/identity.ts`
+(`oauth_applications`, `oauth_access_tokens`, `oauth_consents`).
+
+## The four decisions worth knowing
+
+### 1. An OAuth token is not an API key
+
+They resolve to different **access levels**, and the difference is the point.
+
+| Credential | Level | Sees |
+| --- | --- | --- |
+| API key (`sessions.kind='api'`) | `full` | Everything |
+| OAuth + `lastest:write` | `write` | Read, run tests, author tests, approve/reject diffs |
+| OAuth, anything else | `read` | Read only |
+
+No scope grants `full`. Deletes, share revocation and publishing a public
+`/r/<slug>` link are unreachable over OAuth at any scope — not gated, *absent*.
+
+The table lives in `packages/mcp-server/src/policy.ts`, next to the tools it
+describes, and is applied at registration time by `defineTool()`: a restricted
+caller's `lastest_test` advertises `action: "list" | "get"` and nothing else.
+Filtering the schema rather than rejecting the call matters because an agent
+picks tools by reading schemas — one that can see `delete` keeps trying it.
+`policy.test.ts` fails when the table stops describing the real tool surface.
+
+Observed end-to-end: 16 tools at `read`, 27 at `write`, 29 at `full`.
+
+### 2. OAuth tokens are not accepted by `/api/v1`
+
+The MCP tools do their work by calling this app's own REST API, which keeps one
+implementation of every ownership and capability guard. An API-key caller's key
+is simply reused for those loopback calls.
+
+An OAuth caller has no key, and teaching `/api/v1` to accept access tokens would
+undo everything above: a `lastest:read` token that authenticates directly
+against the REST API can delete a test, because the tool policy lives one layer
+up. So `verifyBearerToken()` does not know about OAuth tokens at all.
+
+Instead `/api/mcp` mints a **loopback grant** (`src/lib/mcp/loopback-grant.ts`):
+an HMAC-signed, 60-second credential naming a user, created on the server, spent
+on the server, never present in any response. Same construction and the same
+fail-closed rule as the EB stream grant — no `ENCRYPTION_KEY`, no grants, 503.
+
+### 3. Consent is not optional
+
+better-auth only shows its consent screen when the client sends
+`prompt=consent`, and many MCP clients don't. Combined with anonymous dynamic
+client registration, that would let an app that registered itself seconds ago
+get a token the moment a signed-in user follows a link, silently.
+
+So the advertised `authorization_endpoint` is **ours** —
+`src/app/oauth/mcp/authorize/route.ts` — which pins `prompt=consent` on and
+forwards everything else untouched. The consent screen
+(`src/app/oauth/consent/`) names the client, shows its `client_id` (a
+dynamically registered client can call itself anything), lists what the grant
+allows in terms of consequences, and lists what it will never allow.
+
+### 4. Discovery uses the public origin, the loopback uses the internal one
+
+Every deployment runs behind `scripts/front-proxy.js`, so `req.url` inside a
+route is `http://127.0.0.1:3001`. Advertising that as the issuer points every
+client at an unreachable host. The discovery documents and the
+`WWW-Authenticate` header therefore use `getPublicUrl(req)`; the loopback
+`LastestClient` deliberately keeps `req.url`'s origin, so tool calls don't take
+a pointless round trip back out through the proxy.
+
+## Files
+
+| Path | Role |
+| --- | --- |
+| `src/app/api/mcp/route.ts` | The endpoint |
+| `src/lib/mcp/remote-auth.ts` | Credential → access level |
+| `src/lib/mcp/tool-policy.ts` | Scope → access level; the advertised scope list |
+| `src/lib/mcp/loopback-grant.ts` | Server-only credential for `/api/v1` calls |
+| `src/lib/mcp/discovery.ts` | RFC 8414 / RFC 9728 documents |
+| `src/app/.well-known/oauth-*/` | Where those documents are served |
+| `src/app/oauth/mcp/authorize/route.ts` | Consent-forcing front door |
+| `src/app/oauth/consent/` | Consent screen |
+| `packages/mcp-server/src/policy.ts` | The access-level table |
+| `packages/mcp-server/src/http-server.ts` | Standalone `--transport http` server |
+
+## Gotchas
+
+- **better-auth's `getMcpSession()` does not check token expiry.** It looks the
+  row up and returns it. `remote-auth.ts` checks `accessTokenExpiresAt` itself;
+  without that a token works forever. Covered by `remote-auth.test.ts`.
+- **`/api/mcp` and `/.well-known/` must be in `PUBLIC_PATHS`** in `src/proxy.ts`.
+  They are bearer-only or anonymous and carry no cookie, so otherwise the proxy
+  answers with a 307 to `/login` and the whole discovery chain dies on step 1.
+- **`@lastest/mcp-server` resolves to `dist/`** from the app. Changing the
+  package's types means running `pnpm --filter @lastest/mcp-server build` before
+  the app typechecks.
+- **Rotating `ENCRYPTION_KEY` invalidates in-flight loopback grants.** They live
+  60 seconds, so this is a non-event, but it is the same key as everything else.
+
+## Not built
+
+- No UI for reviewing or revoking OAuth connections.
+  `getOAuthConnectionsForUser()` exists in `src/lib/db/queries/auth.ts` for it;
+  Settings → Runners & API Access is the obvious home.
+- No token-endpoint rate limiting beyond whatever fronts the app.
+- Registration is anonymous, per RFC 7591 and per what agent platforms expect.
+  Nothing prunes `oauth_applications` rows that never completed a flow.

--- a/packages/db/src/schema/identity.ts
+++ b/packages/db/src/schema/identity.ts
@@ -422,3 +422,113 @@ export const stripeWebhookEvents = pgTable(
 export type StripeWebhookEvent = typeof stripeWebhookEvents.$inferSelect;
 
 export type NewStripeWebhookEvent = typeof stripeWebhookEvents.$inferInsert;
+
+// ===========================================================================
+// OAuth 2.1 authorization server (better-auth `mcp` plugin)
+// ===========================================================================
+//
+// These three tables back better-auth's `mcp` plugin, which turns this app into
+// an OAuth 2.1 authorization server for the remote MCP endpoint at `/api/mcp`.
+// They exist so a third-party agent platform (Salesforce Agentforce, ChatGPT,
+// Claude web, …) can connect *without* a human pasting a long-lived API key:
+// the client registers itself dynamically (RFC 7591), sends the user through
+// `/oauth/consent`, and receives a short-lived access token bound to that user.
+//
+// Shape is dictated by the plugin (`better-auth/plugins/oidc-provider/schema`) —
+// the JS property names below must match its field names exactly, because the
+// Drizzle adapter maps `field -> table[field]`. The table names are ours.
+// `src/lib/auth/auth.ts` wires them in under the adapter's model names
+// (`oauthApplication` / `oauthAccessToken` / `oauthConsent`).
+//
+// API keys (`sessions.kind = 'api'`) remain the other accepted credential on
+// `/api/mcp` — see `src/lib/mcp/remote-auth.ts` for how the two resolve to a
+// single identity plus a tool-policy level.
+
+/** A registered OAuth client. Rows are created by dynamic client registration. */
+export const oauthApplications = pgTable("oauth_applications", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  icon: text("icon"),
+  /** JSON blob of the client's registration metadata. */
+  metadata: text("metadata"),
+  clientId: text("client_id").notNull().unique(),
+  /** Null for public clients (PKCE-only), which is what MCP clients are. */
+  clientSecret: text("client_secret"),
+  /** Comma-separated list, per the plugin's own encoding. */
+  redirectUrls: text("redirect_urls").notNull(),
+  /** 'web' | 'native' | 'user-agent-based' | 'public' */
+  type: text("type").notNull(),
+  disabled: boolean("disabled").default(false),
+  /**
+   * The user who registered the client. Null for anonymous dynamic
+   * registration, which is the normal case for MCP clients.
+   */
+  userId: text("user_id").references(() => users.id, { onDelete: "cascade" }),
+  createdAt: timestamp("created_at"),
+  updatedAt: timestamp("updated_at"),
+});
+
+export type OAuthApplication = typeof oauthApplications.$inferSelect;
+
+export type NewOAuthApplication = typeof oauthApplications.$inferInsert;
+
+/**
+ * An issued access/refresh token pair.
+ *
+ * `scopes` is what `src/lib/mcp/tool-policy.ts` reads to decide how much of the
+ * MCP tool surface the bearer may see — a token without `lastest:write` gets a
+ * read-only server.
+ */
+export const oauthAccessTokens = pgTable(
+  "oauth_access_tokens",
+  {
+    id: text("id").primaryKey(),
+    accessToken: text("access_token").notNull().unique(),
+    // Nullable: only minted when the client asked for `offline_access`.
+    // Postgres permits repeated NULLs under a unique index, so the plugin's
+    // uniqueness requirement and "no refresh token" coexist fine.
+    refreshToken: text("refresh_token").unique(),
+    accessTokenExpiresAt: timestamp("access_token_expires_at"),
+    refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+    clientId: text("client_id").references(() => oauthApplications.clientId, {
+      onDelete: "cascade",
+    }),
+    userId: text("user_id").references(() => users.id, { onDelete: "cascade" }),
+    /** Space-separated scope list. */
+    scopes: text("scopes"),
+    createdAt: timestamp("created_at"),
+    updatedAt: timestamp("updated_at"),
+  },
+  (table) => [
+    index("oauth_access_tokens_client_idx").on(table.clientId),
+    index("oauth_access_tokens_user_idx").on(table.userId),
+  ],
+);
+
+export type OAuthAccessToken = typeof oauthAccessTokens.$inferSelect;
+
+export type NewOAuthAccessToken = typeof oauthAccessTokens.$inferInsert;
+
+/** Remembers that a user already approved a client for a set of scopes. */
+export const oauthConsents = pgTable(
+  "oauth_consents",
+  {
+    id: text("id").primaryKey(),
+    clientId: text("client_id").references(() => oauthApplications.clientId, {
+      onDelete: "cascade",
+    }),
+    userId: text("user_id").references(() => users.id, { onDelete: "cascade" }),
+    scopes: text("scopes"),
+    consentGiven: boolean("consent_given"),
+    createdAt: timestamp("created_at"),
+    updatedAt: timestamp("updated_at"),
+  },
+  (table) => [
+    index("oauth_consents_client_idx").on(table.clientId),
+    index("oauth_consents_user_idx").on(table.userId),
+  ],
+);
+
+export type OAuthConsent = typeof oauthConsents.$inferSelect;
+
+export type NewOAuthConsent = typeof oauthConsents.$inferInsert;

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -156,9 +156,56 @@ while you migrate.
 lastest-mcp --url <url> --api-key <key>
 ```
 
-Both flags are required. The process communicates with the host client over stdio.
+The process communicates with the host client over stdio.
+
+| Flag | Default | Meaning |
+| ---- | ------- | ------- |
+| `--url` | _(required)_ | Lastest instance the tools call. |
+| `--api-key` | — | API key. Required for stdio; in `http` mode it is the fallback for requests that arrive without an `Authorization` header. |
+| `--transport` | `stdio` | `stdio` for a local agent, `http` for a remote Streamable HTTP endpoint. |
+| `--port` / `--host` | `9700` / `127.0.0.1` | Where to listen in `http` mode. |
+| `--access-level` | `full` | `read`, `write` or `full` — how much of the tool surface to expose. |
 
 **Requirements:** Node.js 18+ and a reachable [Lastest](https://lastest.cloud) instance.
+
+## Remote (Streamable HTTP)
+
+Most people want the endpoint your Lastest instance already serves:
+
+```
+https://your-lastest-instance/api/mcp
+```
+
+It speaks Streamable HTTP and accepts either an API key or an OAuth 2.1
+connection, so an agent platform that only knows a URL (Salesforce Agentforce,
+ChatGPT, Claude web) can connect on its own — it discovers the authorization
+server from the `WWW-Authenticate` header, registers itself, and sends you
+through a consent screen. OAuth connections get a **read** or **write** subset
+of the tools; deleting things, revoking shares and publishing public links stay
+behind your own API key.
+
+Run this package as its own HTTP server when you want the MCP endpoint on a
+separate host or port:
+
+```bash
+lastest-mcp --url https://your-lastest-instance --transport http --port 9700
+# → POST http://127.0.0.1:9700/mcp with Authorization: Bearer <api-key>
+```
+
+This mode is API-key only; there is no OAuth in the standalone process.
+
+## Access levels
+
+`--access-level` (and, on `/api/mcp`, the OAuth scope) picks the tool surface:
+
+| Level | Sees |
+| ----- | ---- |
+| `read` | Projects, tests, builds, diffs, coverage, verification, job status. |
+| `write` | Everything in `read`, plus running tests, creating/updating tests and areas, and approving or rejecting visual changes. |
+| `full` | Everything, including deletes, revoking shares and publishing public `/r/` links. API key only. |
+
+Tools are filtered at registration, so a restricted connection never sees an
+action it cannot call.
 
 ## Authentication
 

--- a/packages/mcp-server/src/http-server.ts
+++ b/packages/mcp-server/src/http-server.ts
@@ -1,0 +1,165 @@
+/**
+ * Standalone remote MCP server (Streamable HTTP).
+ *
+ * `lastest-mcp --transport http` runs the same tool surface as the stdio CLI,
+ * but over HTTP, so an agent platform that can only reach a URL — Salesforce
+ * Agentforce, ChatGPT, a hosted Claude — can talk to a self-hosted Lastest
+ * without anyone installing this package next to it.
+ *
+ * Relationship to `/api/mcp`
+ * --------------------------
+ * The Lastest app serves the same protocol at `/api/mcp`, and that is the
+ * endpoint to prefer: it is the one that carries OAuth 2.1, so a client can
+ * connect without a human pasting a key. This process exists for the case where
+ * you want the MCP endpoint on its own host/port — a separate container, a
+ * different network zone, an instance you do not want to expose the whole app
+ * from. It authenticates with an API key only.
+ *
+ * Auth
+ * ----
+ * Every request must carry `Authorization: Bearer <api-key>`. The key is passed
+ * straight through to the Lastest REST API, which is the thing that actually
+ * authenticates it — this process stores no credentials and makes no trust
+ * decisions of its own. `--api-key` supplies a fallback for single-tenant
+ * deployments; when a request brings its own key, the request's key wins, so
+ * one process can serve several users.
+ *
+ * State
+ * -----
+ * Stateless: a fresh server + transport per request, no session ids. That keeps
+ * it safe to run behind a load balancer with no sticky sessions, at the cost of
+ * not supporting server-initiated notifications between calls (no MCP client we
+ * target relies on those here).
+ */
+import { createServer as createHttpServer, type Server } from "node:http";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { LastestClient } from "./client.js";
+import { createServer } from "./server.js";
+import type { ToolAccessLevel } from "./policy.js";
+
+export interface HttpServerOptions {
+  /** Lastest instance the tools call. */
+  url: string;
+  /** Fallback API key, used when a request brings no `Authorization` header. */
+  apiKey?: string;
+  port: number;
+  host: string;
+  /** Tool surface handed to callers. See ./policy.ts. */
+  accessLevel?: ToolAccessLevel;
+  /** Path the MCP endpoint is served at. */
+  path?: string;
+}
+
+const MAX_BODY_BYTES = 4 * 1024 * 1024;
+
+function jsonRpcError(code: number, message: string, detail?: string): string {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    error: { code, message, ...(detail ? { data: { detail } } : {}) },
+    id: null,
+  });
+}
+
+async function readBody(
+  req: import("node:http").IncomingMessage,
+): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of req) {
+    size += (chunk as Buffer).length;
+    // Bounded so an unauthenticated caller cannot make us buffer arbitrarily.
+    if (size > MAX_BODY_BYTES) throw new Error("Request body too large");
+    chunks.push(chunk as Buffer);
+  }
+  if (!chunks.length) return undefined;
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+export function startHttpServer(options: HttpServerOptions): Server {
+  const path = options.path ?? "/mcp";
+
+  const server = createHttpServer(async (req, res) => {
+    if (
+      req.url &&
+      new URL(req.url, "http://localhost").pathname === "/health"
+    ) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+
+    if (!req.url || new URL(req.url, "http://localhost").pathname !== path) {
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(jsonRpcError(-32601, "Not found"));
+      return;
+    }
+
+    const header = req.headers.authorization;
+    const bearer = header?.toLowerCase().startsWith("bearer ")
+      ? header.slice(7).trim()
+      : undefined;
+    const apiKey = bearer || options.apiKey;
+    if (!apiKey) {
+      res.writeHead(401, {
+        "content-type": "application/json",
+        "www-authenticate": 'Bearer realm="lastest"',
+      });
+      res.end(
+        jsonRpcError(
+          -32001,
+          "Unauthorized",
+          "Send Authorization: Bearer <api-key>. Create a key in Settings → Runners & API Access.",
+        ),
+      );
+      return;
+    }
+
+    let body: unknown;
+    try {
+      body = await readBody(req);
+    } catch (err) {
+      res.writeHead(400, { "content-type": "application/json" });
+      res.end(
+        jsonRpcError(
+          -32700,
+          "Bad request",
+          err instanceof Error ? err.message : String(err),
+        ),
+      );
+      return;
+    }
+
+    const mcp = createServer(
+      new LastestClient({ baseUrl: options.url, apiKey }),
+      { accessLevel: options.accessLevel },
+    );
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+    // The transport owns the response from here; closing the MCP server when
+    // the response ends is what releases the per-request pair.
+    res.on("close", () => {
+      void transport.close();
+      void mcp.close();
+    });
+
+    try {
+      await mcp.connect(transport);
+      await transport.handleRequest(req, res, body);
+    } catch (err) {
+      if (!res.headersSent) {
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(
+          jsonRpcError(
+            -32603,
+            "Internal error",
+            err instanceof Error ? err.message : String(err),
+          ),
+        );
+      }
+    }
+  });
+
+  server.listen(options.port, options.host);
+  return server;
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -2,12 +2,35 @@ import { Command } from "commander";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { LastestClient } from "./client.js";
 import { createServer } from "./server.js";
+import { startHttpServer } from "./http-server.js";
+import type { ToolAccessLevel } from "./policy.js";
 
 // Re-exports so the Next.js HTTP route (and any other consumer) can build
 // an MCP server with the same tool surface as the stdio CLI.
 export { LastestClient } from "./client.js";
 export type { LastestClientConfig, ToolResponse } from "./client.js";
 export { createServer } from "./server.js";
+export type { CreateServerOptions } from "./server.js";
+export { startHttpServer } from "./http-server.js";
+export type { HttpServerOptions } from "./http-server.js";
+export {
+  TOOL_RULES,
+  decideTool,
+  levelAllows,
+  deniedActionMessage,
+} from "./policy.js";
+export type { ToolAccessLevel, ToolRule, ToolDecision } from "./policy.js";
+
+const ACCESS_LEVELS: ToolAccessLevel[] = ["read", "write", "full"];
+
+interface CliOptions {
+  url: string;
+  apiKey?: string;
+  transport: string;
+  port: string;
+  host: string;
+  accessLevel: string;
+}
 
 export async function main() {
   const program = new Command();
@@ -21,19 +44,54 @@ export async function main() {
       "--url <url>",
       "Lastest instance URL (e.g., http://localhost:3000)",
     )
-    .requiredOption("--api-key <key>", "API key for authentication")
-    .action(async (opts: { url: string; apiKey: string }) => {
-      const client = new LastestClient({
-        baseUrl: opts.url,
-        apiKey: opts.apiKey,
-      });
+    .option(
+      "--api-key <key>",
+      "API key for authentication. Required for stdio; in http mode it is the fallback for requests that carry no Authorization header.",
+    )
+    .option(
+      "--transport <transport>",
+      "'stdio' (default, for a local agent) or 'http' for a remote Streamable HTTP endpoint",
+      "stdio",
+    )
+    .option("--port <port>", "Port to listen on in http mode", "9700")
+    .option("--host <host>", "Host to bind in http mode", "127.0.0.1")
+    .option(
+      "--access-level <level>",
+      "Tool surface to expose: read | write | full",
+      "full",
+    )
+    .action(async (opts: CliOptions) => {
+      const accessLevel = opts.accessLevel as ToolAccessLevel;
+      if (!ACCESS_LEVELS.includes(accessLevel)) {
+        process.stderr.write(
+          `Invalid --access-level '${opts.accessLevel}'. Expected one of: ${ACCESS_LEVELS.join(", ")}\n`,
+        );
+        process.exit(1);
+      }
+
+      if (opts.transport !== "stdio" && opts.transport !== "http") {
+        process.stderr.write(
+          `Invalid --transport '${opts.transport}'. Expected 'stdio' or 'http'.\n`,
+        );
+        process.exit(1);
+      }
+
+      if (opts.transport === "stdio" && !opts.apiKey) {
+        process.stderr.write("--api-key is required for stdio transport\n");
+        process.exit(1);
+      }
 
       // Verify connectivity (skipped when LASTEST_SKIP_HEALTH_CHECK=1 — used by
       // tooling that introspects the MCP surface without a live backend, e.g.
-      // Glama's container check).
-      if (process.env.LASTEST_SKIP_HEALTH_CHECK !== "1") {
+      // Glama's container check). Only possible when we hold a key up front;
+      // in http mode the key usually arrives per request.
+      if (process.env.LASTEST_SKIP_HEALTH_CHECK !== "1" && opts.apiKey) {
+        const probe = new LastestClient({
+          baseUrl: opts.url,
+          apiKey: opts.apiKey,
+        });
         try {
-          await client.health();
+          await probe.health();
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           process.stderr.write(
@@ -43,7 +101,26 @@ export async function main() {
         }
       }
 
-      const server = createServer(client);
+      if (opts.transport === "http") {
+        const port = Number(opts.port);
+        startHttpServer({
+          url: opts.url,
+          apiKey: opts.apiKey,
+          port,
+          host: opts.host,
+          accessLevel,
+        });
+        process.stderr.write(
+          `Lastest MCP server listening on http://${opts.host}:${port}/mcp (upstream ${opts.url}, access: ${accessLevel})\n`,
+        );
+        return;
+      }
+
+      const client = new LastestClient({
+        baseUrl: opts.url,
+        apiKey: opts.apiKey,
+      });
+      const server = createServer(client, { accessLevel });
       const transport = new StdioServerTransport();
       await server.connect(transport);
 

--- a/packages/mcp-server/src/policy.test.ts
+++ b/packages/mcp-server/src/policy.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "./server.js";
+import { LastestClient } from "./client.js";
+import { TOOL_RULES, decideTool, levelAllows } from "./policy.js";
+import type { ToolAccessLevel } from "./policy.js";
+
+/**
+ * Drift guard for `policy.ts`.
+ *
+ * The rules table is hand-maintained on purpose (see the header comment in
+ * policy.ts), so the thing that has to be automated is noticing when it stops
+ * describing the real tool surface: a tool renamed, an action added to an enum,
+ * a rule left behind for a tool that no longer exists. Every assertion below is
+ * about that gap — none of them re-encode the product judgement itself.
+ */
+
+/** The tool list an access level actually gets, read off a live server. */
+async function toolsAt(level: ToolAccessLevel) {
+  const server = createServer(
+    new LastestClient({ baseUrl: "http://localhost:0", apiKey: "test" }),
+    { accessLevel: level },
+  );
+  const client = new Client({ name: "policy-test", version: "1.0.0" });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  try {
+    const { tools } = await client.listTools();
+    return tools;
+  } finally {
+    await Promise.allSettled([client.close(), server.close()]);
+  }
+}
+
+/** The `action` enum a tool advertises, if it has one. */
+function advertisedActions(
+  tool: { inputSchema?: unknown },
+  param: string,
+): string[] | undefined {
+  const schema = tool.inputSchema as
+    | { properties?: Record<string, { enum?: string[] }> }
+    | undefined;
+  return schema?.properties?.[param]?.enum;
+}
+
+describe("tool policy", () => {
+  it("full sees every tool, and every tool has a rule", async () => {
+    const tools = await toolsAt("full");
+    const live = tools.map((t) => t.name).sort();
+    const ruled = Object.keys(TOOL_RULES).sort();
+    expect(live).toEqual(ruled);
+  });
+
+  it("each rule's actions match the tool's real action enum", async () => {
+    const tools = await toolsAt("full");
+    for (const tool of tools) {
+      const rule = TOOL_RULES[tool.name];
+      const param = rule.actionParam ?? "action";
+      const advertised = advertisedActions(tool, param);
+      if (!rule.actions) {
+        // A tool with no rule actions must not have an action enum either,
+        // otherwise a new action would silently inherit the tool-level floor.
+        expect(
+          advertised,
+          `${tool.name} gained an ${param} enum`,
+        ).toBeUndefined();
+        continue;
+      }
+      expect(advertised, `${tool.name} lost its ${param} enum`).toBeDefined();
+      expect(advertised!.slice().sort()).toEqual(
+        Object.keys(rule.actions).sort(),
+      );
+    }
+  });
+
+  it("levels are cumulative — read ⊆ write ⊆ full", async () => {
+    const [read, write, full] = await Promise.all([
+      toolsAt("read"),
+      toolsAt("write"),
+      toolsAt("full"),
+    ]);
+    const names = (t: { name: string }[]) => new Set(t.map((x) => x.name));
+    const [r, w, f] = [names(read), names(write), names(full)];
+    for (const n of r) expect(w.has(n), `${n} lost at write`).toBe(true);
+    for (const n of w) expect(f.has(n), `${n} lost at full`).toBe(true);
+    expect(r.size).toBeLessThan(w.size);
+    expect(w.size).toBeLessThan(f.size);
+  });
+
+  it("never advertises an action the caller may not use", async () => {
+    for (const level of ["read", "write"] as const) {
+      for (const tool of await toolsAt(level)) {
+        const rule = TOOL_RULES[tool.name];
+        if (!rule.actions) continue;
+        const advertised =
+          advertisedActions(tool, rule.actionParam ?? "action") ?? [];
+        for (const action of advertised) {
+          expect(
+            levelAllows(level, rule.actions[action]),
+            `${level} was offered ${tool.name}.${action}`,
+          ).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("no OAuth level reaches a delete, a revoke, or a public share", async () => {
+    for (const level of ["read", "write"] as const) {
+      const tools = await toolsAt(level);
+      const byName = new Map(tools.map((t) => [t.name, t]));
+      expect(byName.has("lastest_publish_share")).toBe(false);
+      expect(byName.has("lastest_quickstart")).toBe(false);
+      for (const [name, rule] of Object.entries(TOOL_RULES)) {
+        const destructive = Object.keys(rule.actions ?? {}).filter(
+          (a) => a === "delete" || a === "revoke",
+        );
+        if (!destructive.length) continue;
+        const tool = byName.get(name);
+        if (!tool) continue;
+        const advertised =
+          advertisedActions(tool, rule.actionParam ?? "action") ?? [];
+        for (const a of destructive) expect(advertised).not.toContain(a);
+      }
+    }
+  });
+
+  it("fails closed for a tool with no rule", () => {
+    expect(decideTool("lastest_not_a_tool", "read").registered).toBe(false);
+    expect(decideTool("lastest_not_a_tool", "write").registered).toBe(false);
+    expect(decideTool("lastest_not_a_tool", "full").registered).toBe(true);
+  });
+});

--- a/packages/mcp-server/src/policy.test.ts
+++ b/packages/mcp-server/src/policy.test.ts
@@ -16,8 +16,11 @@ import type { ToolAccessLevel } from "./policy.js";
  * about that gap — none of them re-encode the product judgement itself.
  */
 
-/** The tool list an access level actually gets, read off a live server. */
-async function toolsAt(level: ToolAccessLevel) {
+/** Run `fn` against a live client wired to a server at `level`. */
+async function withClientAt<T>(
+  level: ToolAccessLevel,
+  fn: (client: Client) => Promise<T>,
+): Promise<T> {
   const server = createServer(
     new LastestClient({ baseUrl: "http://localhost:0", apiKey: "test" }),
     { accessLevel: level },
@@ -30,11 +33,18 @@ async function toolsAt(level: ToolAccessLevel) {
     client.connect(clientTransport),
   ]);
   try {
-    const { tools } = await client.listTools();
-    return tools;
+    return await fn(client);
   } finally {
     await Promise.allSettled([client.close(), server.close()]);
   }
+}
+
+/** The tool list an access level actually gets, read off a live server. */
+async function toolsAt(level: ToolAccessLevel) {
+  return withClientAt(
+    level,
+    async (client) => (await client.listTools()).tools,
+  );
 }
 
 /** The `action` enum a tool advertises, if it has one. */
@@ -127,6 +137,43 @@ describe("tool policy", () => {
         for (const a of destructive) expect(advertised).not.toContain(a);
       }
     }
+  });
+
+  it("a read caller cannot CALL a write tool, not merely fail to see it", async () => {
+    // The mapping tests above assert what each level is *shown*. This asserts
+    // the property the security review actually cares about: that a read-level
+    // connection cannot reach a write tool end-to-end. A tool that is not
+    // registered has no handler, so the call is rejected by the server itself.
+    await withClientAt("read", async (client) => {
+      const approve = await client.callTool({
+        name: "lastest_decide_diff",
+        arguments: { action: "approve", diffId: "d1" },
+      });
+      expect(approve.isError).toBe(true);
+      expect(JSON.stringify(approve.content)).toContain("not found");
+
+      // A `full`-only tool is equally out of reach.
+      const publish = await client.callTool({
+        name: "lastest_publish_share",
+        arguments: { buildId: "b1" },
+      });
+      expect(publish.isError).toBe(true);
+    });
+  });
+
+  it("a read caller cannot invoke a write ACTION on a tool it can see", async () => {
+    // `lastest_repo` is visible at read, but `create`/`update` are write. The
+    // narrowed enum keeps them off the advertised schema; this exercises the
+    // handler backstop for a caller that sends one anyway.
+    await withClientAt("read", async (client) => {
+      const res = await client.callTool({
+        name: "lastest_repo",
+        arguments: { action: "update", repositoryId: "r1", name: "x" },
+      });
+      // Either the schema rejects it or the backstop throws — both surface as
+      // an error result rather than as a repo that got updated.
+      expect(res.isError).toBe(true);
+    });
   });
 
   it("fails closed for a tool with no rule", () => {

--- a/packages/mcp-server/src/policy.ts
+++ b/packages/mcp-server/src/policy.ts
@@ -1,0 +1,241 @@
+/**
+ * Tool-surface policy: how much of the MCP surface a given caller may see.
+ *
+ * Why this exists
+ * ---------------
+ * The 29 tools here were designed for a caller who *is* the user: the stdio CLI
+ * running on their laptop under their own API key. `/api/mcp` now also accepts
+ * OAuth 2.1 tokens issued to third-party agent platforms (Salesforce
+ * Agentforce, ChatGPT, Claude web, …) that registered themselves dynamically.
+ * That caller is not the user; it is software the user pointed at their data
+ * once, and it should not be handed `action:"delete"`.
+ *
+ * So a caller resolves to one of three levels:
+ *
+ *   read   — observe only. No build is started, nothing is written.
+ *   write  — read, plus everything that creates or updates Lastest's own
+ *            objects and runs tests. Approving a diff lives here: it rewrites a
+ *            baseline, which is a normal reviewer action and is reversible.
+ *   full   — everything, including deletes and anything that makes data
+ *            public. Only an API key (the user's own credential) gets this.
+ *
+ * The levels are cumulative (`read` ⊂ `write` ⊂ `full`), and the mapping from an
+ * OAuth scope to a level lives app-side in `src/lib/mcp/tool-policy.ts`.
+ *
+ * How it is enforced
+ * ------------------
+ * Not by rejecting calls after the fact. `createServer()` routes every
+ * registration through `defineTool`, which:
+ *
+ *   1. skips the tool entirely when the caller's level is below its floor, and
+ *   2. rewrites the tool's `action` enum down to the permitted values.
+ *
+ * So an under-privileged caller never *sees* `delete` in the schema. That
+ * matters more than a runtime check: an agent picks tools by reading schemas,
+ * and one that can see a forbidden action will keep trying it. The runtime
+ * check in `filterActions()` stays as a backstop for a caller that guesses.
+ *
+ * This is deliberately a coarse, hand-maintained table rather than something
+ * derived from the tool definitions. Whether an action is "destructive" is a
+ * product judgement, not a property of its zod schema — and a table you have to
+ * edit is a table someone reviews. `policy.test.ts` fails when a tool or an
+ * action listed here stops existing, which is what keeps it honest.
+ */
+
+export type ToolAccessLevel = "read" | "write" | "full";
+
+const LEVEL_RANK: Record<ToolAccessLevel, number> = {
+  read: 0,
+  write: 1,
+  full: 2,
+};
+
+export function levelAllows(
+  caller: ToolAccessLevel,
+  required: ToolAccessLevel,
+): boolean {
+  return LEVEL_RANK[caller] >= LEVEL_RANK[required];
+}
+
+export interface ToolRule {
+  /** Minimum level needed to see this tool at all. */
+  level: ToolAccessLevel;
+  /**
+   * Per-action minimum levels, keyed by the value of the tool's discriminating
+   * parameter. Every value the tool accepts must appear here; an action missing
+   * from the map is treated as `full` (fail closed) and `policy.test.ts` flags
+   * it.
+   */
+  actions?: Record<string, ToolAccessLevel>;
+  /** The discriminating parameter's name. Almost always `action`. */
+  actionParam?: string;
+}
+
+/**
+ * The table. `level` is the floor for the tool; `actions` refines it per value.
+ *
+ * Judgement calls worth knowing about:
+ *  - **Deletes are `full` everywhere.** No OAuth scope reaches them.
+ *  - **`lastest_publish_share` is `full`.** It mints a `/r/<slug>` URL that
+ *    anyone can open. An agent platform making a customer's screenshots
+ *    world-readable is a different category of mistake from it approving a
+ *    baseline, so it needs the user's own credential.
+ *  - **`lastest_quickstart` is `full`** for the same reason — it ends in a
+ *    published demo.
+ *  - **`lastest_decide_diff` is `write`.** Approving is the single most useful
+ *    thing an agent does here and it is reversible from the UI.
+ *  - **The browser-driving tools (`scout_url`, `ranger`, `explorer`) are
+ *    `write`.** They cost a browser and reach out to a URL the caller chose;
+ *    that is not a read.
+ */
+export const TOOL_RULES: Record<string, ToolRule> = {
+  lastest_status: {
+    level: "read",
+    actions: { health: "read", jobs: "read", job: "read" },
+  },
+  lastest_repo: {
+    level: "read",
+    actions: {
+      list: "read",
+      get: "read",
+      get_settings: "read",
+      create: "write",
+      update: "write",
+      update_settings: "write",
+    },
+  },
+  lastest_area: {
+    level: "read",
+    actions: {
+      list: "read",
+      list_tests: "read",
+      create: "write",
+      update: "write",
+      delete: "full",
+    },
+  },
+  lastest_test: {
+    level: "read",
+    actions: { list: "read", get: "read", update: "write", delete: "full" },
+  },
+  lastest_storage_state: {
+    level: "write",
+    actions: { list: "read", create: "write", delete: "full" },
+  },
+  lastest_setup_script: {
+    level: "read",
+    actions: {
+      list: "read",
+      get: "read",
+      create: "write",
+      update: "write",
+      delete: "full",
+    },
+  },
+  lastest_get_diffs: { level: "read" },
+  lastest_decide_diff: {
+    level: "write",
+    actions: { approve: "write", reject: "write" },
+  },
+  lastest_build: {
+    level: "read",
+    // "review" reads a build and summarizes it; it mutates nothing.
+    actions: { list: "read", get: "read", review: "read" },
+  },
+  lastest_share: {
+    level: "read",
+    actions: { list: "read", revoke: "full" },
+  },
+  lastest_verify: {
+    level: "read",
+    actions: { view: "read", change_map: "read" },
+  },
+  lastest_insights: {
+    level: "read",
+    actions: { coverage: "read", data_coverage: "read", qa: "read" },
+  },
+  lastest_qa_agent: {
+    level: "read",
+    actions: {
+      status: "read",
+      run_status: "read",
+      list_tasks: "read",
+      start_run: "write",
+      add_task: "write",
+    },
+  },
+  lastest_run_tests: { level: "write" },
+  lastest_validate_diff: { level: "write" },
+  lastest_scout_url: { level: "write" },
+  lastest_ranger: { level: "write" },
+  lastest_ranger_status: { level: "read" },
+  lastest_explorer: { level: "write" },
+  lastest_explorer_status: { level: "read" },
+  lastest_explorer_findings: { level: "read" },
+  lastest_explorer_learn: { level: "write" },
+  lastest_create_test: { level: "write" },
+  lastest_heal_test: { level: "write" },
+  // Advisory only — returns a suggested application-code change, never applies
+  // one, and Lastest does not write to the customer's repo.
+  lastest_suggest_app_fix: { level: "read" },
+  lastest_publish_share: { level: "full" },
+  lastest_approve_layer: { level: "write" },
+  lastest_quickstart: { level: "full" },
+  lastest_quickstart_status: { level: "read" },
+};
+
+export interface ToolDecision {
+  /** False when the tool must not be registered for this caller at all. */
+  registered: boolean;
+  /** Name of the discriminating parameter, when the tool has one. */
+  actionParam?: string;
+  /**
+   * The subset of action values this caller may use. Undefined when the tool
+   * has no action parameter, or when nothing was filtered out.
+   */
+  allowedActions?: string[];
+}
+
+/** What a caller at `level` may do with `toolName`. */
+export function decideTool(
+  toolName: string,
+  level: ToolAccessLevel,
+): ToolDecision {
+  const rule = TOOL_RULES[toolName];
+  // Fail closed: a tool added without a rule is only visible to `full`, which
+  // is the API-key path. That keeps a forgotten entry from silently widening
+  // the OAuth surface.
+  if (!rule) return { registered: level === "full" };
+  if (!levelAllows(level, rule.level)) return { registered: false };
+  if (!rule.actions) return { registered: true };
+
+  const allowed = Object.entries(rule.actions)
+    .filter(([, required]) => levelAllows(level, required))
+    .map(([action]) => action);
+  if (allowed.length === 0) return { registered: false };
+
+  const total = Object.keys(rule.actions).length;
+  return {
+    registered: true,
+    actionParam: rule.actionParam ?? "action",
+    allowedActions: allowed.length === total ? undefined : allowed,
+  };
+}
+
+/**
+ * Human-readable reason handed back when a caller invokes an action that was
+ * filtered out of its schema. Names the level it would need, so the agent can
+ * tell its user what to do instead of retrying.
+ */
+export function deniedActionMessage(
+  toolName: string,
+  action: string,
+  level: ToolAccessLevel,
+): string {
+  const required = TOOL_RULES[toolName]?.actions?.[action];
+  const needs =
+    required === "full"
+      ? "an API key created in Settings → Runners & API Access (this action is never available to an OAuth-connected app)"
+      : `the '${required === "write" ? "lastest:write" : "lastest:read"}' scope`;
+  return `'${action}' is not permitted for this connection (access level: ${level}). It requires ${needs}.`;
+}

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -21,10 +21,29 @@ import {
   AUTHORING_CONTRACT,
   buildRepoAuthoringGuide,
 } from "./authoring-guide.js";
+import {
+  decideTool,
+  deniedActionMessage,
+  type ToolAccessLevel,
+} from "./policy.js";
 
-type ToolHandler = (
-  params: Record<string, unknown>,
-) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
+type ToolHandler = (params: Record<string, unknown>) => Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}>;
+
+/**
+ * Rebuild an `action` enum with only the values a caller is allowed to use,
+ * keeping the original description. Used by `defineTool` so a restricted
+ * connection is never shown an action it cannot call.
+ */
+function narrowEnum(
+  original: z.ZodEnum<[string, ...string[]]>,
+  allowed: string[],
+) {
+  const next = z.enum(allowed as [string, ...string[]]);
+  return original.description ? next.describe(original.description) : next;
+}
 
 function withActivityReporting(
   client: LastestClient,
@@ -75,15 +94,76 @@ function requireParam<T>(
   return value;
 }
 
-export function createServer(client: LastestClient): McpServer {
+export interface CreateServerOptions {
+  /**
+   * How much of the tool surface this caller may see. Defaults to `"full"`,
+   * which is the stdio CLI running under the user's own API key.
+   *
+   * Anything less is a third party acting on the user's behalf — an OAuth
+   * client that registered itself against `/api/mcp`. See `./policy.ts` for
+   * what each level covers and why.
+   */
+  accessLevel?: ToolAccessLevel;
+}
+
+export function createServer(
+  client: LastestClient,
+  options: CreateServerOptions = {},
+): McpServer {
   const server = new McpServer({
     name: "lastest",
     version: "0.5.0",
   });
 
+  const accessLevel: ToolAccessLevel = options.accessLevel ?? "full";
+
+  /**
+   * Registers a tool, subject to `accessLevel`. Every `server.tool()` call in
+   * this file goes through here — see `./policy.ts` for why filtering happens
+   * at registration time rather than inside the handlers.
+   */
+  const defineTool = (
+    name: string,
+    description: string,
+    paramsSchema: z.ZodRawShape,
+    cb: ToolHandler,
+  ): void => {
+    const decision = decideTool(name, accessLevel);
+    if (!decision.registered) return;
+
+    const param = decision.actionParam;
+    const allowed = decision.allowedActions;
+    if (!param || !allowed) {
+      server.tool(name, description, paramsSchema, cb as never);
+      return;
+    }
+
+    const original = paramsSchema[param];
+    const narrowed =
+      original instanceof z.ZodEnum
+        ? { ...paramsSchema, [param]: narrowEnum(original, allowed) }
+        : paramsSchema;
+
+    server.tool(
+      name,
+      `${description}\n\nThis connection may only use ${param}: ${allowed
+        .map((a) => `"${a}"`)
+        .join(", ")}.`,
+      narrowed,
+      (async (params: Record<string, unknown>) => {
+        // Backstop for a caller that sends an action it was never shown.
+        const requested = params[param];
+        if (typeof requested === "string" && !allowed.includes(requested)) {
+          throw new Error(deniedActionMessage(name, requested, accessLevel));
+        }
+        return cb(params);
+      }) as never,
+    );
+  };
+
   // ===== lastest_status (health, jobs, job) =====
   // Replaces lastest_health_check, lastest_list_active_jobs, lastest_get_job_status.
-  server.tool(
+  defineTool(
     "lastest_status",
     'Instance & background-job status. `action`: "health" (check connectivity to the Lastest instance), "jobs" (list currently active background jobs — builds, AI operations, etc.), "job" (get status/progress of a specific background job — requires `jobId`).',
     {
@@ -151,7 +231,7 @@ export function createServer(client: LastestClient): McpServer {
   // ===== lastest_repo (list, get, create, update, get_settings, update_settings) =====
   // Replaces lastest_list_repos, lastest_get_repo, lastest_create_repo, lastest_update_repo,
   // lastest_get_playwright_settings, lastest_update_playwright_settings.
-  server.tool(
+  defineTool(
     "lastest_repo",
     'Repository resource. `action`: "list" (all repos for the team), "get" (one repo — needs repositoryId), "create" (new local repo — needs name; optional baseUrl points the repo at an external app so generated tests target the right origin), "update" (rename / branches / baseUrl — needs repositoryId), "get_settings" (repo-level Playwright settings — needs repositoryId), "update_settings" (upsert repo-level Playwright settings — needs repositoryId + at least one field).',
     {
@@ -478,7 +558,7 @@ export function createServer(client: LastestClient): McpServer {
   // ===== lastest_area (list, create, update, delete, list_tests) =====
   // Replaces lastest_list_areas, lastest_create_area, lastest_update_area, lastest_delete_area,
   // lastest_list_tests_by_area.
-  server.tool(
+  defineTool(
     "lastest_area",
     'Functional-area resource (test groupings). `action`: "list" (areas for a repo — needs repositoryId), "create" (new area — needs name; optional repositoryId/parentId), "update" (rename/describe/reparent — needs functionalAreaId), "delete" (soft-delete; tests become unassigned — needs functionalAreaId), "list_tests" (tests within an area — needs functionalAreaId).',
     {
@@ -667,7 +747,7 @@ export function createServer(client: LastestClient): McpServer {
     cursorPlaybackSpeed: z.number().nonnegative().optional(),
     selectorTimeoutMs: z.number().nonnegative().optional(),
   });
-  server.tool(
+  defineTool(
     "lastest_test",
     'Test resource (read/update/delete). `action`: "list" (all tests in a repo with pass/fail status — needs repositoryId; pass filter:"failing" to return only failing tests with error details), "get" (full details of one test incl. code/URL/last run — needs testId), "update" (name/code/URL/area/setup wiring/runtime overrides — needs testId), "delete" (soft-delete, restorable — needs testId). To create a test use lastest_create_test; to auto-fix a failing test use lastest_heal_test. For update, pass `setupTestId` to point this test at another test for setup, or `setupScriptId` to point at a saved setup script (mutually exclusive). Use `setupOverrides`/`teardownOverrides` to skip default steps or inject extra ones. `playwrightOverrides` self-configures runtime knobs without touching repo settings. Pass `null` for any override block to clear it.',
     {
@@ -920,7 +1000,7 @@ export function createServer(client: LastestClient): McpServer {
 
   // ===== lastest_storage_state (list, create, delete) =====
   // Replaces lastest_list_storage_states, lastest_create_storage_state, lastest_delete_storage_state.
-  server.tool(
+  defineTool(
     "lastest_storage_state",
     'Storage-state resource — saved Playwright `storageState()` blobs (cookies + localStorage). `action`: "list" (metadata only for a repo; raw JSON omitted because it holds live auth tokens — needs repositoryId), "create" (save a new state from a storageState() JSON string — needs repositoryId + name + storageStateJson), "delete" (remove a state — needs storageStateId). Wire a state into a test with lastest_test action:"update" using setupOverrides.extraSteps.',
     {
@@ -1060,7 +1140,7 @@ export function createServer(client: LastestClient): McpServer {
 
   // ===== lastest_setup_script (list, get, create, update, delete) =====
   // Replaces the 5 setup-script tools.
-  server.tool(
+  defineTool(
     "lastest_setup_script",
     'Setup-script resource — reusable Playwright/API setup blocks. `action`: "list" (scripts for a repo with id/name/type/code — needs repositoryId), "get" (one script incl. code — needs setupScriptId), "create" (new script — needs repositoryId + name + type + code), "update" (name/type/code/description — needs setupScriptId), "delete" (remove; 409 if a test still references it — needs setupScriptId). Attach a script to a test via lastest_test action:"update" with setupScriptId.',
     {
@@ -1233,7 +1313,7 @@ export function createServer(client: LastestClient): McpServer {
 
   // ===== lastest_get_diffs (scope: single | build) =====
   // Replaces lastest_get_diff, lastest_get_visual_diff.
-  server.tool(
+  defineTool(
     "lastest_get_diffs",
     'Read visual diffs. `scope`: "single" (full details of one visual diff incl. pixel data, AI analysis, test info — needs diffId), "build" (all visual diffs for a build with AI classification/confidence + aiAnalysis commentary — needs buildId). For "build", pass `full: true` only if you also need the heavy joined payloads.',
     {
@@ -1334,7 +1414,7 @@ export function createServer(client: LastestClient): McpServer {
   // ===== lastest_decide_diff (approve | reject) =====
   // Replaces lastest_approve_diff, lastest_reject_diff, lastest_approve_all_diffs,
   // lastest_approve_baseline, lastest_reject_baseline.
-  server.tool(
+  defineTool(
     "lastest_decide_diff",
     'Approve or reject visual diffs (updates baselines / marks regressions). `action`: "approve" or "reject". Provide either `diffIds` (a batch of one or more diff IDs to approve/reject) OR, for action:"approve", a `buildId` to approve ALL pending diffs in that build at once. Exactly one of diffIds / buildId is required.',
     {
@@ -1417,7 +1497,7 @@ export function createServer(client: LastestClient): McpServer {
   // ===== lastest_build (list, get, review) =====
   // Replaces lastest_list_builds, lastest_get_build_status, lastest_review_build.
   // (lastest_get_test_run is dropped — build "get" covers it.)
-  server.tool(
+  defineTool(
     "lastest_build",
     'Build resource. `action`: "list" (recent builds for a repo with status/test counts — needs repositoryId; optional limit), "get" (current status & results of a build; slim diff index by default — needs buildId; pass includeDiffs:"full" for joined a11y/network/AI payloads), "review" (comprehensive QA review: build details + visual diffs + failed tests into a structured summary with action items — needs buildId).',
     {
@@ -1651,7 +1731,7 @@ export function createServer(client: LastestClient): McpServer {
   // ===== lastest_share (list, revoke) =====
   // Replaces lastest_list_build_shares, lastest_list_test_shares, lastest_revoke_share.
   // (Publishing stays as lastest_publish_share.)
-  server.tool(
+  defineTool(
     "lastest_share",
     'Manage existing public shares (publishing is lastest_publish_share). `action`: "list" (shares anchored on a build — needs buildId — or on a test — needs testId; includes revoked ones, check `status`), "revoke" (kill a share by its share ID so the /r/<slug> URL stops resolving — needs shareId; find share IDs via a "list" call).',
     {
@@ -1752,7 +1832,7 @@ export function createServer(client: LastestClient): McpServer {
 
   // ===== lastest_verify (view, change_map) =====
   // Replaces lastest_verify_build, lastest_get_change_map.
-  server.tool(
+  defineTool(
     "lastest_verify",
     'Verify-phase reads for a build (needs buildId). `action`: "view" (full verify-build view — Change Map + step comparisons grouped by regression vs intent gate, plus `visualUrlsByDiffId` clickable /api/media URLs and `testsByTestId` source/setup hints), "change_map" (just the build-level Change Map — 4-signal area ranking + AI intent/risk summary).',
     {
@@ -1792,7 +1872,7 @@ export function createServer(client: LastestClient): McpServer {
 
   // ===== lastest_insights (coverage, qa) =====
   // Replaces lastest_get_coverage, lastest_qa_summary.
-  server.tool(
+  defineTool(
     "lastest_insights",
     'Repository-level insights (needs repositoryId). `action`: "coverage" (STRUCTURAL coverage — which routes and functional areas have any test at all), "data_coverage" (DATA coverage — the combinatorial cell model: cell/t-way/weighted-volume coverage, the stopping decision, the highest-weight uncovered cells, and the coverage trend over recent builds), "qa" (comprehensive QA overview: test health, recent builds, and action items). Use "data_coverage" for "are we testing enough of the data space / is coverage improving"; "coverage" only answers "which pages have a test".',
     {
@@ -1992,7 +2072,7 @@ export function createServer(client: LastestClient): McpServer {
   );
 
   // ===== lastest_qa_agent (ongoing QA agent: status, runs, direction queue) =====
-  server.tool(
+  defineTool(
     "lastest_qa_agent",
     'Drive the ongoing QA agent for a repository (needs repositoryId). `action`: "status" (live session, latest coverage summary, task board, trigger config), "start_run" (start an autonomous run — optional mode full|refresh_spec|fill_gaps and targetUrl; 409 when a session is already running), "run_status" (poll a session by sessionId), "add_task" (queue a directive on the agent\'s task board — it picks tasks up when idle, works them with the right protocol, and replies on the card), "list_tasks" (the task board).',
     {
@@ -2154,7 +2234,7 @@ export function createServer(client: LastestClient): McpServer {
   // ===== Workflow verbs (standalone, unchanged) =====
 
   // --- lastest_run_tests ---
-  server.tool(
+  defineTool(
     "lastest_run_tests",
     "Trigger a test build and return structured results. Can run all tests in a repo, all tests inside one functional area, or specific test IDs. Pass `forceVideoRecording: true` when you intend to publish a share that should include the video player (the share page renders the embedded clip only when the build has video).",
     {
@@ -2210,7 +2290,7 @@ export function createServer(client: LastestClient): McpServer {
   );
 
   // --- lastest_validate_diff ---
-  server.tool(
+  defineTool(
     "lastest_validate_diff",
     "Diff-scoped validation in one call: pass a git diff (or a base/head branch range for GitHub repos) and Lastest maps the changed files to the affected tests, runs ONLY those, and returns a pass/fail/review verdict with the failing tests and pending visual changes. Use this in a coding-agent loop right after making a change to confirm nothing relevant broke, without running the whole suite. Blocks until the scoped build finishes by default; pass `wait: false` to get a buildId to poll instead.",
     {
@@ -2283,7 +2363,7 @@ export function createServer(client: LastestClient): McpServer {
   );
 
   // --- lastest_scout_url ---
-  server.tool(
+  defineTool(
     "lastest_scout_url",
     "Static (no-browser) scout of a URL: returns title, headings, forms, inputs, links, and candidate selectors to help you author a test. Best-effort — SPA/JS-rendered content won't appear, so prefer your own Playwright MCP for live pages and use this only as a fallback or quick map.",
     {
@@ -2309,7 +2389,7 @@ export function createServer(client: LastestClient): McpServer {
   );
 
   // --- lastest_ranger ---
-  server.tool(
+  defineTool(
     "lastest_ranger",
     "Start a 'ranger' — an Embedded Browser that navigates a URL live and returns a rendered (SPA-aware) page map: headings, landmarks, forms, inputs, buttons, links, test-ids, and candidate selectors. Unlike lastest_scout_url (static, instant), ranger drives a real browser and is WATCHABLE in the Lastest activity feed via a live stream. Async: returns a sessionId immediately — poll lastest_ranger_status for the live streamUrl and the final page map. Prefer your own Playwright MCP if you have one; use ranger when you don't, or want a watchable run on a JS-rendered page.",
     {
@@ -2348,7 +2428,7 @@ export function createServer(client: LastestClient): McpServer {
   );
 
   // --- lastest_ranger_status ---
-  server.tool(
+  defineTool(
     "lastest_ranger_status",
     "Poll a ranger session: returns its status, the live stream URL (watchable while it runs), and — once completed — the rendered page map to author tests from.",
     {
@@ -2382,7 +2462,7 @@ export function createServer(client: LastestClient): McpServer {
   );
 
   // --- lastest_explorer ---
-  server.tool(
+  defineTool(
     "lastest_explorer",
     "Start the Explorer — an autonomous exploratory-testing agent (explorbot-style). It loops research → plan → act → analyze on a live Embedded Browser: maps each page, drafts scenarios in rotating styles (normal/curious/psycho), drives the browser through them adapting as it goes, records defect/UX findings clustered by root cause, learns per-page experience reused on later runs, and keeps passing flows as quarantined tests. WATCHABLE live in the Lastest activity feed. Async: returns a sessionId — poll lastest_explorer_status.",
     {
@@ -2419,7 +2499,7 @@ export function createServer(client: LastestClient): McpServer {
   );
 
   // --- lastest_explorer_status ---
-  server.tool(
+  defineTool(
     "lastest_explorer_status",
     "Poll an explorer session: status, current iteration, live stream URL, findings summary, and — once completed — the root-cause-clustered report plus any kept test ids.",
     {
@@ -2453,7 +2533,7 @@ export function createServer(client: LastestClient): McpServer {
   );
 
   // --- lastest_explorer_findings ---
-  server.tool(
+  defineTool(
     "lastest_explorer_findings",
     "List the full finding rows (defects + UX issues with severity, root-cause cluster, page state, and evidence) recorded by an explorer session.",
     {
@@ -2481,7 +2561,7 @@ export function createServer(client: LastestClient): McpServer {
   );
 
   // --- lastest_explorer_learn ---
-  server.tool(
+  defineTool(
     "lastest_explorer_learn",
     "Teach the Explorer about the app: store a knowledge note (markdown hint) matched to pages by URL pattern — quirks, form rules, test data, navigation notes. Matching notes are injected into the explorer's planning and testing prompts on later runs (explorbot's /learn).",
     {
@@ -2526,7 +2606,7 @@ export function createServer(client: LastestClient): McpServer {
   );
 
   // --- lastest_create_test ---
-  server.tool(
+  defineTool(
     "lastest_create_test",
     'Create a test. **Preferred (MCP-first): DIRECT browser mode** — YOU write the Playwright code and pass { name, code }. First read the resource lastest://repo/{repositoryId}/authoring-guide for the exact runner contract + this repo\'s base URL, areas, and setup; discover selectors with your Playwright MCP (or lastest_scout_url). The `author-test` prompt walks the whole flow. Other modes: **AI browser** ({ url } and/or { prompt }) has the Lastest AI generate the test server-side (only if in-product AI is configured there — else fall back to direct). **direct API** (E1) — { name, testType:"api", apiDefinition } inserts a headless HTTP test (method/url/headers/body + assertions, runs without a browser). **AI API** (E1) — { testType:"api", prompt } (and optionally endpoint/openapiSpec) has the AI generate an API test. Direct modes return immediately; AI modes may take longer.',
     {
@@ -2744,7 +2824,7 @@ export function createServer(client: LastestClient): McpServer {
   );
 
   // --- lastest_heal_test ---
-  server.tool(
+  defineTool(
     "lastest_heal_test",
     "Trigger the AI healer agent to automatically fix a failing test by inspecting the live UI and updating selectors/assertions.",
     {
@@ -2774,7 +2854,7 @@ export function createServer(client: LastestClient): McpServer {
   );
 
   // --- lastest_suggest_app_fix ---
-  server.tool(
+  defineTool(
     "lastest_suggest_app_fix",
     'For a failing test classified as a real regression, get a structured APPLICATION-code fix recommendation (file, snippet, rationale) localized against the build\'s change map. This is the "fix the app" loop: it complements lastest_heal_test (which fixes the *test*). The suggestion is advisory only — Lastest never edits your application code; review and apply it yourself. Returns `not_a_regression` when the failure was triaged as flaky/environment/test-maintenance.',
     {
@@ -2811,7 +2891,7 @@ export function createServer(client: LastestClient): McpServer {
   );
 
   // --- lastest_publish_share (PROTECTED — shape unchanged) ---
-  server.tool(
+  defineTool(
     "lastest_publish_share",
     "Publish a public-share link for a build (or a single test within it). Returns a `/r/<slug>` URL anyone can view without logging in. Use after a build completes so demos and outreach messages can link directly to the visual result. Pass `scopedTestId` to scope the share to one test instead of the whole build.",
     {
@@ -2841,7 +2921,7 @@ export function createServer(client: LastestClient): McpServer {
   );
 
   // --- lastest_approve_layer ---
-  server.tool(
+  defineTool(
     "lastest_approve_layer",
     "Per-layer feedback on a step comparison: approve (Mark expected → write baseline), reject (Needs fix → create todo), or snooze (suppress for this build only).",
     {
@@ -2891,7 +2971,7 @@ export function createServer(client: LastestClient): McpServer {
   // ===== QuickStart agent (PROTECTED — shapes unchanged) =====
 
   // --- lastest_quickstart ---
-  server.tool(
+  defineTool(
     "lastest_quickstart",
     "Productized form of /gtm-lastest-saas-demo. Spins up a 2-test demo (auth setup + app walkthrough) on a repo whose baseUrl is set, runs it with video, and writes build_demo_notes. Gated by team early-adopter mode + repo baseUrl. Returns a sessionId to poll with lastest_quickstart_status.",
     {
@@ -2966,7 +3046,7 @@ export function createServer(client: LastestClient): McpServer {
   );
 
   // --- lastest_quickstart_status ---
-  server.tool(
+  defineTool(
     "lastest_quickstart_status",
     "Poll a QuickStart session by ID. Returns step-by-step status, the auth-setup outcome, the walkthrough test ID, the build ID, and whether demo notes were written.",
     {

--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,29 @@
+/**
+ * RFC 8414 authorization-server metadata, at the path clients actually probe.
+ *
+ * The `mcp` plugin also serves this under `/api/auth/.well-known/…`, but the
+ * issuer this deployment advertises is the site origin, and RFC 8414 says a
+ * client derives the metadata URL from the issuer. So it has to live here.
+ */
+import { NextRequest } from "next/server";
+import {
+  authorizationServerMetadata,
+  discoveryResponse,
+  DISCOVERY_HEADERS,
+} from "@/lib/mcp/discovery";
+import { getPublicUrl } from "@/lib/utils";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest): Promise<Response> {
+  // The public origin, not `req.url`: every deployment sits behind
+  // scripts/front-proxy.js, so `req.url` is the internal 127.0.0.1:3001
+  // address. Advertising that as the issuer would point every client at
+  // an unreachable host.
+  return discoveryResponse(authorizationServerMetadata(getPublicUrl(req)));
+}
+
+export async function OPTIONS(): Promise<Response> {
+  return new Response(null, { status: 204, headers: DISCOVERY_HEADERS });
+}

--- a/src/app/.well-known/oauth-protected-resource/api/mcp/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/api/mcp/route.ts
@@ -1,0 +1,31 @@
+/**
+ * RFC 9728 protected-resource metadata, at the path-suffixed spelling.
+ *
+ * RFC 9728 §3.1 says a client inserts `/.well-known/oauth-protected-resource`
+ * between the resource's host and its path, so a resource at `/api/mcp` is
+ * described at `/.well-known/oauth-protected-resource/api/mcp`. Several clients
+ * instead probe the bare well-known path, which `../../route.ts` serves with
+ * the same body.
+ */
+import { NextRequest } from "next/server";
+import {
+  protectedResourceMetadata,
+  discoveryResponse,
+  DISCOVERY_HEADERS,
+} from "@/lib/mcp/discovery";
+import { getPublicUrl } from "@/lib/utils";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest): Promise<Response> {
+  // The public origin, not `req.url`: every deployment sits behind
+  // scripts/front-proxy.js, so `req.url` is the internal 127.0.0.1:3001
+  // address. Advertising that as the issuer would point every client at
+  // an unreachable host.
+  return discoveryResponse(protectedResourceMetadata(getPublicUrl(req)));
+}
+
+export async function OPTIONS(): Promise<Response> {
+  return new Response(null, { status: 204, headers: DISCOVERY_HEADERS });
+}

--- a/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,30 @@
+/**
+ * RFC 9728 protected-resource metadata for `/api/mcp`.
+ *
+ * This is the document the `WWW-Authenticate` header on a 401 from `/api/mcp`
+ * points at. `./api/mcp/route.ts` serves the same body at the path-suffixed
+ * URL that clients derive from the resource's own path — both spellings are in
+ * the wild, so we answer both.
+ */
+import { NextRequest } from "next/server";
+import {
+  protectedResourceMetadata,
+  discoveryResponse,
+  DISCOVERY_HEADERS,
+} from "@/lib/mcp/discovery";
+import { getPublicUrl } from "@/lib/utils";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest): Promise<Response> {
+  // The public origin, not `req.url`: every deployment sits behind
+  // scripts/front-proxy.js, so `req.url` is the internal 127.0.0.1:3001
+  // address. Advertising that as the issuer would point every client at
+  // an unreachable host.
+  return discoveryResponse(protectedResourceMetadata(getPublicUrl(req)));
+}
+
+export async function OPTIONS(): Promise<Response> {
+  return new Response(null, { status: 204, headers: DISCOVERY_HEADERS });
+}

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,45 +1,67 @@
 /**
- * Streamable HTTP MCP endpoint.
+ * Remote MCP endpoint (Streamable HTTP).
  *
- * Lets remote MCP clients (Smithery, Claude Code via `--transport http`,
- * Cursor, Cline, …) talk to this Lastest instance without spawning the
- * `@lastest/mcp-server` stdio process locally.
+ * Lets remote MCP clients talk to this Lastest instance without spawning the
+ * `@lastest/mcp-server` stdio process locally. Two kinds of caller arrive here:
  *
- * Authentication:
- *   Authorization: Bearer <api-key>
- * where the API key is created in Settings → Runners & API Access.
+ *  - **A developer's own agent** (Claude Code `--transport http`, Cursor,
+ *    Cline, Smithery) carrying an API key from Settings → Runners & API Access.
+ *  - **An agent platform** (Salesforce Agentforce, ChatGPT, Claude web) that
+ *    discovered our OAuth 2.1 authorization server from the `WWW-Authenticate`
+ *    header below, registered itself, and is carrying an access token.
  *
- * The tool surface is shared with the stdio package by re-using
- * `createServer()` from `@lastest/mcp-server`. The server's tools call our
- * own `/api/v1/*` endpoints over HTTP — slight loopback overhead, but keeps
- * a single source of truth for tool definitions and auth.
+ * The two are not equally trusted, and the difference is the whole point of
+ * `@/lib/mcp/remote-auth` + the tool policy in `@lastest/mcp-server`: an API key
+ * sees every tool, an OAuth token sees a read- or write-level subset with no
+ * deletes, no share revocation and no public publishing. Tools are filtered at
+ * registration, so a restricted caller never sees an action it cannot call.
+ *
+ * The tool surface itself is shared with the stdio package via `createServer()`.
+ * Its tools call our own `/api/v1/*` endpoints over HTTP — slight loopback
+ * overhead, but it keeps one implementation of every ownership and capability
+ * guard.
  */
 import { NextRequest } from "next/server";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { createServer, LastestClient } from "@lastest/mcp-server";
-import { verifyBearerToken } from "@/lib/auth/api-key";
+import { authenticateMcpRequest, wwwAuthenticate } from "@/lib/mcp/remote-auth";
+import { getLogger } from "@/lib/logger";
+import { getPublicUrl } from "@/lib/utils";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-async function handle(req: NextRequest): Promise<Response> {
-  const authHeader = req.headers.get("authorization");
-  if (!authHeader?.toLowerCase().startsWith("bearer ")) {
-    return unauthorized(
-      "Missing Bearer token. Create an API key in Settings → Runners & API Access.",
-    );
-  }
-  const token = authHeader.slice(7).trim();
-  const session = await verifyBearerToken(token);
-  if (!session) {
-    return unauthorized("Invalid or expired API key.");
-  }
+const log = getLogger("MCP");
 
-  // Use this request's own origin so the MCP tools call the same instance
-  // they're being served from (works across localhost, self-hosted, cloud).
-  const baseUrl = new URL(req.url).origin;
-  const client = new LastestClient({ baseUrl, apiKey: token });
-  const server = createServer(client);
+async function handle(req: NextRequest): Promise<Response> {
+  // Two different origins, deliberately.
+  //
+  // `loopbackOrigin` is where the MCP tools send their /api/v1 calls: this
+  // request's own address, so they hit the very instance being served and skip
+  // a pointless round trip back out through the front proxy.
+  //
+  // `publicOrigin` is what we advertise to the client in WWW-Authenticate. It
+  // must be the externally reachable host — `req.url` here is the internal
+  // 127.0.0.1:3001 address that scripts/front-proxy.js forwards to.
+  const loopbackOrigin = new URL(req.url).origin;
+  const publicOrigin = getPublicUrl(req);
+
+  const result = await authenticateMcpRequest(req);
+  if (!result.ok) {
+    return unauthorized(publicOrigin, result.status, result.detail);
+  }
+  const { caller } = result;
+
+  log.debug(
+    { client: caller.client, accessLevel: caller.accessLevel },
+    "MCP request authenticated",
+  );
+
+  const client = new LastestClient({
+    baseUrl: loopbackOrigin,
+    apiKey: caller.loopbackToken,
+  });
+  const server = createServer(client, { accessLevel: caller.accessLevel });
 
   // Stateless: fresh transport per request, no session persistence.
   // Serverless-friendly and plays nicely with Smithery's connection model.
@@ -51,20 +73,31 @@ async function handle(req: NextRequest): Promise<Response> {
   return transport.handleRequest(req as unknown as Request);
 }
 
-function unauthorized(detail: string): Response {
+function unauthorized(
+  origin: string,
+  status: number,
+  detail: string,
+): Response {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (status === 401) {
+    // RFC 9728. This is how an agent platform finds the authorization server
+    // without being told about it out of band — it is the difference between
+    // "paste the URL and click connect" and "go generate an API key first".
+    headers["www-authenticate"] = wwwAuthenticate(origin, "invalid_token");
+  }
   return new Response(
     JSON.stringify({
       jsonrpc: "2.0",
-      error: { code: -32001, message: "Unauthorized", data: { detail } },
+      error: {
+        code: status === 401 ? -32001 : -32603,
+        message: status === 401 ? "Unauthorized" : "Unavailable",
+        data: { detail },
+      },
       id: null,
     }),
-    {
-      status: 401,
-      headers: {
-        "content-type": "application/json",
-        "www-authenticate": 'Bearer realm="lastest"',
-      },
-    },
+    { status, headers },
   );
 }
 

--- a/src/app/oauth/consent/consent-client.tsx
+++ b/src/app/oauth/consent/consent-client.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Check, X, ShieldAlert } from "lucide-react";
+
+interface Props {
+  consentCode: string;
+  clientName: string;
+  clientId: string;
+  registered: boolean;
+  canWrite: boolean;
+  userEmail: string;
+  teamName: string | null;
+}
+
+/** What the connection will be able to do, in plain language. */
+function grants(canWrite: boolean): string[] {
+  const read = [
+    "Read your projects, tests, builds and visual diffs",
+    "Read coverage, verification results and QA insights",
+  ];
+  if (!canWrite) return read;
+  return [
+    ...read,
+    "Run tests and start verification builds",
+    "Create and update tests, areas and setup scripts",
+    "Approve or reject visual changes (this rewrites baselines)",
+  ];
+}
+
+const NEVER = [
+  "Delete tests, areas, setup scripts or stored logins",
+  "Publish a public share link, or revoke an existing one",
+  "Read or change your billing, team members or API keys",
+];
+
+export function ConsentClient({
+  consentCode,
+  clientName,
+  clientId,
+  registered,
+  canWrite,
+  userEmail,
+  teamName,
+}: Props) {
+  const [busy, setBusy] = useState<"accept" | "deny" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function decide(accept: boolean) {
+    setBusy(accept ? "accept" : "deny");
+    setError(null);
+    try {
+      const res = await fetch("/api/auth/oauth2/consent", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ accept, consent_code: consentCode }),
+      });
+      const body = (await res.json()) as { redirectURI?: string };
+      if (!res.ok || !body.redirectURI) {
+        throw new Error(
+          "The authorization request expired or is no longer valid. Start the connection again.",
+        );
+      }
+      window.location.href = body.redirectURI;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setBusy(null);
+    }
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-md flex-col justify-center px-4 py-10">
+      <div className="rounded-xl border bg-card p-6 shadow-sm">
+        <h1 className="text-lg font-semibold tracking-tight">
+          Connect {clientName} to Lastest?
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Signed in as {userEmail}
+          {teamName ? ` · ${teamName}` : ""}
+        </p>
+
+        {!registered && (
+          <div className="mt-4 flex gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs">
+            <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+            <span>
+              This app registered itself moments ago and has not been verified
+              by anyone. Only continue if you started this connection.
+            </span>
+          </div>
+        )}
+
+        <section className="mt-5">
+          <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            It will be able to
+          </h2>
+          <ul className="mt-2 space-y-1.5 text-sm">
+            {grants(canWrite).map((g) => (
+              <li key={g} className="flex gap-2">
+                <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" />
+                <span>{g}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="mt-5">
+          <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            It will never be able to
+          </h2>
+          <ul className="mt-2 space-y-1.5 text-sm text-muted-foreground">
+            {NEVER.map((n) => (
+              <li key={n} className="flex gap-2">
+                <X className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground/70" />
+                <span>{n}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <p className="mt-5 break-all font-mono text-[10px] text-muted-foreground">
+          client_id: {clientId}
+        </p>
+
+        {error && (
+          <p className="mt-4 text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+
+        <div className="mt-6 flex gap-2">
+          <Button
+            variant="outline"
+            className="flex-1"
+            disabled={busy !== null}
+            onClick={() => decide(false)}
+          >
+            {busy === "deny" ? "Cancelling…" : "Cancel"}
+          </Button>
+          <Button
+            className="flex-1"
+            disabled={busy !== null}
+            onClick={() => decide(true)}
+          >
+            {busy === "accept" ? "Connecting…" : "Allow"}
+          </Button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/oauth/consent/page.tsx
+++ b/src/app/oauth/consent/page.tsx
@@ -1,0 +1,82 @@
+/**
+ * OAuth consent screen for the remote MCP endpoint.
+ *
+ * Reached from `/api/auth/mcp/authorize` when a client asks for consent. The
+ * authorization server has already established who the user is by this point;
+ * this page's job is to name the client, spell out what the requested scopes
+ * actually let it do in Lastest, and turn an approval into a POST to
+ * `/api/auth/oauth2/consent`.
+ *
+ * The scope descriptions are written in terms of *consequences* rather than
+ * scope strings, and they say plainly what stays out of reach: no deletes, no
+ * revoking shares, no publishing anything publicly. That is the truth enforced
+ * by the tool policy (`@lastest/mcp-server`'s `policy.ts`), not a reassurance —
+ * those tools are never registered for an OAuth caller.
+ */
+import { redirect } from "next/navigation";
+import { getCurrentSession } from "@/lib/auth";
+import { getOAuthApplicationByClientId } from "@/lib/db/queries";
+import { MCP_WRITE_SCOPE, parseScopes } from "@/lib/mcp/tool-policy";
+import { ConsentClient } from "./consent-client";
+
+export const dynamic = "force-dynamic";
+
+interface Props {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+function first(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? (value[0] ?? "") : (value ?? "");
+}
+
+export default async function McpConsentPage({ searchParams }: Props) {
+  const sp = await searchParams;
+  const consentCode = first(sp.consent_code);
+  const clientId = first(sp.client_id);
+  const scope = first(sp.scope);
+
+  const session = await getCurrentSession();
+  if (!session?.user) {
+    // Defensive only: the authorization endpoint bounces through /login before
+    // it ever redirects here, so an unauthenticated visitor means someone
+    // opened the link out of order.
+    const back = new URLSearchParams({
+      consent_code: consentCode,
+      client_id: clientId,
+      scope,
+    });
+    const target = `/oauth/consent?${back.toString()}`;
+    redirect(`/login?returnTo=${encodeURIComponent(target)}`);
+  }
+
+  if (!consentCode || !clientId) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-md flex-col justify-center px-4">
+        <h1 className="text-lg font-semibold">Invalid authorization request</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          This link is missing its authorization code. Start the connection
+          again from the app you were connecting.
+        </p>
+      </main>
+    );
+  }
+
+  const app = await getOAuthApplicationByClientId(clientId);
+  const scopes = parseScopes(scope);
+  const canWrite = scopes.includes(MCP_WRITE_SCOPE);
+
+  return (
+    <ConsentClient
+      consentCode={consentCode}
+      clientName={app?.name || "An unnamed application"}
+      // Dynamic client registration means anyone can pick a name. Showing the
+      // client id alongside it is the only thing that distinguishes a genuine
+      // "Salesforce Agentforce" from something that typed the same name in.
+      clientId={clientId}
+      registered={Boolean(app)}
+      canWrite={canWrite}
+      userEmail={session.user.email}
+      teamName={session.team?.name ?? null}
+    />
+  );
+}

--- a/src/app/oauth/mcp/authorize/route.ts
+++ b/src/app/oauth/mcp/authorize/route.ts
@@ -1,0 +1,38 @@
+/**
+ * Front door for the MCP authorization endpoint.
+ *
+ * This is what `/.well-known/oauth-authorization-server` advertises as the
+ * `authorization_endpoint`, rather than better-auth's `/api/auth/mcp/authorize`
+ * directly, for one reason: **consent must not be optional.**
+ *
+ * The plugin only shows the consent screen when the client asks for it with
+ * `prompt=consent`, and plenty of MCP clients don't. Combined with anonymous
+ * dynamic client registration, that would mean an app that registered itself
+ * seconds ago could get a token the moment a signed-in user follows a link,
+ * with nothing shown to them. So this route pins `prompt=consent` on the way
+ * through, and every other parameter is passed along untouched.
+ *
+ * It intentionally validates nothing else — `client_id`, `redirect_uri`, PKCE
+ * and scope checking all belong to the authorization endpoint proper, and
+ * duplicating them here would just create two places to get them wrong.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { getPublicUrl } from "@/lib/utils";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const params = new URLSearchParams(req.nextUrl.searchParams);
+
+  const prompt = params.get("prompt");
+  const values = new Set((prompt ?? "").split(/\s+/).filter(Boolean));
+  values.add("consent");
+  params.set("prompt", Array.from(values).join(" "));
+
+  // Relative to the public origin so the browser stays on the host it started
+  // on — a redirect to the internal 127.0.0.1:3001 address would dead-end.
+  return NextResponse.redirect(
+    new URL(`/api/auth/mcp/authorize?${params.toString()}`, getPublicUrl(req)),
+  );
+}

--- a/src/lib/auth/api-key.ts
+++ b/src/lib/auth/api-key.ts
@@ -7,9 +7,27 @@
  */
 import * as queries from "@/lib/db/queries";
 import type { SessionData } from "./session";
+import {
+  LOOPBACK_GRANT_PREFIX,
+  verifyLoopbackGrant,
+} from "@/lib/mcp/loopback-grant";
+
 export async function verifyBearerToken(
   token: string,
 ): Promise<SessionData | null> {
+  // Server-minted, minute-long grant used by /api/mcp to make its own
+  // loopback calls on behalf of an OAuth-authenticated user. Never issued to a
+  // client, never persisted — see @/lib/mcp/loopback-grant for why OAuth
+  // access tokens themselves are deliberately not accepted here.
+  if (token.startsWith(LOOPBACK_GRANT_PREFIX)) {
+    const grant = verifyLoopbackGrant(token);
+    if (!grant) return null;
+    const user = await queries.getUserById(grant.u);
+    if (!user) return null;
+    const team = user.teamId ? await queries.getTeam(user.teamId) : null;
+    return { user, sessionId: `mcp-oauth:${grant.c}`, team: team ?? null };
+  }
+
   const result = await queries.getSessionWithUser(token);
   if (!result || result.session.expiresAt < new Date()) {
     return null;

--- a/src/lib/auth/api-key.ts
+++ b/src/lib/auth/api-key.ts
@@ -25,6 +25,11 @@ export async function verifyBearerToken(
     const user = await queries.getUserById(grant.u);
     if (!user) return null;
     const team = user.teamId ? await queries.getTeam(user.teamId) : null;
+    // A label, not a key: no `sessions` row exists for an OAuth MCP caller by
+    // design (the grant is minted per request and never persisted). Verified
+    // that nothing treats `SessionData.sessionId` as a lookup handle — the only
+    // readers are log fields — and the `mcp-oauth:` prefix keeps it obviously
+    // non-UUID if one ever appears.
     return { user, sessionId: `mcp-oauth:${grant.c}`, team: team ?? null };
   }
 

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -1,6 +1,11 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { nextCookies } from "better-auth/next-js";
+// From the `plugins` barrel, not `better-auth/plugins/mcp`: better-auth 1.6.14
+// ships `dist/plugins/mcp/` but its package `exports` map only publishes
+// `./plugins/mcp/client`, so the deep path resolves under neither Turbopack nor
+// tsc. The barrel re-exports `mcp` (and `withMcpAuth`) and is the supported way in.
+import { mcp } from "better-auth/plugins";
 import { stripe as stripePlugin } from "@better-auth/stripe";
 import { db } from "@/lib/db";
 import * as schema from "@/lib/db/schema";
@@ -13,6 +18,9 @@ import { sendPasswordResetEmail } from "@/lib/email";
 import { syncReposIfStale } from "@/server/actions/repos";
 import { syncUserToTwentyCRM } from "@/lib/integrations/twenty-crm";
 import { getStripeClient } from "@/lib/billing/stripe";
+// The scope list the authorization server advertises, kept next to the
+// scope → tool-access mapping it has to agree with.
+import { MCP_OAUTH_SCOPES } from "@/lib/mcp/tool-policy";
 import {
   getCatalog,
   invalidateCatalog,
@@ -138,6 +146,10 @@ export const auth = betterAuth({
       // plugin reads/writes `teams.stripeCustomerId` directly.
       subscription: schema.subscriptions,
       organization: schema.teams,
+      // OAuth 2.1 authorization-server tables for the `mcp` plugin below.
+      oauthApplication: schema.oauthApplications,
+      oauthAccessToken: schema.oauthAccessTokens,
+      oauthConsent: schema.oauthConsents,
     },
   }),
 
@@ -368,6 +380,37 @@ export const auth = betterAuth({
 
   plugins: [
     nextCookies(),
+    // Turns this app into an OAuth 2.1 authorization server for the remote MCP
+    // endpoint at /api/mcp, so agent platforms (Salesforce Agentforce, ChatGPT,
+    // Claude web, …) can connect without a human pasting an API key.
+    //
+    // Mounted under /api/auth: /mcp/register (RFC 7591 dynamic client
+    // registration), /mcp/authorize, /mcp/token, /mcp/get-session, plus
+    // /.well-known/oauth-authorization-server. The two root-level
+    // /.well-known/* routes re-serve the discovery documents at the paths
+    // RFC 8414 / RFC 9728 clients actually probe.
+    mcp({
+      loginPage: "/login",
+      oidcConfig: {
+        loginPage: "/login",
+        // Anonymous DCR is what makes "paste the URL, click connect" work in an
+        // agent platform. Clients are public + PKCE-only; a registration row on
+        // its own grants nothing until a signed-in user approves it at
+        // /oauth/consent.
+        allowDynamicClientRegistration: true,
+        requirePKCE: true,
+        allowPlainCodeChallengeMethod: false,
+        consentPage: "/oauth/consent",
+        // `lastest:read` / `lastest:write` decide how much of the MCP tool
+        // surface the resulting token sees — see src/lib/mcp/tool-policy.ts.
+        // Deletes are never reachable over OAuth at all, at any scope.
+        scopes: [...MCP_OAUTH_SCOPES],
+        defaultScope: "openid lastest:read",
+        accessTokenExpiresIn: 3600,
+        refreshTokenExpiresIn: 60 * 60 * 24 * 30,
+        storeClientSecret: "hashed",
+      },
+    }),
     // Lazily skip the Stripe plugin when STRIPE_SECRET_KEY is unset so
     // self-hosters who don't want billing don't have to set fake env vars.
     ...buildStripePlugin(),

--- a/src/lib/db/queries/auth.ts
+++ b/src/lib/db/queries/auth.ts
@@ -17,6 +17,8 @@ import {
   repositories,
   githubAccounts,
   tests,
+  oauthApplications,
+  oauthAccessTokens,
 } from "../schema";
 import type {
   NewTeam,
@@ -794,4 +796,41 @@ export async function revokeConsent(userId: string, consentType: ConsentType) {
         isNull(userConsents.revokedAt),
       ),
     );
+}
+
+// ===========================================================================
+// OAuth 2.1 clients (MCP)
+// ===========================================================================
+//
+// Rows here are written by better-auth's `mcp` plugin via dynamic client
+// registration; we only ever read them — to name the app on the consent screen,
+// and to list/revoke connections from settings.
+
+export async function getOAuthApplicationByClientId(clientId: string) {
+  const [row] = await db
+    .select()
+    .from(oauthApplications)
+    .where(eq(oauthApplications.clientId, clientId))
+    .limit(1);
+  return row ?? null;
+}
+
+/** Live (unexpired) OAuth connections a user has granted, newest first. */
+export async function getOAuthConnectionsForUser(userId: string) {
+  return db
+    .select({
+      id: oauthAccessTokens.id,
+      clientId: oauthAccessTokens.clientId,
+      scopes: oauthAccessTokens.scopes,
+      createdAt: oauthAccessTokens.createdAt,
+      accessTokenExpiresAt: oauthAccessTokens.accessTokenExpiresAt,
+      clientName: oauthApplications.name,
+    })
+    .from(oauthAccessTokens)
+    .leftJoin(
+      oauthApplications,
+      eq(oauthApplications.clientId, oauthAccessTokens.clientId),
+    )
+    .where(eq(oauthAccessTokens.userId, userId))
+    .orderBy(desc(oauthAccessTokens.createdAt));
 }

--- a/src/lib/mcp/discovery.test.ts
+++ b/src/lib/mcp/discovery.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import {
+  authorizationServerMetadata,
+  protectedResourceMetadata,
+  MCP_AUTHORIZE_PATH,
+  MCP_OAUTH_BASE,
+  MCP_RESOURCE_PATH,
+} from "./discovery";
+
+const ORIGIN = "https://lastest.example.com";
+
+/**
+ * The discovery documents are a set of promises about which URLs exist. These
+ * assertions are the cheap half of keeping them true: that every advertised
+ * path resolves to a route we actually ship (or, for the better-auth-mounted
+ * ones, to the plugin's basePath), and that the OAuth 2.1 posture we claim —
+ * S256-only, code flow only — is what we advertise.
+ */
+describe("mcp discovery metadata", () => {
+  const meta = authorizationServerMetadata(ORIGIN);
+
+  it("advertises this origin as the issuer", () => {
+    expect(meta.issuer).toBe(ORIGIN);
+    for (const url of [
+      meta.authorization_endpoint,
+      meta.token_endpoint,
+      meta.registration_endpoint,
+    ]) {
+      expect(url.startsWith(`${ORIGIN}/`)).toBe(true);
+    }
+  });
+
+  it("is OAuth 2.1: code flow, PKCE S256 only", () => {
+    expect(meta.response_types_supported).toEqual(["code"]);
+    expect(meta.code_challenge_methods_supported).toEqual(["S256"]);
+    expect(meta.grant_types_supported).toContain("authorization_code");
+    expect(meta.grant_types_supported).not.toContain("implicit");
+    expect(meta.grant_types_supported).not.toContain("password");
+  });
+
+  it("routes the authorize endpoint through our consent-forcing front door", () => {
+    // Advertising better-auth's endpoint directly would let a client skip the
+    // consent screen by simply not sending prompt=consent.
+    expect(meta.authorization_endpoint).toBe(`${ORIGIN}${MCP_AUTHORIZE_PATH}`);
+    expect(meta.authorization_endpoint).not.toBe(
+      `${ORIGIN}${MCP_OAUTH_BASE}/authorize`,
+    );
+    expect(
+      existsSync(
+        path.join(process.cwd(), "src/app", MCP_AUTHORIZE_PATH, "route.ts"),
+      ),
+      `${MCP_AUTHORIZE_PATH} has no route`,
+    ).toBe(true);
+  });
+
+  it("points the protected-resource document at /api/mcp", () => {
+    const prm = protectedResourceMetadata(ORIGIN);
+    expect(prm.resource).toBe(`${ORIGIN}${MCP_RESOURCE_PATH}`);
+    expect(prm.authorization_servers).toEqual([ORIGIN]);
+    expect(prm.scopes_supported).toEqual(["lastest:read", "lastest:write"]);
+    expect(
+      existsSync(
+        path.join(process.cwd(), "src/app", MCP_RESOURCE_PATH, "route.ts"),
+      ),
+    ).toBe(true);
+  });
+
+  it("ships both well-known spellings of the resource document", () => {
+    const base = path.join(
+      process.cwd(),
+      "src/app/.well-known/oauth-protected-resource",
+    );
+    expect(existsSync(path.join(base, "route.ts"))).toBe(true);
+    // RFC 9728 §3.1 path-suffixed form, for clients that derive it from the
+    // resource's own path.
+    expect(
+      existsSync(path.join(base, "api/mcp/route.ts")),
+      "missing /.well-known/oauth-protected-resource/api/mcp",
+    ).toBe(true);
+  });
+});

--- a/src/lib/mcp/discovery.ts
+++ b/src/lib/mcp/discovery.ts
@@ -1,0 +1,92 @@
+/**
+ * OAuth discovery documents for the remote MCP endpoint.
+ *
+ * An agent platform is handed one thing: the URL `https://<host>/api/mcp`. From
+ * there it has to find out, unaided, that the resource is OAuth-protected, who
+ * the authorization server is, and how to register itself. That chain is:
+ *
+ *   1. `POST /api/mcp` with no credential → 401 carrying
+ *      `WWW-Authenticate: Bearer resource_metadata="…"` (RFC 9728).
+ *   2. `GET /.well-known/oauth-protected-resource` → names this resource and
+ *      its authorization server.
+ *   3. `GET /.well-known/oauth-authorization-server` → RFC 8414 metadata with
+ *      the authorize/token/register endpoints.
+ *   4. `POST …/mcp/register` → RFC 7591 dynamic client registration.
+ *
+ * Both documents are built from the *request's* origin rather than a configured
+ * base URL, so a self-hosted instance, a preview deployment and localhost all
+ * advertise themselves correctly with no env var to set. The endpoints they
+ * point at are the ones better-auth's `mcp` plugin mounts under `/api/auth`;
+ * `discovery.test.ts` asserts the two stay in step.
+ */
+import { MCP_OAUTH_SCOPES } from "@/lib/mcp/tool-policy";
+
+/** Where better-auth mounts the `mcp` plugin's OAuth endpoints. */
+export const MCP_OAUTH_BASE = "/api/auth/mcp";
+
+/**
+ * Our own front door for authorization. It forwards to
+ * `${MCP_OAUTH_BASE}/authorize` with `prompt=consent` pinned on, so a client
+ * that never asks for consent still cannot get a token without the user seeing
+ * what they are approving. See that route for why.
+ */
+export const MCP_AUTHORIZE_PATH = "/oauth/mcp/authorize";
+
+/** The MCP resource this authorization server protects. */
+export const MCP_RESOURCE_PATH = "/api/mcp";
+
+export function authorizationServerMetadata(origin: string) {
+  return {
+    issuer: origin,
+    authorization_endpoint: `${origin}${MCP_AUTHORIZE_PATH}`,
+    token_endpoint: `${origin}${MCP_OAUTH_BASE}/token`,
+    registration_endpoint: `${origin}${MCP_OAUTH_BASE}/register`,
+    scopes_supported: [...MCP_OAUTH_SCOPES],
+    response_types_supported: ["code"],
+    response_modes_supported: ["query"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    // Public clients only — MCP clients cannot keep a secret, and PKCE is what
+    // actually protects the code exchange.
+    token_endpoint_auth_methods_supported: [
+      "none",
+      "client_secret_basic",
+      "client_secret_post",
+    ],
+    // S256 only. `plain` is disabled in the plugin config for the same reason
+    // OAuth 2.1 drops it.
+    code_challenge_methods_supported: ["S256"],
+    service_documentation:
+      "https://github.com/las-team/lastest/wiki/MCP-Server",
+  };
+}
+
+export function protectedResourceMetadata(origin: string) {
+  return {
+    resource: `${origin}${MCP_RESOURCE_PATH}`,
+    authorization_servers: [origin],
+    // Only the two that mean anything here. `openid`/`profile`/`email`/
+    // `offline_access` are accepted but say nothing about Lastest data.
+    scopes_supported: ["lastest:read", "lastest:write"],
+    bearer_methods_supported: ["header"],
+    resource_documentation:
+      "https://github.com/las-team/lastest/wiki/MCP-Server",
+  };
+}
+
+/**
+ * Discovery documents are fetched cross-origin by clients running in a browser,
+ * and they are entirely public — they contain no user data and no secrets.
+ */
+export const DISCOVERY_HEADERS: Record<string, string> = {
+  "content-type": "application/json",
+  "cache-control": "public, max-age=3600",
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": "GET, OPTIONS",
+  "access-control-allow-headers":
+    "Content-Type, Authorization, MCP-Protocol-Version",
+  "access-control-max-age": "86400",
+};
+
+export function discoveryResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { headers: DISCOVERY_HEADERS });
+}

--- a/src/lib/mcp/loopback-grant.test.ts
+++ b/src/lib/mcp/loopback-grant.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mintLoopbackGrant,
+  verifyLoopbackGrant,
+  LOOPBACK_GRANT_PREFIX,
+} from "./loopback-grant";
+
+const KEY_A = "a".repeat(64);
+const KEY_B = "b".repeat(64);
+
+describe("mcp loopback grant", () => {
+  const original = process.env.ENCRYPTION_KEY;
+  beforeEach(() => {
+    process.env.ENCRYPTION_KEY = KEY_A;
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env.ENCRYPTION_KEY;
+    else process.env.ENCRYPTION_KEY = original;
+  });
+
+  it("round-trips the user and client", () => {
+    const grant = mintLoopbackGrant("user-1", "client-1")!;
+    expect(grant.startsWith(LOOPBACK_GRANT_PREFIX)).toBe(true);
+    expect(verifyLoopbackGrant(grant)).toMatchObject({
+      u: "user-1",
+      c: "client-1",
+    });
+  });
+
+  it("rejects a tampered payload", () => {
+    const grant = mintLoopbackGrant("user-1", "client-1")!;
+    const [payload, sig] = grant.slice(LOOPBACK_GRANT_PREFIX.length).split(".");
+    const forged = Buffer.from(
+      JSON.stringify({
+        u: "someone-else",
+        c: "client-1",
+        e: Date.now() + 1000,
+      }),
+    ).toString("base64url");
+    expect(payload).not.toBe(forged);
+    expect(
+      verifyLoopbackGrant(`${LOOPBACK_GRANT_PREFIX}${forged}.${sig}`),
+    ).toBeNull();
+  });
+
+  it("rejects a grant signed with a different ENCRYPTION_KEY", () => {
+    const grant = mintLoopbackGrant("user-1", "client-1")!;
+    process.env.ENCRYPTION_KEY = KEY_B;
+    expect(verifyLoopbackGrant(grant)).toBeNull();
+  });
+
+  it("rejects an expired grant", () => {
+    const grant = mintLoopbackGrant("user-1", "client-1", -1)!;
+    expect(verifyLoopbackGrant(grant)).toBeNull();
+  });
+
+  it("fails closed with no usable ENCRYPTION_KEY", () => {
+    const grant = mintLoopbackGrant("user-1", "client-1")!;
+    delete process.env.ENCRYPTION_KEY;
+    expect(mintLoopbackGrant("user-1", "client-1")).toBeNull();
+    expect(verifyLoopbackGrant(grant)).toBeNull();
+
+    process.env.ENCRYPTION_KEY = "not-hex";
+    expect(mintLoopbackGrant("user-1", "client-1")).toBeNull();
+  });
+
+  it("ignores tokens that are not grants at all", () => {
+    expect(verifyLoopbackGrant("some-api-key")).toBeNull();
+    expect(verifyLoopbackGrant(`${LOOPBACK_GRANT_PREFIX}nonsense`)).toBeNull();
+  });
+});

--- a/src/lib/mcp/loopback-grant.ts
+++ b/src/lib/mcp/loopback-grant.ts
@@ -1,0 +1,119 @@
+/**
+ * Short-lived, server-side-only credentials for the MCP loopback.
+ *
+ * Why this exists
+ * ---------------
+ * The MCP tools do their work by calling this app's own `/api/v1/*` endpoints
+ * over HTTP, which keeps one implementation of every guard
+ * (`requireTeamAccess`, `requireRepoAccess`, capabilities) instead of two. That
+ * loopback call needs a credential `/api/v1` understands, and for an
+ * API-key caller it simply reuses the caller's key.
+ *
+ * An OAuth caller has no key — it holds an access token issued by the `mcp`
+ * plugin. Teaching `/api/v1` to accept those tokens would be the obvious move
+ * and would be a security bug: the whole point of the tool policy is that a
+ * `lastest:read` token cannot delete a test, and a token that authenticates
+ * directly against `/api/v1` bypasses the MCP layer where that is enforced.
+ * OAuth tokens are therefore deliberately *not* accepted by
+ * `verifyBearerToken()`.
+ *
+ * So `/api/mcp` mints one of these instead: an HMAC-signed grant naming a user,
+ * valid for a minute, used as the Authorization header of the loopback fetches
+ * belonging to that one request. It is created on the server, spent on the
+ * server, and never appears in any response — the OAuth client never sees it.
+ * Same construction as the EB stream grant (`@/lib/eb/stream-grant`), same
+ * fail-closed rule: no `ENCRYPTION_KEY`, no grants.
+ *
+ * Wire format (URL-safe base64, no padding):
+ *
+ *     lmcp_<base64url(JSON payload)>.<base64url(HMAC-SHA256(payload, key))>
+ */
+import crypto from "node:crypto";
+
+export const LOOPBACK_GRANT_PREFIX = "lmcp_";
+
+/** A minute is far longer than any single MCP request's fan-out needs. */
+const DEFAULT_TTL_MS = 60_000;
+
+const GRANT_KEY_INFO = "mcp-loopback-grant-v1";
+
+/** Mirrors the validation in @/lib/crypto — 32 bytes, hex-encoded. */
+const ENCRYPTION_KEY_RE = /^[0-9a-f]{64}$/i;
+
+export interface LoopbackGrantPayload {
+  /** User the loopback call acts as. */
+  u: string;
+  /** Issuing OAuth client id, for audit trails. */
+  c: string;
+  /** Expiry, epoch milliseconds. */
+  e: number;
+}
+
+function grantKey(): Buffer | null {
+  const hex = process.env.ENCRYPTION_KEY?.trim();
+  if (!hex || !ENCRYPTION_KEY_RE.test(hex)) return null;
+  return crypto
+    .createHmac("sha256", Buffer.from(hex, "hex"))
+    .update(GRANT_KEY_INFO)
+    .digest();
+}
+
+function sign(payload: string, key: Buffer): string {
+  return crypto.createHmac("sha256", key).update(payload).digest("base64url");
+}
+
+/**
+ * Mint a loopback grant for `userId`. Returns null when `ENCRYPTION_KEY` is
+ * missing or malformed — callers must fail closed rather than fall back to an
+ * unsigned or constant-keyed token.
+ */
+export function mintLoopbackGrant(
+  userId: string,
+  clientId: string,
+  ttlMs = DEFAULT_TTL_MS,
+): string | null {
+  const key = grantKey();
+  if (!key) return null;
+  const payload: LoopbackGrantPayload = {
+    u: userId,
+    c: clientId,
+    e: Date.now() + ttlMs,
+  };
+  const encoded = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${LOOPBACK_GRANT_PREFIX}${encoded}.${sign(encoded, key)}`;
+}
+
+/** Verify a grant. Returns its payload, or null for anything not currently valid. */
+export function verifyLoopbackGrant(
+  token: string,
+): LoopbackGrantPayload | null {
+  if (!token.startsWith(LOOPBACK_GRANT_PREFIX)) return null;
+  const key = grantKey();
+  if (!key) return null;
+
+  const [encoded, signature] = token
+    .slice(LOOPBACK_GRANT_PREFIX.length)
+    .split(".");
+  if (!encoded || !signature) return null;
+
+  const expected = sign(encoded, key);
+  const a = Buffer.from(signature);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) return null;
+
+  let payload: LoopbackGrantPayload;
+  try {
+    payload = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (
+    typeof payload?.u !== "string" ||
+    !payload.u ||
+    typeof payload.e !== "number" ||
+    payload.e <= Date.now()
+  ) {
+    return null;
+  }
+  return payload;
+}

--- a/src/lib/mcp/remote-auth.test.ts
+++ b/src/lib/mcp/remote-auth.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// vi.mock is hoisted above these declarations, so the factories have to build
+// their own spies rather than close over module-level ones.
+vi.mock("@/lib/auth/auth", () => ({
+  auth: { api: { getMcpSession: vi.fn() } },
+}));
+vi.mock("@/lib/auth/api-key", () => ({ verifyBearerToken: vi.fn() }));
+
+import { auth } from "@/lib/auth/auth";
+import { verifyBearerToken as verifyBearerTokenImport } from "@/lib/auth/api-key";
+import { authenticateMcpRequest, wwwAuthenticate } from "./remote-auth";
+
+const getMcpSession = vi.mocked(auth.api.getMcpSession);
+const verifyBearerToken = vi.mocked(verifyBearerTokenImport);
+
+const ORIGIN = "https://lastest.example.com";
+
+function request(authorization?: string): Request {
+  return new Request(`${ORIGIN}/api/mcp`, {
+    method: "POST",
+    headers: authorization ? { authorization } : {},
+  });
+}
+
+/** Minimal stand-in for the plugin's OAuthAccessToken row. */
+function oauthToken(overrides: Record<string, unknown> = {}) {
+  return {
+    accessToken: "oauth-tok",
+    refreshToken: "refresh-tok",
+    refreshTokenExpiresAt: new Date(Date.now() + 600_000),
+    userId: "user-1",
+    clientId: "client-1",
+    scopes: "openid lastest:read",
+    accessTokenExpiresAt: new Date(Date.now() + 60_000),
+    ...overrides,
+  } as Parameters<typeof getMcpSession.mockResolvedValue>[0];
+}
+
+describe("authenticateMcpRequest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ENCRYPTION_KEY = "a".repeat(64);
+    getMcpSession.mockResolvedValue(null);
+    verifyBearerToken.mockResolvedValue(null);
+  });
+
+  it("rejects a request with no Bearer token", async () => {
+    const result = await authenticateMcpRequest(request());
+    expect(result).toMatchObject({ ok: false, status: 401 });
+  });
+
+  it("gives an API key the full tool surface", async () => {
+    verifyBearerToken.mockResolvedValue({
+      user: { id: "user-9" },
+      sessionId: "s1",
+      team: null,
+    } as Awaited<ReturnType<typeof verifyBearerTokenImport>>);
+    const result = await authenticateMcpRequest(request("Bearer key-123"));
+    expect(result).toMatchObject({
+      ok: true,
+      caller: {
+        accessLevel: "full",
+        client: "api-key",
+        loopbackToken: "key-123",
+      },
+    });
+  });
+
+  it("maps OAuth scopes onto read/write, never full", async () => {
+    getMcpSession.mockResolvedValue(oauthToken());
+    const read = await authenticateMcpRequest(request("Bearer oauth-tok"));
+    expect(read).toMatchObject({ ok: true, caller: { accessLevel: "read" } });
+
+    getMcpSession.mockResolvedValue(
+      oauthToken({ scopes: "openid lastest:write" }),
+    );
+    const write = await authenticateMcpRequest(request("Bearer oauth-tok"));
+    expect(write).toMatchObject({ ok: true, caller: { accessLevel: "write" } });
+  });
+
+  it("does not forward the OAuth token onward — it mints a loopback grant", async () => {
+    getMcpSession.mockResolvedValue(oauthToken());
+    const result = await authenticateMcpRequest(request("Bearer oauth-tok"));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // /api/v1 deliberately does not accept OAuth tokens; handing one to the
+    // loopback client would defeat the scope-derived tool policy.
+    expect(result.caller.loopbackToken).not.toBe("oauth-tok");
+    expect(result.caller.loopbackToken.startsWith("lmcp_")).toBe(true);
+  });
+
+  it("rejects an expired access token", async () => {
+    // better-auth's getMcpSession looks the token up without checking expiry,
+    // so this guard is ours. Without it a token would work forever.
+    getMcpSession.mockResolvedValue(
+      oauthToken({ accessTokenExpiresAt: new Date(Date.now() - 1000) }),
+    );
+    expect(
+      await authenticateMcpRequest(request("Bearer oauth-tok")),
+    ).toMatchObject({ ok: false, status: 401 });
+
+    getMcpSession.mockResolvedValue(oauthToken({ accessTokenExpiresAt: null }));
+    expect(
+      await authenticateMcpRequest(request("Bearer oauth-tok")),
+    ).toMatchObject({ ok: false, status: 401 });
+  });
+
+  it("fails closed when the instance cannot sign a loopback grant", async () => {
+    delete process.env.ENCRYPTION_KEY;
+    getMcpSession.mockResolvedValue(oauthToken());
+    expect(
+      await authenticateMcpRequest(request("Bearer oauth-tok")),
+    ).toMatchObject({ ok: false, status: 503 });
+  });
+
+  it("points WWW-Authenticate at the protected-resource document", () => {
+    expect(wwwAuthenticate(ORIGIN, "invalid_token")).toBe(
+      `Bearer realm="lastest", resource_metadata="${ORIGIN}/.well-known/oauth-protected-resource", error="invalid_token"`,
+    );
+  });
+});

--- a/src/lib/mcp/remote-auth.ts
+++ b/src/lib/mcp/remote-auth.ts
@@ -25,7 +25,11 @@
 import type { ToolAccessLevel } from "@lastest/mcp-server";
 import { auth } from "@/lib/auth/auth";
 import { verifyBearerToken } from "@/lib/auth/api-key";
-import { accessLevelForScopes } from "@/lib/mcp/tool-policy";
+import {
+  accessLevelForScopes,
+  MCP_READ_SCOPE,
+  MCP_WRITE_SCOPE,
+} from "@/lib/mcp/tool-policy";
 import { mintLoopbackGrant } from "@/lib/mcp/loopback-grant";
 
 export interface McpCaller {
@@ -111,11 +115,22 @@ export async function authenticateMcpRequest(
           "This instance is not configured for OAuth MCP access (ENCRYPTION_KEY is unset).",
       };
     }
+    // A token carrying no Lastest scope is refused rather than defaulted to
+    // read. `insufficient_scope` is the RFC 6750 error for exactly this, and
+    // naming the scopes lets the client re-run consent asking for one.
+    const accessLevel = accessLevelForScopes(oauth.scopes);
+    if (!accessLevel) {
+      return {
+        ok: false,
+        status: 403,
+        detail: `This token carries no Lastest scope. Request ${MCP_READ_SCOPE} or ${MCP_WRITE_SCOPE}.`,
+      };
+    }
     return {
       ok: true,
       caller: {
         loopbackToken,
-        accessLevel: accessLevelForScopes(oauth.scopes),
+        accessLevel,
         userId: oauth.userId,
         client: oauth.clientId ?? "unknown",
       },

--- a/src/lib/mcp/remote-auth.ts
+++ b/src/lib/mcp/remote-auth.ts
@@ -1,0 +1,143 @@
+/**
+ * Who is calling `/api/mcp`, and how much of the tool surface they get.
+ *
+ * Two credentials are accepted, and they are not equivalent:
+ *
+ *   **API key** (`sessions.kind = 'api'`, created in Settings → Runners & API
+ *   Access). This is the user themselves — a key they generated and pasted into
+ *   their own agent. Access level `full`.
+ *
+ *   **OAuth 2.1 access token**, issued by the `mcp` plugin to a client that
+ *   registered itself dynamically. This is a third party the user connected
+ *   once, so it gets `read` or `write` depending on the scopes it was granted,
+ *   and never `full`. See `./tool-policy.ts`.
+ *
+ * The OAuth branch mints a loopback grant rather than forwarding the access
+ * token onward: `/api/v1` does not accept OAuth tokens, precisely so that the
+ * scope-derived tool policy cannot be sidestepped by calling the REST API
+ * directly. See `./loopback-grant.ts`.
+ *
+ * On failure the 401 carries a real `WWW-Authenticate` header pointing at the
+ * protected-resource metadata (RFC 9728). That header is what lets an agent
+ * platform discover the authorization server and start the OAuth dance on its
+ * own — without it, "paste the URL and connect" cannot work.
+ */
+import type { ToolAccessLevel } from "@lastest/mcp-server";
+import { auth } from "@/lib/auth/auth";
+import { verifyBearerToken } from "@/lib/auth/api-key";
+import { accessLevelForScopes } from "@/lib/mcp/tool-policy";
+import { mintLoopbackGrant } from "@/lib/mcp/loopback-grant";
+
+export interface McpCaller {
+  /** Credential to put on loopback calls to `/api/v1`. */
+  loopbackToken: string;
+  accessLevel: ToolAccessLevel;
+  userId: string;
+  /** "api-key" or the OAuth client id — used for logging only. */
+  client: string;
+}
+
+export type McpAuthResult =
+  | { ok: true; caller: McpCaller }
+  | { ok: false; status: number; detail: string };
+
+/** RFC 9728 metadata URL for this deployment's MCP resource. */
+export function protectedResourceMetadataUrl(origin: string): string {
+  return `${origin}/.well-known/oauth-protected-resource`;
+}
+
+export function wwwAuthenticate(origin: string, error?: string): string {
+  const parts = [
+    `Bearer realm="lastest"`,
+    `resource_metadata="${protectedResourceMetadataUrl(origin)}"`,
+  ];
+  if (error) parts.push(`error="${error}"`);
+  return parts.join(", ");
+}
+
+/**
+ * Resolve the request's credential.
+ *
+ * Order matters only for cost: an OAuth token lookup is one indexed read, an
+ * API key is one indexed read plus a team fetch, and the two token spaces do
+ * not overlap, so trying OAuth first costs a miss on the API-key path and
+ * nothing else.
+ */
+export async function authenticateMcpRequest(
+  req: Request,
+): Promise<McpAuthResult> {
+  const header = req.headers.get("authorization");
+  if (!header?.toLowerCase().startsWith("bearer ")) {
+    return {
+      ok: false,
+      status: 401,
+      detail:
+        "Missing Bearer token. Connect with OAuth, or create an API key in Settings → Runners & API Access.",
+    };
+  }
+  const token = header.slice(7).trim();
+
+  // --- OAuth 2.1 access token -------------------------------------------
+  const oauth = await auth.api
+    .getMcpSession({ headers: req.headers })
+    .catch(() => null);
+  if (oauth) {
+    // better-auth's getMcpSession looks the token up but does NOT check its
+    // expiry, so an expired token would otherwise keep working forever.
+    const expiresAt = oauth.accessTokenExpiresAt
+      ? new Date(oauth.accessTokenExpiresAt)
+      : null;
+    if (!expiresAt || expiresAt.getTime() <= Date.now()) {
+      return {
+        ok: false,
+        status: 401,
+        detail: "Access token expired. Refresh it and retry.",
+      };
+    }
+    if (!oauth.userId) {
+      return { ok: false, status: 401, detail: "Access token has no subject." };
+    }
+    const loopbackToken = mintLoopbackGrant(
+      oauth.userId,
+      oauth.clientId ?? "unknown",
+    );
+    if (!loopbackToken) {
+      // No ENCRYPTION_KEY: fail closed rather than fall back to a credential
+      // we cannot sign.
+      return {
+        ok: false,
+        status: 503,
+        detail:
+          "This instance is not configured for OAuth MCP access (ENCRYPTION_KEY is unset).",
+      };
+    }
+    return {
+      ok: true,
+      caller: {
+        loopbackToken,
+        accessLevel: accessLevelForScopes(oauth.scopes),
+        userId: oauth.userId,
+        client: oauth.clientId ?? "unknown",
+      },
+    };
+  }
+
+  // --- API key -----------------------------------------------------------
+  const session = await verifyBearerToken(token);
+  if (!session) {
+    return {
+      ok: false,
+      status: 401,
+      detail: "Invalid or expired credential.",
+    };
+  }
+  return {
+    ok: true,
+    caller: {
+      loopbackToken: token,
+      accessLevel: "full",
+      userId: session.user.id,
+      client: "api-key",
+    },
+  };
+}

--- a/src/lib/mcp/tool-policy.test.ts
+++ b/src/lib/mcp/tool-policy.test.ts
@@ -13,24 +13,34 @@ describe("mcp scope → access level", () => {
     expect(accessLevelForScopes(["openid", MCP_WRITE_SCOPE])).toBe("write");
   });
 
-  it("defaults to read for everything else", () => {
-    expect(accessLevelForScopes("openid profile email")).toBe("read");
+  it("grants read for the read scope", () => {
     expect(accessLevelForScopes(MCP_READ_SCOPE)).toBe("read");
-    expect(accessLevelForScopes("")).toBe("read");
-    expect(accessLevelForScopes(null)).toBe("read");
-    expect(accessLevelForScopes(undefined)).toBe("read");
+    expect(accessLevelForScopes(`openid ${MCP_READ_SCOPE}`)).toBe("read");
+  });
+
+  it("refuses a token carrying no Lastest scope", () => {
+    // "Sign in with Lastest" and "read everything in Lastest" are different
+    // consents. Defaulting to read granted the second off the first — and the
+    // unparseable cases below all collapse to [], so they took the same path.
+    expect(accessLevelForScopes("openid profile email")).toBeNull();
+    expect(accessLevelForScopes("")).toBeNull();
+    expect(accessLevelForScopes(null)).toBeNull();
+    expect(accessLevelForScopes(undefined)).toBeNull();
+    expect(accessLevelForScopes([])).toBeNull();
   });
 
   it("never grants full — deletes and public shares stay behind an API key", () => {
     for (const scope of MCP_OAUTH_SCOPES) {
       expect(accessLevelForScopes(scope)).not.toBe("full");
     }
+    expect(accessLevelForScopes(MCP_OAUTH_SCOPES.join(" "))).toBe("write");
     expect(accessLevelForScopes(MCP_OAUTH_SCOPES.join(" "))).not.toBe("full");
   });
 
   it("does not match a scope by prefix or substring", () => {
-    expect(accessLevelForScopes("lastest:write-ish")).toBe("read");
-    expect(accessLevelForScopes("notlastest:write")).toBe("read");
+    expect(accessLevelForScopes("lastest:write-ish")).toBeNull();
+    expect(accessLevelForScopes("notlastest:write")).toBeNull();
+    expect(accessLevelForScopes(`lastest:read-only`)).toBeNull();
   });
 
   it("parses space- and comma-separated lists", () => {

--- a/src/lib/mcp/tool-policy.test.ts
+++ b/src/lib/mcp/tool-policy.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import {
+  accessLevelForScopes,
+  parseScopes,
+  MCP_OAUTH_SCOPES,
+  MCP_WRITE_SCOPE,
+  MCP_READ_SCOPE,
+} from "./tool-policy";
+
+describe("mcp scope → access level", () => {
+  it("grants write only for the write scope", () => {
+    expect(accessLevelForScopes("openid lastest:write")).toBe("write");
+    expect(accessLevelForScopes(["openid", MCP_WRITE_SCOPE])).toBe("write");
+  });
+
+  it("defaults to read for everything else", () => {
+    expect(accessLevelForScopes("openid profile email")).toBe("read");
+    expect(accessLevelForScopes(MCP_READ_SCOPE)).toBe("read");
+    expect(accessLevelForScopes("")).toBe("read");
+    expect(accessLevelForScopes(null)).toBe("read");
+    expect(accessLevelForScopes(undefined)).toBe("read");
+  });
+
+  it("never grants full — deletes and public shares stay behind an API key", () => {
+    for (const scope of MCP_OAUTH_SCOPES) {
+      expect(accessLevelForScopes(scope)).not.toBe("full");
+    }
+    expect(accessLevelForScopes(MCP_OAUTH_SCOPES.join(" "))).not.toBe("full");
+  });
+
+  it("does not match a scope by prefix or substring", () => {
+    expect(accessLevelForScopes("lastest:write-ish")).toBe("read");
+    expect(accessLevelForScopes("notlastest:write")).toBe("read");
+  });
+
+  it("parses space- and comma-separated lists", () => {
+    expect(parseScopes("a b  c")).toEqual(["a", "b", "c"]);
+    expect(parseScopes("a,b, c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("advertises both Lastest scopes", () => {
+    expect(MCP_OAUTH_SCOPES).toContain(MCP_READ_SCOPE);
+    expect(MCP_OAUTH_SCOPES).toContain(MCP_WRITE_SCOPE);
+  });
+});

--- a/src/lib/mcp/tool-policy.ts
+++ b/src/lib/mcp/tool-policy.ts
@@ -8,10 +8,17 @@
  *
  * The rule is short on purpose:
  *
- *   API key            → full   (the user's own credential, created by hand in
- *                                Settings → Runners & API Access)
- *   OAuth + write scope → write
- *   OAuth, anything else → read
+ *   API key                    → full   (the user's own credential, created by
+ *                                        hand in Settings → Runners & API Access)
+ *   OAuth + `lastest:write`    → write
+ *   OAuth + `lastest:read`     → read
+ *   OAuth with neither         → refused
+ *
+ * The last line matters. Returning `read` by default meant a client that asked
+ * for `openid profile` — or one whose scope string failed to parse, since
+ * `parseScopes` maps every falsy input to `[]` — got every build, test, diff
+ * and coverage row the user can see, off a consent screen the user reads as
+ * "sign in with Lastest". Data access now requires a scope that names it.
  *
  * There is no scope that grants `full`. Deleting a test, revoking a share and
  * publishing data to a public URL stay behind the user's own key, so no amount
@@ -45,9 +52,19 @@ export function parseScopes(
   return list.map((s) => s.trim()).filter(Boolean);
 }
 
-/** The tool surface an OAuth token with these scopes may see. */
+/**
+ * The tool surface an OAuth token with these scopes may see, or `null` when it
+ * carries no Lastest scope at all and must be refused.
+ *
+ * `null` rather than a default level: "sign in with Lastest" and "read
+ * everything in Lastest" are different consents, and only the second is
+ * something a user can be said to have granted here.
+ */
 export function accessLevelForScopes(
   scopes: string | string[] | null | undefined,
-): ToolAccessLevel {
-  return parseScopes(scopes).includes(MCP_WRITE_SCOPE) ? "write" : "read";
+): ToolAccessLevel | null {
+  const list = parseScopes(scopes);
+  if (list.includes(MCP_WRITE_SCOPE)) return "write";
+  if (list.includes(MCP_READ_SCOPE)) return "read";
+  return null;
 }

--- a/src/lib/mcp/tool-policy.ts
+++ b/src/lib/mcp/tool-policy.ts
@@ -1,0 +1,53 @@
+/**
+ * OAuth scope → MCP tool-access level.
+ *
+ * The levels themselves (and what each one may call) live in
+ * `@lastest/mcp-server`'s `policy.ts`, next to the tools they describe. This
+ * module is only the mapping from the credential a caller presented to one of
+ * those levels, plus the scope list the authorization server advertises.
+ *
+ * The rule is short on purpose:
+ *
+ *   API key            → full   (the user's own credential, created by hand in
+ *                                Settings → Runners & API Access)
+ *   OAuth + write scope → write
+ *   OAuth, anything else → read
+ *
+ * There is no scope that grants `full`. Deleting a test, revoking a share and
+ * publishing data to a public URL stay behind the user's own key, so no amount
+ * of scope creep in a third-party agent platform's consent screen can reach
+ * them. That is the property the AgentExchange security review cares about, and
+ * it is enforced by construction rather than by a check somewhere.
+ */
+import type { ToolAccessLevel } from "@lastest/mcp-server";
+
+/** Scope the authorization server will issue. Advertised in the AS metadata. */
+export const MCP_OAUTH_SCOPES = [
+  "openid",
+  "profile",
+  "email",
+  "offline_access",
+  /** Read builds, tests, diffs, coverage. The default. */
+  "lastest:read",
+  /** Additionally run tests, create/update tests, approve or reject diffs. */
+  "lastest:write",
+] as const;
+
+export const MCP_WRITE_SCOPE = "lastest:write";
+export const MCP_READ_SCOPE = "lastest:read";
+
+/** Split a scope string (or the plugin's stored list) into scope values. */
+export function parseScopes(
+  scopes: string | string[] | null | undefined,
+): string[] {
+  if (!scopes) return [];
+  const list = Array.isArray(scopes) ? scopes : scopes.split(/[\s,]+/);
+  return list.map((s) => s.trim()).filter(Boolean);
+}
+
+/** The tool surface an OAuth token with these scopes may see. */
+export function accessLevelForScopes(
+  scopes: string | string[] | null | undefined,
+): ToolAccessLevel {
+  return parseScopes(scopes).includes(MCP_WRITE_SCOPE) ? "write" : "read";
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -20,6 +20,13 @@ const PUBLIC_PATHS = [
   "/api/og/", // Public OG/Twitter card images for shared builds
   "/api/badge/", // Public embeddable badge SVGs
   "/api/auth/",
+  "/.well-known/", // OAuth discovery documents — must be reachable unauthed,
+  // that is the entire point of them (RFC 8414 / RFC 9728).
+  "/api/mcp", // Remote MCP endpoint. Bearer-only (API key or OAuth access
+  // token) and has no cookie, so without this every MCP
+  // client gets a 307 to /login instead of a 401 carrying the
+  // WWW-Authenticate that starts the OAuth flow. The route
+  // authenticates every request itself.
   "/api/health",
   "/api/webhooks/",
   "/api/builds/",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -22,11 +22,6 @@ const PUBLIC_PATHS = [
   "/api/auth/",
   "/.well-known/", // OAuth discovery documents — must be reachable unauthed,
   // that is the entire point of them (RFC 8414 / RFC 9728).
-  "/api/mcp", // Remote MCP endpoint. Bearer-only (API key or OAuth access
-  // token) and has no cookie, so without this every MCP
-  // client gets a 307 to /login instead of a 401 carrying the
-  // WWW-Authenticate that starts the OAuth flow. The route
-  // authenticates every request itself.
   "/api/health",
   "/api/webhooks/",
   "/api/builds/",
@@ -49,6 +44,22 @@ const PUBLIC_PATHS = [
   "/_umami/",
   "/api/umami/", // resilient umami ingest forwarder (rewrite target of /_umami/api/*)
 ];
+
+/**
+ * Public paths matched EXACTLY, not by prefix.
+ *
+ * `/api/mcp` is here rather than in the prefix list on purpose. As a prefix it
+ * also exempted `/api/mcp/session` and every future `/api/mcp*` route, making
+ * the default for that subtree "public unless the route remembers to check" —
+ * the wrong direction for the one subtree that carries an agent's access to a
+ * signed-in user's data. A new route under it now has to opt in.
+ *
+ * `/api/mcp` itself must stay public: it is bearer-only (API key or OAuth
+ * access token) and carries no cookie, so without the exemption every MCP
+ * client gets a 307 to /login instead of the 401 with `WWW-Authenticate` that
+ * starts the OAuth flow. The route authenticates every request itself.
+ */
+const PUBLIC_EXACT_PATHS = ["/api/mcp"];
 
 const isDev = process.env.NODE_ENV !== "production";
 
@@ -120,7 +131,9 @@ export default function proxy(request: NextRequest) {
   const csp = nonce ? buildCsp(nonce) : null;
 
   // Auth check first — redirects skip CSP wiring entirely.
-  const isPublic = PUBLIC_PATHS.some((p) => pathname.startsWith(p));
+  const isPublic =
+    PUBLIC_EXACT_PATHS.includes(pathname) ||
+    PUBLIC_PATHS.some((p) => pathname.startsWith(p));
   if (!isPublic) {
     const session = getSessionCookie(request);
     if (!session) {


### PR DESCRIPTION
Stacked on `feat/qa-agent-bento`.

`/api/mcp` could only be reached with an API key, which means an agent platform can only use Lastest if a human first generates one and pastes it in. This makes the endpoint an OAuth-protected resource a client can connect to knowing nothing but its URL and — because that client is not the user — narrows what it can see.

Phases 1 and 2 of [`docs/architecture/agentexchange-listing-plan.md`](docs/architecture/agentexchange-listing-plan.md). Design notes: [`docs/architecture/remote-mcp-oauth.md`](docs/architecture/remote-mcp-oauth.md).

## OAuth 2.1

better-auth's `mcp` plugin supplies the authorization server (RFC 8414 metadata, RFC 7591 dynamic client registration, PKCE S256), backed by three new tables in `packages/db/src/schema/identity.ts`. A 401 from `/api/mcp` carries RFC 9728 `WWW-Authenticate`, and `/.well-known/oauth-{authorization-server,protected-resource}` serve discovery at the paths clients actually probe.

Two decisions worth reviewing:

- **Discovery uses the public origin.** `req.url` inside a route is the internal `127.0.0.1:3001` address `scripts/front-proxy.js` forwards to; advertising that as the issuer points every client at an unreachable host. The loopback `LastestClient` deliberately keeps `req.url`'s origin so tool calls don't round-trip back out through the proxy.
- **The advertised authorization endpoint is ours** (`/oauth/mcp/authorize`), which pins `prompt=consent` and forwards everything else. better-auth only shows consent when the client asks for it, and combined with anonymous client registration that would let an app registered seconds ago get a token silently.

## Access levels

An OAuth token is not an API key.

| Credential | Level | Tools |
| --- | --- | --- |
| API key | `full` | 29 |
| OAuth + `lastest:write` | `write` | 27 |
| OAuth, anything else | `read` | 16 |

The level is applied at tool **registration**, not inside handlers: a restricted caller's `lastest_test` advertises `action: "list" \| "get"` and nothing else. That matters more than a runtime check — an agent picks tools by reading schemas, and one that can see a forbidden action keeps trying it. Deletes, share revocation and publishing a public `/r/` link are unreachable over OAuth at any scope: not gated, absent. Table in `packages/mcp-server/src/policy.ts`, drift-guarded by `policy.test.ts` against the live surface.

**OAuth tokens are deliberately not accepted by `/api/v1`.** A `lastest:read` token that authenticates against REST directly would bypass the policy entirely, so `verifyBearerToken()` does not know about them. `/api/mcp` mints a 60-second HMAC loopback grant instead — server-created, server-spent, never in a response — same construction and fail-closed rule as the EB stream grant.

## Also in here

- **Bug fix:** `/api/mcp` was missing from `PUBLIC_PATHS`, so bearer-only clients were 307'd to `/login` and never saw the 401 that starts discovery.
- **Bug fix:** better-auth's `getMcpSession()` looks a token up without checking expiry — an expired token would work forever. `remote-auth.ts` checks it.
- `lastest-mcp --transport http` runs the same tool surface as a standalone server, for deployments that want the MCP endpoint on its own host/port.

## Verification

End to end against a local instance: discovery → dynamic client registration → login → forced consent → PKCE exchange (wrong verifier → 401) → `initialize` → scope-limited `tools/list` → `delete` rejected by the narrowed schema. Read/write/full observed as 16/27/29. Probe user and rows cleaned out of the dev DB.

`pnpm test` 144 files / 2075 tests pass, `pnpm lint` 0 errors, `pnpm build` clean with all new routes registered. `pnpm db:push` applied locally; the three tables are additive.

## Not done

Recorded in the plan doc rather than silently skipped:

- No per-connection rate limiting or audit logging (the route logs one debug line). Needed before an AgentExchange submission.
- Tool **responses** are not redacted — `redactSecrets()` only covers inbound params on their way to activity logs.
- No UI for reviewing or revoking OAuth connections. `getOAuthConnectionsForUser()` exists for it; Settings → Runners & API Access is the obvious home.
- Tool descriptions were not rewritten for AgentExchange's semantic search; that is listing-copy work and belongs with Phase 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)