### PR TITLE
chore: fix migrate schema-load in Docker images + fail boot on swallowed push errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,6 +129,16 @@ COPY --from=builder --chown=nextjs:nodejs /app/packages/db/src/schema.ts ./packa
 # The barrel `export * from "./schema/<mod>"` is a VALUE re-export that esbuild
 # must resolve, so the split schema modules have to come along with it.
 COPY --from=builder --chown=nextjs:nodejs /app/packages/db/src/schema/ ./packages/db/src/schema/
+# @lastest/coverage-model is the one workspace import esbuild must RESOLVE:
+# schema/coverage.ts and schema/tests.ts re-export its DEFAULT_* policies as
+# VALUES (its "main" points at src/index.ts). It must be a SYMLINK, not a copy:
+# Node 24 refuses to type-strip .ts files whose real path is under
+# node_modules (ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING), and the link's
+# realpath resolves to /app/libs/, which is allowed.
+COPY --from=builder --chown=nextjs:nodejs /app/libs/coverage-model/ ./libs/coverage-model/
+RUN mkdir -p ./node_modules/@lastest && \
+    ln -sfn /app/libs/coverage-model ./node_modules/@lastest/coverage-model && \
+    chown -h nextjs:nodejs ./node_modules/@lastest/coverage-model
 # drizzle.config.ts's schema glob also covers ./plugins/*/src/schema.ts (each
 # plugin owns its own tables) — without these, push silently creates none of
 # those tables. Same erasure argument as core's schema.ts above; add a line

--- a/Dockerfile.migrate
+++ b/Dockerfile.migrate
@@ -23,8 +23,8 @@
 # The one exception is @lastest/coverage-model: schema/coverage.ts and
 # schema/tests.ts re-export its DEFAULT_* policies as VALUES, so esbuild must
 # resolve it. It is a dependency-free pure-TypeScript lib, so it is dropped in
-# as a bare node_modules entry (its package.json "main" points at src/index.ts,
-# which esbuild loads as TS) rather than dragging in a pnpm workspace install.
+# as a node_modules SYMLINK to ./libs (its package.json "main" points at
+# src/index.ts, loaded as TS) rather than dragging in a pnpm workspace install.
 #
 # NOT traced. scripts/migrate.js talks to `postgres` directly and never loads
 # @lastest/db's instrumented client, so the DB spans in packages/db/src/tracing.ts
@@ -55,8 +55,15 @@ RUN npm install --no-audit --no-fund \
 # files, so the drizzle/ out-dir is intentionally absent.
 COPY packages/db/src/schema.ts ./packages/db/src/schema.ts
 COPY packages/db/src/schema/ ./packages/db/src/schema/
-COPY libs/coverage-model/package.json ./node_modules/@lastest/coverage-model/
-COPY libs/coverage-model/src/ ./node_modules/@lastest/coverage-model/src/
+# Must be a SYMLINK into ./libs, not a copy under node_modules: Node ≥ 24
+# refuses to type-strip .ts files whose real path is under node_modules
+# (ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING) — and drizzle-kit swallows
+# that loader crash with exit 0. The link's realpath lands in /app/libs/,
+# which is allowed. Same fixup as the root Dockerfile.
+COPY libs/coverage-model/package.json ./libs/coverage-model/package.json
+COPY libs/coverage-model/src/ ./libs/coverage-model/src/
+RUN mkdir -p ./node_modules/@lastest && \
+    ln -sfn /app/libs/coverage-model ./node_modules/@lastest/coverage-model
 COPY drizzle.config.ts ./
 COPY scripts/migrate.js ./scripts/migrate.js
 

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1483,12 +1483,19 @@ async function main() {
 
   console.log("[migrate] Running drizzle-kit push...");
   try {
-    execSync("./node_modules/.bin/drizzle-kit push --force 2>&1", {
+    // Output is CAPTURED (pipe), not inherited: drizzle-kit exits 0 even when
+    // its esbuild schema loader crashes before touching the DB ("Cannot find
+    // module", Node's ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING, …) — the
+    // only failure signal is the error text on stdout, so it must be scanned.
+    // Verified in production 2026-09-02: two releases booted "green" on an
+    // unmigrated database exactly this way.
+    const out = execSync("./node_modules/.bin/drizzle-kit push --force 2>&1", {
       // stdin is /dev/null, never the container's. This alone does NOT save us —
       // verified: drizzle-kit's prompt blocks on a closed stdin exactly as it
       // does on an empty one — but it keeps push from ever reading a real tty
       // during an interactive `node scripts/migrate.js`. The timeout is the guard.
-      stdio: ["ignore", "inherit", "inherit"],
+      stdio: ["ignore", "pipe", "inherit"],
+      encoding: "utf8",
       // Backstop for the same class of bug. Without it an unanswerable prompt
       // blocks until the Job's activeDeadlineSeconds kills the pod, and the only
       // signal is a deadline: no failing statement, no exit code, no cause.
@@ -1497,11 +1504,23 @@ async function main() {
       timeout: PUSH_TIMEOUT_MS,
       killSignal: "SIGKILL",
     });
+    process.stdout.write(out);
+    if (/^\s*(?:Error(?::| \[)|error:)/m.test(out)) {
+      console.error(
+        "[migrate] Failed: drizzle-kit push exited 0 but printed an error — " +
+          "its schema-loader crashes are not reflected in the exit code. The " +
+          "schema was NOT pushed; refusing to start on a stale database.",
+      );
+      process.exit(1);
+    }
     console.log("[migrate] Done");
   } catch (e) {
     // `catch` binds `unknown`; execSync surfaces a timeout kill as `killed` /
     // `signal` on the thrown Error, neither of which is on the Error type.
     const err = /** @type {any} */ (e);
+    // stdout is piped now, so on failure the child's output only exists on the
+    // thrown error — print it, or the messages below point at nothing.
+    if (err.stdout) process.stdout.write(String(err.stdout));
     if (err.killed || err.signal === "SIGKILL") {
       console.error(
         `[migrate] Failed: drizzle-kit push was killed after ${PUSH_TIMEOUT_MS}ms. ` +


### PR DESCRIPTION
## What

Post-incident fixes from the 2026-09-02 prod outage (site-wide 500s after deploy).

- **Dockerfile**: stage `libs/coverage-model` and **symlink** it into `node_modules/@lastest`. The boot-time `drizzle-kit push` couldn't resolve the schema's value import (`@lastest/coverage-model`), so no migration ran and the new code hit `column teams.regulated_mode does not exist`.
- **Symlink, not copy**: Node 24 refuses to type-strip `.ts` whose realpath is under `node_modules` (`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`); a link's realpath in `/app/libs/` is allowed.
- **Dockerfile.migrate**: same symlink treatment (it had the copy-under-node_modules pattern and would hit the same refusal).
- **scripts/migrate.js**: capture push output and exit non-zero when drizzle-kit prints a schema-loader error but exits 0 — both broken deploys booted "green" on an unmigrated database exactly this way; the entrypoint's `set -e` then blocks startup as intended.

## Verified

- Third deploy with these image fixes applied the migration (`[✓] Changes applied`) and prod is healthy.
- `node --check` on migrate.js; lint-staged clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)